### PR TITLE
feat(upgrade): student-facing consultant upgrade submission (FR-ONB-07)

### DIFF
--- a/client/src/services/api/upgradeRequests.ts
+++ b/client/src/services/api/upgradeRequests.ts
@@ -1,0 +1,39 @@
+import { apiClient } from "@/services/api/client";
+
+/** Wire shape for `POST /api/upgrade-requests/consultant`. */
+export interface SubmitConsultantUpgradeRequestPayload {
+  biography: string;
+  professionalTitle: string;
+  highestDegree: string;
+  fieldOfExpertise: string;
+  yearsOfExperience: number | null;
+  sessionFeeUsd: number | null;
+  sessionDurationMinutes: number | null;
+  expertiseTags: string[] | null;
+  languages: string[] | null;
+  country: string;
+  timezone: string;
+  linkedInUrl?: string | null;
+  portfolioUrl?: string | null;
+}
+
+export interface SubmitUpgradeResponse {
+  requestId: string;
+}
+
+export const upgradeRequestsApi = {
+  /**
+   * Submit a Student → Consultant upgrade request. The backing endpoint
+   * persists the consultant profile fields and creates a Pending UpgradeRequest
+   * row that the admin upgrade queue picks up.
+   */
+  async submitConsultantUpgradeRequest(
+    payload: SubmitConsultantUpgradeRequestPayload,
+  ): Promise<SubmitUpgradeResponse> {
+    const { data } = await apiClient.post<SubmitUpgradeResponse>(
+      "/api/upgrade-requests/consultant",
+      payload,
+    );
+    return data;
+  },
+};

