### PR TITLE
fix(profile): align profile.ts types with Profile.tsx consultant fields

### DIFF
--- a/client/src/services/api/profile.ts
+++ b/client/src/services/api/profile.ts
@@ -26,6 +26,18 @@ export interface UserProfile {
   organizationVerificationStatus: string | null;
   sessionFeeUsd: number | null;
   sessionDurationMinutes: number | null;
+  // ── Consultant professional fields (consumed by the role-aware profile
+  // panel introduced in 6a363af). Optional because legacy users predate
+  // these columns and the GetProfile DTO may not surface them yet — every
+  // call site uses `?? …` to default. ───────────────────────────────────
+  professionalTitle: string | null;
+  yearsOfExperience: number | null;
+  expertiseTags: string[] | null;
+  languages: string[] | null;
+  timezone: string | null;
+  // True when the account has a password set (i.e. not an SSO-only login);
+  // gates the Change Password section per CR-PROF-06.
+  hasPasswordCredential: boolean;
   completenessPercent: number;
 }
 
@@ -49,6 +61,40 @@ export interface UpdateProfileRequest {
   organizationWebsite?: string | null;
   sessionFeeUsd?: number | null;
   sessionDurationMinutes?: number | null;
+  // Consultant professional fields written from the role-aware editor.
+  professionalTitle?: string | null;
+  yearsOfExperience?: number | null;
+  expertiseTags?: string[] | null;
+  languages?: string[] | null;
+  timezone?: string | null;
+}
+
+/**
+ * MIME types accepted by the profile-photo uploader. Matches the page hint
+ * "JPG, PNG or WebP, up to 5 MB.". Kept as a tuple so React's
+ * <input accept> can join it with commas.
+ */
+export const PHOTO_ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
+
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Validates a profile-photo file before upload. Returns null if the file is
+ * acceptable, or an i18n key suffix (`unsupportedType` / `tooLarge`) that the
+ * caller renders via `t('profile:photo.validation.<suffix>')`.
+ */
+export function validatePhotoFile(file: File): "unsupportedType" | "tooLarge" | null {
+  if (!(PHOTO_ALLOWED_MIME_TYPES as readonly string[]).includes(file.type)) {
+    return "unsupportedType";
+  }
+  if (file.size > MAX_PHOTO_BYTES) {
+    return "tooLarge";
+  }
+  return null;
 }
 
 export const profileApi = {


### PR DESCRIPTION
## Summary

Pre-existing `npm run typecheck` failures on `main` were blocking client CI on **every open PR**. This PR fixes the `Profile.tsx` ↔ `profile.ts` half of the drift introduced by commit `6a363af` ("fix(profile): role-aware Personal Info section + consultant professional fields"), which added new field references and imports to the page but never updated the API types or helpers.

Scope is deliberately limited to **`client/src/services/api/profile.ts`** — no Profile.tsx, no backend, no CI workflow changes.

## Errors fixed

| `Profile.tsx` line | Missing in `profile.ts` |
|---|---|
| L28 `import { validatePhotoFile }` | export not present |
| L29 `import { PHOTO_ALLOWED_MIME_TYPES }` | export not present |
| L131 `p.professionalTitle` | not on `UserProfile` |
| L133 `p.yearsOfExperience` | not on `UserProfile` |
| L134 `p.expertiseTags` | not on `UserProfile` |
| L135 `p.languages` | not on `UserProfile` |
| L136 `p.timezone` | not on `UserProfile` |
| L184 `professionalTitle` written via `UpdateProfileRequest` | not on `UpdateProfileRequest` |
| L1565 `profile.hasPasswordCredential` | not on `UserProfile` |

## What this PR does

Adds the missing fields and helpers to `client/src/services/api/profile.ts`:

1. **`UserProfile`** gains six fields the page already reads:
   `professionalTitle: string | null`, `yearsOfExperience: number | null`,
   `expertiseTags: string[] | null`, `languages: string[] | null`,
   `timezone: string | null`, `hasPasswordCredential: boolean`.
2. **`UpdateProfileRequest`** gains the five writable peers
   (`professionalTitle?`, `yearsOfExperience?`, `expertiseTags?`,
   `languages?`, `timezone?`).
3. New exported constant **`PHOTO_ALLOWED_MIME_TYPES`** (`["image/jpeg", "image/png", "image/webp"] as const`) — matches the existing UI hint *"JPG, PNG or WebP, up to 5 MB."*
4. New exported function **`validatePhotoFile(file)`** — returns `null`, `"unsupportedType"`, or `"tooLarge"`; the caller already concatenates the suffix into `t('profile:photo.validation.<suffix>')`. Enforces 5 MB and the MIME allow-list.

The new fields are typed as `T | null` (read) / `T | null` (optional write). Every call site in `Profile.tsx` already defaults with `?? …`, so until the backend `UserProfileDto` actually populates them, the page renders empty strings and the patch round-trip is a no-op — no behavioural regression.

## What this PR does NOT do

- Does **not** modify `Profile.tsx` (the user asked for "Profile.tsx ↔ profile.ts type mismatch" only, and the page is already correct against the new types).
- Does **not** modify the backend `UserProfileDto`, `GetProfileQueryHandler`, or `UpdateProfileCommand` — that's the follow-up to actually persist and surface these fields. Frontend types are now ready for it.
- Does **not** touch `.github/workflows/ci.yml` — Type-check stays required.
- Does **not** modify any other PR's branch.

## Remaining typecheck noise on `main` (not in this PR)

After this change, `npm run typecheck` still reports **5 errors in `client/src/pages/company/ApplicationsReview.tsx`** — a separate drift against `CompanyApplicationRow` in `services/api/applications.ts` (`submittedAt` and `applicationId` missing). It is unrelated to the Profile module and was deliberately left out of scope per the task. A separate `fix/applications-review-typecheck-drift` branch can address it the same way.

## Test plan

- [x] `npm run lint` — clean (`exit 0`, no warnings).
- [x] `npm run typecheck` — 8 Profile-related errors **all resolved**; remaining 5 errors are the unrelated `ApplicationsReview.tsx` drift noted above.
- [ ] CI on push — backend should remain green; client should clear the Profile-half but may still fail on the ApplicationsReview drift.

## Why open this even though CI may still be red

CI will go from **9 broken files → 5 broken files**, all of which are in a different module. That unblocks the Profile half permanently and shrinks the surface that needs the second PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDpczHZb3m1z3QPjWAJEhW)_