--- a/server/src/ScholarPath.API/Controllers/UpgradeRequestsController.cs
+++ b/server/src/ScholarPath.API/Controllers/UpgradeRequestsController.cs
@@ -1,0 +1,64 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ScholarPath.Application.UpgradeRequests.Commands.SubmitConsultantUpgradeRequest;
+
+namespace ScholarPath.API.Controllers;
+
+/// <summary>
+/// Student-facing upgrade-request submission (FR-ONB-07). The Admin queue and
+/// the approve / reject flow live under <c>/api/admin/upgrade-queue</c> in
+/// <see cref="AdminController"/>; this controller only feeds it.
+/// </summary>
+[ApiController]
+[Route("api/upgrade-requests")]
+[Authorize]
+[Produces("application/json")]
+public sealed class UpgradeRequestsController(IMediator mediator) : ControllerBase
+{
+    /// <summary>Submit a Consultant upgrade request as an active Student.</summary>
+    [HttpPost("consultant")]
+    [Authorize(Roles = "Student")]
+    [ProducesResponseType(typeof(SubmitUpgradeResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> SubmitConsultantUpgrade(
+        [FromBody] SubmitConsultantUpgradeRequestBody body,
+        CancellationToken ct)
+    {
+        var id = await mediator.Send(new SubmitConsultantUpgradeRequestCommand(
+            body.Biography,
+            body.ProfessionalTitle,
+            body.HighestDegree,
+            body.FieldOfExpertise,
+            body.YearsOfExperience,
+            body.SessionFeeUsd,
+            body.SessionDurationMinutes,
+            body.ExpertiseTags,
+            body.Languages,
+            body.Country,
+            body.Timezone,
+            body.LinkedInUrl,
+            body.PortfolioUrl), ct).ConfigureAwait(false);
+        return StatusCode(StatusCodes.Status201Created, new SubmitUpgradeResponse(id));
+    }
+}
+
+/// <summary>Wire shape for the Student upgrade-submission endpoint.</summary>
+public sealed record SubmitConsultantUpgradeRequestBody(
+    string Biography,
+    string ProfessionalTitle,
+    string HighestDegree,
+    string FieldOfExpertise,
+    int? YearsOfExperience,
+    decimal? SessionFeeUsd,
+    int? SessionDurationMinutes,
+    string[]? ExpertiseTags,
+    string[]? Languages,
+    string Country,
+    string Timezone,
+    string? LinkedInUrl,
+    string? PortfolioUrl);
+
+public sealed record SubmitUpgradeResponse(Guid RequestId);

--- a/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommand.cs
+++ b/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommand.cs
@@ -1,0 +1,27 @@
+using MediatR;
+using ScholarPath.Application.Common.Auditing;
+using ScholarPath.Domain.Enums;
+
+namespace ScholarPath.Application.UpgradeRequests.Commands.SubmitConsultantUpgradeRequest;
+
+/// <summary>
+/// Student-initiated request to be upgraded to Consultant (FR-ONB-07).
+/// The submitted consultant profile fields are persisted on the user's
+/// profile so the existing Admin review queue surfaces a complete request;
+/// the upgrade itself is granted by the existing ReviewUpgradeRequest flow.
+/// </summary>
+[Auditable(AuditAction.RoleChanged, "UpgradeRequest")]
+public sealed record SubmitConsultantUpgradeRequestCommand(
+    string Biography,
+    string ProfessionalTitle,
+    string HighestDegree,
+    string FieldOfExpertise,
+    int? YearsOfExperience,
+    decimal? SessionFeeUsd,
+    int? SessionDurationMinutes,
+    string[]? ExpertiseTags,
+    string[]? Languages,
+    string Country,
+    string Timezone,
+    string? LinkedInUrl = null,
+    string? PortfolioUrl = null) : IRequest<Guid>;

--- a/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandHandler.cs
+++ b/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandHandler.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
+
+namespace ScholarPath.Application.UpgradeRequests.Commands.SubmitConsultantUpgradeRequest;
+
+/// <summary>
+/// Persists a Consultant upgrade submission so it shows up in the Admin
+/// upgrade queue. Side-effects: writes the submitted consultant profile fields
+/// onto the user's <see cref="UserProfile"/> (Student fields are untouched —
+/// the schemas don't overlap) so the reviewer sees the proposed profile, and
+/// fills <see cref="ApplicationUser.CountryOfResidence"/> if it's blank.
+/// </summary>
+public sealed class SubmitConsultantUpgradeRequestCommandHandler(
+    IApplicationDbContext db,
+    ICurrentUserService currentUser,
+    IUserAdministration userAdministration,
+    IDateTimeService clock,
+    ILogger<SubmitConsultantUpgradeRequestCommandHandler> logger)
+    : IRequestHandler<SubmitConsultantUpgradeRequestCommand, Guid>
+{
+    public async Task<Guid> Handle(SubmitConsultantUpgradeRequestCommand request, CancellationToken ct)
+    {
+        var userId = currentUser.UserId
+            ?? throw new ForbiddenAccessException("Not authenticated.");
+
+        var user = await db.Users
+            .Include(u => u.Profile)
+            .FirstOrDefaultAsync(u => u.Id == userId, ct)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException(nameof(ApplicationUser), userId);
+
+        // Only an active account can request an upgrade — suspended / pending
+        // users have other things to resolve first.
+        if (user.AccountStatus != AccountStatus.Active)
+        {
+            throw new ConflictException(
+                "Your account must be active before requesting a consultant upgrade.");
+        }
+
+        var roles = await userAdministration.GetRolesAsync(userId, ct).ConfigureAwait(false);
+        if (!roles.Contains("Student"))
+        {
+            throw new ForbiddenAccessException(
+                "Only active Students can request a consultant upgrade.");
+        }
+        if (roles.Contains("Consultant"))
+        {
+            throw new ConflictException("You are already a Consultant.");
+        }
+
+        // One outstanding consultant request at a time — if it's still Pending
+        // the admin will see the latest fields by editing the profile, not by
+        // stacking duplicate queue entries.
+        var existingPending = await db.UpgradeRequests
+            .AnyAsync(r => r.UserId == userId
+                          && r.Target == UpgradeTarget.Consultant
+                          && r.Status == UpgradeRequestStatus.Pending
+                          && !r.IsDeleted, ct)
+            .ConfigureAwait(false);
+        if (existingPending)
+        {
+            throw new ConflictException(
+                "You already have a pending consultant upgrade request.");
+        }
+
+        // Stamp the submitted consultant fields on the profile so the admin
+        // reviews a complete picture. Student-only fields (AcademicLevel,
+        // FieldOfStudy, …) are not touched.
+        if (user.Profile is null)
+        {
+            var newProfile = new UserProfile
+            {
+                UserId = userId,
+                CreatedAt = clock.UtcNow,
+            };
+            db.UserProfiles.Add(newProfile);
+            user.Profile = newProfile;
+        }
+
+        user.Profile.Biography = request.Biography;
+        user.Profile.ProfessionalTitle = request.ProfessionalTitle;
+        user.Profile.HighestDegree = request.HighestDegree;
+        user.Profile.FieldOfExpertise = request.FieldOfExpertise;
+        user.Profile.YearsOfExperience = request.YearsOfExperience;
+        user.Profile.SessionFeeUsd = request.SessionFeeUsd;
+        user.Profile.SessionDurationMinutes = request.SessionDurationMinutes ?? 45;
+        user.Profile.ExpertiseTagsJson = request.ExpertiseTags is { Length: > 0 } tags
+            ? JsonSerializer.Serialize(tags)
+            : null;
+        user.Profile.LanguagesJson = request.Languages is { Length: > 0 } langs
+            ? JsonSerializer.Serialize(langs)
+            : null;
+        user.Profile.Timezone = request.Timezone;
+        user.Profile.LinkedInUrl = request.LinkedInUrl;
+        user.Profile.PortfolioUrl = request.PortfolioUrl;
+        // Don't clobber an existing Student-set country.
+        if (string.IsNullOrWhiteSpace(user.CountryOfResidence))
+        {
+            user.CountryOfResidence = request.Country;
+        }
+
+        var upgradeRequest = new UpgradeRequest
+        {
+            UserId = userId,
+            Target = UpgradeTarget.Consultant,
+            Status = UpgradeRequestStatus.Pending,
+            Reason = "Student-initiated consultant upgrade.",
+            CreatedAt = clock.UtcNow,
+        };
+        db.UpgradeRequests.Add(upgradeRequest);
+
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "User {UserId} submitted consultant upgrade request {RequestId}.",
+            userId, upgradeRequest.Id);
+
+        return upgradeRequest.Id;
+    }
+}

--- a/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandValidator.cs
+++ b/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandValidator.cs
@@ -1,0 +1,60 @@
+using FluentValidation;
+
+namespace ScholarPath.Application.UpgradeRequests.Commands.SubmitConsultantUpgradeRequest;
+
+/// <summary>
+/// Mirrors the Consultant rules in <c>SelectRoleCommandValidator</c> so a
+/// Student-initiated upgrade is held to the same bar as a fresh Consultant
+/// onboarding.
+/// </summary>
+public sealed class SubmitConsultantUpgradeRequestCommandValidator
+    : AbstractValidator<SubmitConsultantUpgradeRequestCommand>
+{
+    public SubmitConsultantUpgradeRequestCommandValidator()
+    {
+        RuleFor(x => x.Biography)
+            .NotEmpty().MaximumLength(2000)
+            .WithMessage("A short bio is required.");
+        RuleFor(x => x.ProfessionalTitle)
+            .NotEmpty().MaximumLength(150)
+            .WithMessage("Professional title is required.");
+        RuleFor(x => x.HighestDegree)
+            .NotEmpty().MaximumLength(150)
+            .WithMessage("Highest degree is required.");
+        RuleFor(x => x.FieldOfExpertise)
+            .NotEmpty().MaximumLength(200)
+            .WithMessage("Field of expertise is required.");
+        RuleFor(x => x.YearsOfExperience)
+            .NotNull().GreaterThanOrEqualTo(0).LessThanOrEqualTo(80)
+            .WithMessage("Years of experience must be 0 or greater.");
+        RuleFor(x => x.SessionFeeUsd)
+            .NotNull().GreaterThan(0)
+            .WithMessage("Session fee must be greater than zero.");
+        RuleFor(x => x.SessionDurationMinutes)
+            .NotNull()
+            .Must(d => d is 30 or 45 or 60 or 90)
+            .WithMessage("Session duration must be 30, 45, 60 or 90 minutes.");
+        RuleFor(x => x.ExpertiseTags)
+            .NotNull()
+            .Must(tags => tags is { Length: > 0 })
+            .WithMessage("At least one expertise tag is required.");
+        RuleFor(x => x.Languages)
+            .NotNull()
+            .Must(langs => langs is { Length: > 0 })
+            .WithMessage("At least one language is required.");
+        RuleFor(x => x.Country)
+            .NotEmpty().MaximumLength(80)
+            .WithMessage("Country is required.");
+        RuleFor(x => x.Timezone)
+            .NotEmpty().MaximumLength(64)
+            .WithMessage("Time zone is required.");
+        RuleFor(x => x.LinkedInUrl)
+            .MaximumLength(2048)
+            .Must(u => string.IsNullOrEmpty(u) || Uri.TryCreate(u, UriKind.Absolute, out _))
+            .WithMessage("LinkedIn URL must be a valid URL.");
+        RuleFor(x => x.PortfolioUrl)
+            .MaximumLength(2048)
+            .Must(u => string.IsNullOrEmpty(u) || Uri.TryCreate(u, UriKind.Absolute, out _))
+            .WithMessage("Portfolio URL must be a valid URL.");
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/UpgradeRequests/SubmitConsultantUpgradeRequestCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/UpgradeRequests/SubmitConsultantUpgradeRequestCommandHandlerTests.cs
@@ -1,0 +1,285 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.UpgradeRequests.Commands.SubmitConsultantUpgradeRequest;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.UpgradeRequests;
+
+public class SubmitConsultantUpgradeRequestCommandHandlerTests
+{
+    private static ApplicationDbContext CreateDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static ICurrentUserService CurrentUser(Guid? id)
+    {
+        var u = Substitute.For<ICurrentUserService>();
+        u.UserId.Returns(id);
+        return u;
+    }
+
+    private static IDateTimeService Clock()
+    {
+        var c = Substitute.For<IDateTimeService>();
+        c.UtcNow.Returns(DateTimeOffset.UtcNow);
+        return c;
+    }
+
+    private static SubmitConsultantUpgradeRequestCommandHandler Sut(
+        ApplicationDbContext db, Guid? userId, IUserAdministration admin) =>
+        new(db, CurrentUser(userId), admin, Clock(),
+            NullLogger<SubmitConsultantUpgradeRequestCommandHandler>.Instance);
+
+    private static Guid SeedActiveStudent(ApplicationDbContext db)
+    {
+        var id = Guid.NewGuid();
+        db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Active",
+            LastName = "Student",
+            Email = "student@scholarpath.local",
+            UserName = "student@scholarpath.local",
+            AccountStatus = AccountStatus.Active,
+        });
+        return id;
+    }
+
+    private static SubmitConsultantUpgradeRequestCommand ValidCommand() => new(
+        Biography: "5 years guiding scholarship applicants.",
+        ProfessionalTitle: "Admissions Consultant",
+        HighestDegree: "MSc Education",
+        FieldOfExpertise: "Graduate admissions",
+        YearsOfExperience: 5,
+        SessionFeeUsd: 40m,
+        SessionDurationMinutes: 60,
+        ExpertiseTags: new[] { "SoP", "Interview Prep" },
+        Languages: new[] { "English", "Arabic" },
+        Country: "Egypt",
+        Timezone: "Africa/Cairo",
+        LinkedInUrl: "https://linkedin.com/in/example",
+        PortfolioUrl: null);
+
+    private static IUserAdministration Admin(params string[] roles)
+    {
+        var a = Substitute.For<IUserAdministration>();
+        a.GetRolesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(roles);
+        return a;
+    }
+
+    [Fact]
+    public async Task Active_student_can_submit_consultant_upgrade()
+    {
+        using var db = CreateDb();
+        var userId = SeedActiveStudent(db);
+        await db.SaveChangesAsync();
+
+        var id = await Sut(db, userId, Admin("Student")).Handle(ValidCommand(), default);
+
+        id.Should().NotBe(Guid.Empty);
+        var saved = await db.UpgradeRequests
+            .Include(r => r.User)
+            .FirstAsync(r => r.UserId == userId);
+        saved.Target.Should().Be(UpgradeTarget.Consultant);
+        saved.Status.Should().Be(UpgradeRequestStatus.Pending);
+        saved.Reason.Should().NotBeNullOrEmpty();
+
+        var user = await db.Users.Include(u => u.Profile).FirstAsync(u => u.Id == userId);
+        user.Profile.Should().NotBeNull();
+        user.Profile!.ProfessionalTitle.Should().Be("Admissions Consultant");
+        user.Profile.SessionFeeUsd.Should().Be(40m);
+        user.Profile.SessionDurationMinutes.Should().Be(60);
+        user.Profile.Timezone.Should().Be("Africa/Cairo");
+        user.Profile.ExpertiseTagsJson.Should().Contain("SoP");
+        user.Profile.LanguagesJson.Should().Contain("Arabic");
+        user.CountryOfResidence.Should().Be("Egypt");
+    }
+
+    [Fact]
+    public async Task Throws_when_not_authenticated()
+    {
+        using var db = CreateDb();
+        var act = () => Sut(db, userId: null, Admin()).Handle(ValidCommand(), default);
+        await act.Should().ThrowAsync<ForbiddenAccessException>();
+    }
+
+    [Fact]
+    public async Task Non_student_cannot_submit()
+    {
+        using var db = CreateDb();
+        var userId = SeedActiveStudent(db);
+        await db.SaveChangesAsync();
+
+        // Mock returns Company role; user is not a Student.
+        var act = () => Sut(db, userId, Admin("Company")).Handle(ValidCommand(), default);
+
+        await act.Should().ThrowAsync<ForbiddenAccessException>()
+            .WithMessage("*Student*");
+    }
+
+    [Fact]
+    public async Task Existing_consultant_cannot_submit()
+    {
+        using var db = CreateDb();
+        var userId = SeedActiveStudent(db);
+        await db.SaveChangesAsync();
+
+        var act = () => Sut(db, userId, Admin("Student", "Consultant")).Handle(ValidCommand(), default);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*already a Consultant*");
+    }
+
+    [Fact]
+    public async Task Duplicate_pending_request_is_blocked()
+    {
+        using var db = CreateDb();
+        var userId = SeedActiveStudent(db);
+        db.UpgradeRequests.Add(new UpgradeRequest
+        {
+            UserId = userId,
+            Target = UpgradeTarget.Consultant,
+            Status = UpgradeRequestStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+
+        var act = () => Sut(db, userId, Admin("Student")).Handle(ValidCommand(), default);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*pending consultant upgrade request*");
+    }
+
+    [Fact]
+    public async Task Pending_block_ignores_decided_or_soft_deleted_history()
+    {
+        using var db = CreateDb();
+        var userId = SeedActiveStudent(db);
+        // A rejected request and a soft-deleted pending request should NOT
+        // count toward the duplicate check — the student must be able to retry.
+        db.UpgradeRequests.Add(new UpgradeRequest
+        {
+            UserId = userId,
+            Target = UpgradeTarget.Consultant,
+            Status = UpgradeRequestStatus.Rejected,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-2),
+        });
+        db.UpgradeRequests.Add(new UpgradeRequest
+        {
+            UserId = userId,
+            Target = UpgradeTarget.Consultant,
+            Status = UpgradeRequestStatus.Pending,
+            IsDeleted = true,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+        });
+        await db.SaveChangesAsync();
+
+        var id = await Sut(db, userId, Admin("Student")).Handle(ValidCommand(), default);
+
+        id.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task Non_active_account_is_blocked()
+    {
+        using var db = CreateDb();
+        var id = Guid.NewGuid();
+        db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Pending",
+            LastName = "Student",
+            Email = "p@scholarpath.local",
+            UserName = "p@scholarpath.local",
+            AccountStatus = AccountStatus.Suspended,
+        });
+        await db.SaveChangesAsync();
+
+        var act = () => Sut(db, id, Admin("Student")).Handle(ValidCommand(), default);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*account must be active*");
+    }
+
+    [Fact]
+    public void Validator_rejects_missing_required_fields()
+    {
+        var v = new SubmitConsultantUpgradeRequestCommandValidator();
+
+        var bare = new SubmitConsultantUpgradeRequestCommand(
+            Biography: "",
+            ProfessionalTitle: "",
+            HighestDegree: "",
+            FieldOfExpertise: "",
+            YearsOfExperience: null,
+            SessionFeeUsd: null,
+            SessionDurationMinutes: null,
+            ExpertiseTags: null,
+            Languages: null,
+            Country: "",
+            Timezone: "");
+        v.Validate(bare).IsValid.Should().BeFalse();
+
+        var valid = new SubmitConsultantUpgradeRequestCommand(
+            Biography: "Hello world",
+            ProfessionalTitle: "Senior Consultant",
+            HighestDegree: "MSc",
+            FieldOfExpertise: "Admissions",
+            YearsOfExperience: 3,
+            SessionFeeUsd: 50m,
+            SessionDurationMinutes: 60,
+            ExpertiseTags: new[] { "SoP" },
+            Languages: new[] { "English" },
+            Country: "Egypt",
+            Timezone: "Africa/Cairo");
+        v.Validate(valid).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validator_rejects_invalid_session_duration()
+    {
+        var v = new SubmitConsultantUpgradeRequestCommandValidator();
+        var bad = new SubmitConsultantUpgradeRequestCommand(
+            Biography: "Hello",
+            ProfessionalTitle: "Title",
+            HighestDegree: "MSc",
+            FieldOfExpertise: "Admissions",
+            YearsOfExperience: 5,
+            SessionFeeUsd: 50m,
+            SessionDurationMinutes: 25, // not allowed
+            ExpertiseTags: new[] { "SoP" },
+            Languages: new[] { "English" },
+            Country: "Egypt",
+            Timezone: "Africa/Cairo");
+        v.Validate(bad).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validator_rejects_invalid_urls()
+    {
+        var v = new SubmitConsultantUpgradeRequestCommandValidator();
+        var bad = new SubmitConsultantUpgradeRequestCommand(
+            Biography: "Hello",
+            ProfessionalTitle: "Title",
+            HighestDegree: "MSc",
+            FieldOfExpertise: "Admissions",
+            YearsOfExperience: 5,
+            SessionFeeUsd: 50m,
+            SessionDurationMinutes: 60,
+            ExpertiseTags: new[] { "SoP" },
+            Languages: new[] { "English" },
+            Country: "Egypt",
+            Timezone: "Africa/Cairo",
+            LinkedInUrl: "not-a-url");
+        v.Validate(bad).IsValid.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Closes the gap where the existing Admin upgrade queue (`/api/admin/upgrade-queue`) had **no way to be fed**: the `UpgradeRequest` entity, the queue query, and the approve/reject flow already lived in the codebase, but there was no Student-facing endpoint to create a Pending request.

This PR adds `POST /api/upgrade-requests/consultant`, authorized as `Student`. The existing review pipeline takes care of the rest — on approval the user gains the `Consultant` role without losing `Student`, yielding a dual-role account (FR-ONB-09).

## Endpoint

```
POST /api/upgrade-requests/consultant
Authorize  [Authorize, Roles="Student"]
Body       SubmitConsultantUpgradeRequestBody
           { biography, professionalTitle, highestDegree, fieldOfExpertise,
             yearsOfExperience, sessionFeeUsd, sessionDurationMinutes,
             expertiseTags[], languages[], country, timezone,
             linkedInUrl?, portfolioUrl? }
Response   201 Created → { requestId }
Errors     400 (validation) | 403 (not Student) | 409 (already consultant
           / duplicate pending / non-active account)
```

The route lives in a new dedicated controller `UpgradeRequestsController` rather than `AdminController` (admin-only) or `AuthController` (auth-only), to keep it discoverable and out of unrelated namespaces.

## Authorization & business rules implemented

1. Authenticated user only (`ICurrentUserService.UserId` required).
2. Account status must be `Active` (else `409`).
3. User must hold the `Student` role (else `403`).
4. User must **not** already hold `Consultant` (else `409`).
5. User must **not** already have a `Status=Pending`, `Target=Consultant`, non-soft-deleted upgrade request (else `409`). Previously rejected or soft-deleted rows are ignored, so a rejected student can retry.
6. Validator mirrors the Consultant rules from `SelectRoleCommandValidator`: bio ≤2000, title ≤150, highest degree ≤150, field of expertise ≤200, years 0–80, session fee > 0, session duration ∈ {30,45,60,90}, ≥1 expertise tag, ≥1 language, country ≤80, time zone ≤64, LinkedIn/Portfolio URLs must be absolute URIs if present.

On success, the handler:

- Creates the `UserProfile` row if missing (using the explicit `db.UserProfiles.Add(...)` pattern that the rest of the code uses; navigation-only assignment is fragile under the InMemory provider).
- Stamps the submitted consultant fields on the profile (`Biography`, `ProfessionalTitle`, `HighestDegree`, `FieldOfExpertise`, `YearsOfExperience`, `SessionFeeUsd`, `SessionDurationMinutes`, `ExpertiseTagsJson`, `LanguagesJson`, `Timezone`, `LinkedInUrl`, `PortfolioUrl`). Student-only fields (`AcademicLevel`, `FieldOfStudy`, `CurrentInstitution`, GPA, preferences) are not touched — the consultant and student schemas don't overlap.
- Fills `user.CountryOfResidence` only if it was blank (so a Student's existing country isn't overwritten).
- Inserts `UpgradeRequest{ Target=Consultant, Status=Pending, Reason="Student-initiated consultant upgrade." }`.
- Returns the new request id.

The existing `GetUpgradeQueueQueryHandler` and `ReviewUpgradeRequestCommandHandler` are untouched — they already do the right thing.

## Files changed

```
server/src/ScholarPath.API/Controllers/UpgradeRequestsController.cs                                                                            (new)
server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommand.cs            (new)
server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandValidator.cs   (new)
server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandHandler.cs     (new)
server/tests/ScholarPath.UnitTests/UpgradeRequests/SubmitConsultantUpgradeRequestCommandHandlerTests.cs                                        (new — 10 tests)
client/src/services/api/upgradeRequests.ts                                                                                                     (new — minimal API helper)
```

No unrelated files modified. No migrations needed — `UpgradeRequest` and the consultant fields on `UserProfile` already exist.

## Tests added

`SubmitConsultantUpgradeRequestCommandHandlerTests` — 10 cases:

1. Active student can submit (assertions on `UpgradeRequest.Target/Status` + persisted `UserProfile` fields + `CountryOfResidence`).
2. Throws `ForbiddenAccessException` when not authenticated.
3. Non-Student users blocked (`ForbiddenAccessException`).
4. Existing Consultant blocked (`ConflictException`).
5. Duplicate Pending request blocked (`ConflictException`).
6. Previously rejected or soft-deleted requests do **not** count toward the duplicate check (retry works).
7. Non-`Active` account status blocked (`ConflictException`).
8. Validator rejects bare/empty payload.
9. Validator rejects invalid `SessionDurationMinutes` (e.g. 25).
10. Validator rejects malformed LinkedIn URL.

## Test plan

- [x] `dotnet build server/ScholarPath.slnx -c Release` — 0 errors, 0 warnings.
- [x] `dotnet test server/tests/ScholarPath.UnitTests/...` — **530 passed, 0 failed** (10 new + 520 pre-existing).
- [x] Targeted run: `--filter "FullyQualifiedName~SubmitConsultantUpgradeRequest"` — 10/10 passed.
- [x] `cd client && npm run lint` — clean.
- [ ] CI: backend + client + status (will run on push).

Client lint passes; client `typecheck` already has pre-existing errors in `src/pages/profile/Profile.tsx` unrelated to this change (verified by removing my new file and re-running — same errors).

## Remaining manual testing

- End-to-end: log in as an Active Student, `POST /api/upgrade-requests/consultant` with a valid payload, confirm the row appears in `GET /api/admin/upgrade-queue?status=Pending`, then approve via the existing admin UI and confirm the user holds **both** `Student` and `Consultant` roles afterwards.
- A frontend page for the Student to fill out this form is **not** included in this PR (the task spec said "add the minimum necessary frontend service function only, without building a full UI unless clearly required") — that's a separate ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDpczHZb3m1z3QPjWAJEhW)_