### PR TITLE
feat(consultant-booking): add session reminder notifications

### DIFF
--- a/server/src/ScholarPath.API/Program.cs
+++ b/server/src/ScholarPath.API/Program.cs
@@ -370,6 +370,8 @@ if (hangfireOpts.Enabled)
     recurring.AddOrUpdate<IIntegrityCheckJob>("integrity-check", j => j.RunAsync(CancellationToken.None), Cron.Daily(4));
     recurring.AddOrUpdate<ISessionExpiryJob>("session-expiry", j => j.RunAsync(CancellationToken.None), "*/15 * * * *"); // every 15 min
     recurring.AddOrUpdate<ICompletionJob>("booking-completion", j => j.RunAsync(CancellationToken.None), "*/15 * * * *"); // every 15 min
+    // PB-006 — 24-hour and 1-hour BookingReminder notifications for Confirmed sessions.
+    recurring.AddOrUpdate<IBookingReminderJob>("booking-reminders", j => j.RunAsync(CancellationToken.None), "*/15 * * * *"); // every 15 min
     // FR-217 — automated no-show detection from session-room join timestamps.
     recurring.AddOrUpdate<IMeetingNoShowSweepJob>("meeting-no-show-sweep", j => j.RunAsync(CancellationToken.None), "*/15 * * * *"); // every 15 min
     recurring.AddOrUpdate<IStripePayoutJob>("stripe-payouts", j => j.RunAsync(CancellationToken.None), Cron.Daily(2));

--- a/server/src/ScholarPath.Application/Common/Interfaces/IBookingReminderJob.cs
+++ b/server/src/ScholarPath.Application/Common/Interfaces/IBookingReminderJob.cs
@@ -1,0 +1,12 @@
+namespace ScholarPath.Application.Common.Interfaces;
+
+/// <summary>
+/// Recurring sweep that fires reminder notifications (BookingReminder, 24-hour and
+/// 1-hour variants) to the student and consultant before a Confirmed session.
+/// Idempotency is provided by the notification dispatcher's IdempotencyKey lookup,
+/// so a re-run after the job was down still sends each reminder exactly once.
+/// </summary>
+public interface IBookingReminderJob
+{
+    Task RunAsync(CancellationToken cancellationToken);
+}

--- a/server/src/ScholarPath.Application/Notifications/NotificationCatalog.cs
+++ b/server/src/ScholarPath.Application/Notifications/NotificationCatalog.cs
@@ -120,6 +120,8 @@ public sealed class NotificationCatalog : INotificationCatalog
             $"Your session{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" with {p.CounterpartyName}")} is complete — you can now leave a rating.",
             $"اكتملت جلستك{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" مع {p.CounterpartyName}")} — يمكنك الآن إضافة تقييمك."),
 
+        NotificationType.BookingReminder => RenderBookingReminder(p),
+
         NotificationType.OnboardingApproved => new(
             "Account approved", "تم اعتماد حسابك",
             "Your onboarding request was approved — your account is now active.",
@@ -176,6 +178,27 @@ public sealed class NotificationCatalog : INotificationCatalog
             "New notification", "إشعار جديد",
             "You have a new notification.",
             "لديك إشعار جديد."),
+    };
+
+    // BookingReminder has two variants — a day-out heads-up and a final 1-hour ping — so
+    // the catalog picks the wording per kind and falls back to a neutral message if the
+    // discriminator was somehow missed.
+    private static NotificationContent RenderBookingReminder(NotificationParams p) => p.ReminderKind switch
+    {
+        "1h" => new(
+            "Session starts in 1 hour", "تبدأ جلستك خلال ساعة",
+            $"Your session{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" with {p.CounterpartyName}")} starts in about 1 hour{(string.IsNullOrEmpty(p.StartAtText) ? string.Empty : $" ({p.StartAtText})")}.",
+            $"تبدأ جلستك{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" مع {p.CounterpartyName}")} خلال ساعة تقريبًا{(string.IsNullOrEmpty(p.StartAtText) ? string.Empty : $" ({p.StartAtText})")}."),
+
+        "24h" => new(
+            "Session reminder — tomorrow", "تذكير بالجلسة — غدًا",
+            $"Reminder: your session{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" with {p.CounterpartyName}")} is scheduled in about 24 hours{(string.IsNullOrEmpty(p.StartAtText) ? string.Empty : $" on {p.StartAtText}")}.",
+            $"تذكير: جلستك{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" مع {p.CounterpartyName}")} مجدولة خلال 24 ساعة تقريبًا{(string.IsNullOrEmpty(p.StartAtText) ? string.Empty : $" بتاريخ {p.StartAtText}")}."),
+
+        _ => new(
+            "Session reminder", "تذكير بالجلسة",
+            $"Reminder: your session{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" with {p.CounterpartyName}")} is coming up{(string.IsNullOrEmpty(p.StartAtText) ? string.Empty : $" on {p.StartAtText}")}.",
+            $"تذكير: جلستك{(string.IsNullOrEmpty(p.CounterpartyName) ? string.Empty : $" مع {p.CounterpartyName}")} قادمة{(string.IsNullOrEmpty(p.StartAtText) ? string.Empty : $" بتاريخ {p.StartAtText}")}."),
     };
 
     private static NotificationContent RenderReviewRefund(NotificationParams p) => p.RefundKind switch

--- a/server/src/ScholarPath.Application/Notifications/NotificationParams.cs
+++ b/server/src/ScholarPath.Application/Notifications/NotificationParams.cs
@@ -30,6 +30,9 @@ public sealed record NotificationParams
     /// <summary>Refund variant for CompanyReviewRefunded: "Full", "Partial", or "Timeout".</summary>
     public string? RefundKind { get; init; }
 
+    /// <summary>Reminder variant for BookingReminder: "24h" or "1h" before the session starts.</summary>
+    public string? ReminderKind { get; init; }
+
     /// <summary>A counterparty display name (consultant or student) for booking notifications.</summary>
     public string? CounterpartyName { get; init; }
 

--- a/server/src/ScholarPath.Infrastructure/DependencyInjection.cs
+++ b/server/src/ScholarPath.Infrastructure/DependencyInjection.cs
@@ -308,6 +308,7 @@ public static class DependencyInjection
         services.AddScoped<IStripePayoutJob, StripePayoutJob>();
         services.AddScoped<ISessionExpiryJob, SessionExpiryJob>();
         services.AddScoped<ICompletionJob, CompletionJob>();
+        services.AddScoped<IBookingReminderJob, BookingReminderJob>();
         services.AddScoped<IMeetingNoShowSweepJob, MeetingNoShowSweepJob>();
         services.AddScoped<IIntegrityCheckJob, IntegrityCheckJob>();
         services.AddScoped<IDataExportJob, DataExportJob>();

--- a/server/src/ScholarPath.Infrastructure/Jobs/BookingReminderJob.cs
+++ b/server/src/ScholarPath.Infrastructure/Jobs/BookingReminderJob.cs
@@ -1,0 +1,142 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Enums;
+
+namespace ScholarPath.Infrastructure.Jobs;
+
+/// <summary>
+/// Recurring sweep (PB-006) — fires BookingReminder notifications to the student and
+/// the consultant before a Confirmed session.
+///
+/// Two reminder kinds:
+///   • <c>24h</c> — once when the session is within the next 24 hours and still more
+///     than 1 hour away.
+///   • <c>1h</c> — once when the session is within the next 1 hour.
+///
+/// Idempotency is keyed per booking × kind × recipient, so the dispatcher's
+/// IdempotencyKey lookup prevents duplicates even if the job is re-run, replayed,
+/// or has been down for a while. Late reminders (job was paused) are still allowed
+/// as long as the session has not started and the reminder was not sent yet.
+/// </summary>
+public sealed class BookingReminderJob(
+    IApplicationDbContext db,
+    INotificationDispatcher notifications,
+    ILogger<BookingReminderJob> logger) : IBookingReminderJob
+{
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var oneHourOut = now.AddHours(1);
+        var twentyFourHoursOut = now.AddHours(24);
+
+        // Pull every Confirmed booking whose start window we still care about: future
+        // start within the next 24 hours. The narrow window keeps the projection cheap.
+        var upcoming = await db.Bookings
+            .Where(b => b.Status == BookingStatus.Confirmed
+                && b.ScheduledStartAt > now
+                && b.ScheduledStartAt <= twentyFourHoursOut)
+            .Select(b => new UpcomingBooking(
+                b.Id,
+                b.StudentId,
+                b.ConsultantId,
+                b.ScheduledStartAt,
+                (b.Student!.FirstName + " " + b.Student.LastName).Trim(),
+                (b.Consultant!.FirstName + " " + b.Consultant.LastName).Trim()))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (upcoming.Count == 0)
+        {
+            logger.LogInformation("[booking-reminder] no upcoming bookings in the next 24h.");
+            return;
+        }
+
+        var sent = 0;
+        foreach (var booking in upcoming)
+        {
+            // Within the final hour: only the 1h reminder is in scope. Anything past
+            // its start is filtered out by the query above.
+            if (booking.ScheduledStartAt <= oneHourOut)
+            {
+                sent += await DispatchAsync(booking, kind: "1h", cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                // ScheduledStartAt > now + 1h AND <= now + 24h
+                sent += await DispatchAsync(booking, kind: "24h", cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        logger.LogInformation(
+            "[booking-reminder] run complete — {Bookings} booking(s) in window, {Sent} reminder(s) dispatched.",
+            upcoming.Count, sent);
+    }
+
+    private async Task<int> DispatchAsync(
+        UpcomingBooking booking, string kind, CancellationToken ct)
+    {
+        var startAtText = booking.ScheduledStartAt.ToUniversalTime()
+            .ToString("yyyy-MM-dd HH:mm 'UTC'");
+        var dispatched = 0;
+
+        // Student-facing reminder — counterparty is the consultant.
+        try
+        {
+            await notifications.DispatchAsync(
+                booking.StudentId,
+                NotificationType.BookingReminder,
+                new NotificationParams
+                {
+                    CounterpartyName = booking.ConsultantName,
+                    StartAtText = startAtText,
+                    ReminderKind = kind,
+                },
+                deepLink: $"/student/bookings/{booking.Id}",
+                idempotencyKey: $"booking-reminder:{booking.Id:N}:{kind}:student",
+                ct).ConfigureAwait(false);
+            dispatched++;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "[booking-reminder] {Kind} dispatch failed for booking {BookingId} -> student.",
+                kind, booking.Id);
+        }
+
+        // Consultant-facing reminder — counterparty is the student.
+        try
+        {
+            await notifications.DispatchAsync(
+                booking.ConsultantId,
+                NotificationType.BookingReminder,
+                new NotificationParams
+                {
+                    CounterpartyName = booking.StudentName,
+                    StartAtText = startAtText,
+                    ReminderKind = kind,
+                },
+                deepLink: $"/consultant/bookings/{booking.Id}",
+                idempotencyKey: $"booking-reminder:{booking.Id:N}:{kind}:consultant",
+                ct).ConfigureAwait(false);
+            dispatched++;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "[booking-reminder] {Kind} dispatch failed for booking {BookingId} -> consultant.",
+                kind, booking.Id);
+        }
+
+        return dispatched;
+    }
+
+    private sealed record UpcomingBooking(
+        Guid Id,
+        Guid StudentId,
+        Guid ConsultantId,
+        DateTimeOffset ScheduledStartAt,
+        string StudentName,
+        string ConsultantName);
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingReminderJobTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingReminderJobTests.cs
@@ -1,0 +1,292 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Infrastructure.Hubs;
+using ScholarPath.Infrastructure.Jobs;
+using ScholarPath.Infrastructure.Persistence;
+using ScholarPath.Infrastructure.Services;
+using Xunit;
+
+namespace ScholarPath.UnitTests.ConsultantBookings;
+
+/// <summary>
+/// PB-006 — BookingReminderJob fires BookingReminder notifications to the student
+/// and consultant 24 hours and 1 hour before a Confirmed session, idempotent per
+/// (booking, kind, recipient).
+/// </summary>
+public sealed class BookingReminderJobTests
+{
+    private static ApplicationDbContext CreateDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options);
+
+    private static ApplicationUser NewUser(Guid id, string first, string last)
+    {
+        var email = $"{first}@test.com";
+        return new ApplicationUser
+        {
+            Id = id,
+            FirstName = first,
+            LastName = last,
+            Email = email,
+            UserName = email,
+            AccountStatus = AccountStatus.Active,
+        };
+    }
+
+    private static (Guid StudentId, Guid ConsultantId, Guid BookingId) Seed(
+        ApplicationDbContext db,
+        DateTimeOffset scheduledStartAt,
+        BookingStatus status = BookingStatus.Confirmed,
+        string studentFirst = "Tasneem",
+        string consultantFirst = "Sarah")
+    {
+        var studentId = Guid.NewGuid();
+        var consultantId = Guid.NewGuid();
+        var bookingId = Guid.NewGuid();
+
+        db.Users.Add(NewUser(studentId, studentFirst, "Shaban"));
+        db.Users.Add(NewUser(consultantId, consultantFirst, "Adel"));
+        db.Bookings.Add(new ConsultantBooking
+        {
+            Id = bookingId,
+            StudentId = studentId,
+            ConsultantId = consultantId,
+            Status = status,
+            ScheduledStartAt = scheduledStartAt,
+            ScheduledEndAt = scheduledStartAt.AddMinutes(45),
+            DurationMinutes = 45,
+            PriceUsd = 100m,
+        });
+        db.SaveChanges();
+        return (studentId, consultantId, bookingId);
+    }
+
+    private static BookingReminderJob Sut(ApplicationDbContext db, INotificationDispatcher notifier) =>
+        new(db, notifier, NullLogger<BookingReminderJob>.Instance);
+
+    // ─── 24-hour reminder ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sends_24h_reminder_when_session_is_inside_24h_and_more_than_1h_away()
+    {
+        using var db = CreateDb();
+        var startAt = DateTimeOffset.UtcNow.AddHours(20);
+        var ids = Seed(db, startAt);
+
+        var notifier = Substitute.For<INotificationDispatcher>();
+        await Sut(db, notifier).RunAsync(default);
+
+        // Student + Consultant, both with the "24h" kind.
+        await notifier.Received(1).DispatchAsync(
+            ids.StudentId, NotificationType.BookingReminder,
+            Arg.Is<NotificationParams>(p => p.ReminderKind == "24h"),
+            Arg.Any<string?>(),
+            Arg.Is<string?>(k => k == $"booking-reminder:{ids.BookingId:N}:24h:student"),
+            Arg.Any<CancellationToken>());
+        await notifier.Received(1).DispatchAsync(
+            ids.ConsultantId, NotificationType.BookingReminder,
+            Arg.Is<NotificationParams>(p => p.ReminderKind == "24h"),
+            Arg.Any<string?>(),
+            Arg.Is<string?>(k => k == $"booking-reminder:{ids.BookingId:N}:24h:consultant"),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ─── 1-hour reminder ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sends_1h_reminder_when_session_is_within_the_next_hour()
+    {
+        using var db = CreateDb();
+        var startAt = DateTimeOffset.UtcNow.AddMinutes(45);
+        var ids = Seed(db, startAt);
+
+        var notifier = Substitute.For<INotificationDispatcher>();
+        await Sut(db, notifier).RunAsync(default);
+
+        await notifier.Received(1).DispatchAsync(
+            ids.StudentId, NotificationType.BookingReminder,
+            Arg.Is<NotificationParams>(p => p.ReminderKind == "1h"),
+            Arg.Any<string?>(),
+            Arg.Is<string?>(k => k == $"booking-reminder:{ids.BookingId:N}:1h:student"),
+            Arg.Any<CancellationToken>());
+        await notifier.Received(1).DispatchAsync(
+            ids.ConsultantId, NotificationType.BookingReminder,
+            Arg.Is<NotificationParams>(p => p.ReminderKind == "1h"),
+            Arg.Any<string?>(),
+            Arg.Is<string?>(k => k == $"booking-reminder:{ids.BookingId:N}:1h:consultant"),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ─── Both recipients ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Notifies_both_student_and_consultant_with_counterparty_name_and_start_time()
+    {
+        using var db = CreateDb();
+        var startAt = DateTimeOffset.UtcNow.AddHours(12);
+        var ids = Seed(db, startAt, studentFirst: "Tasneem", consultantFirst: "Sarah");
+
+        var notifier = Substitute.For<INotificationDispatcher>();
+        await Sut(db, notifier).RunAsync(default);
+
+        // Student sees the consultant's name as the counterparty.
+        await notifier.Received(1).DispatchAsync(
+            ids.StudentId, NotificationType.BookingReminder,
+            Arg.Is<NotificationParams>(p =>
+                p.CounterpartyName == "Sarah Adel"
+                && !string.IsNullOrEmpty(p.StartAtText)),
+            $"/student/bookings/{ids.BookingId}",
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+
+        // Consultant sees the student's name as the counterparty.
+        await notifier.Received(1).DispatchAsync(
+            ids.ConsultantId, NotificationType.BookingReminder,
+            Arg.Is<NotificationParams>(p =>
+                p.CounterpartyName == "Tasneem Shaban"
+                && !string.IsNullOrEmpty(p.StartAtText)),
+            $"/consultant/bookings/{ids.BookingId}",
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ─── Non-Confirmed statuses are skipped ──────────────────────────────────
+
+    [Theory]
+    [InlineData(BookingStatus.Requested)]
+    [InlineData(BookingStatus.Rejected)]
+    [InlineData(BookingStatus.Expired)]
+    [InlineData(BookingStatus.Cancelled)]
+    [InlineData(BookingStatus.Completed)]
+    [InlineData(BookingStatus.NoShowStudent)]
+    [InlineData(BookingStatus.NoShowConsultant)]
+    public async Task Skips_bookings_in_non_confirmed_statuses(BookingStatus status)
+    {
+        using var db = CreateDb();
+        // Within the 24h window but not Confirmed — must be ignored.
+        Seed(db, DateTimeOffset.UtcNow.AddHours(12), status: status);
+
+        var notifier = Substitute.For<INotificationDispatcher>();
+        await Sut(db, notifier).RunAsync(default);
+
+        await notifier.DidNotReceiveWithAnyArgs().DispatchAsync(
+            default, default, default!, default, default, default);
+    }
+
+    // ─── No reminders after the session has started ──────────────────────────
+
+    [Fact]
+    public async Task Does_not_send_reminder_after_the_session_start_time()
+    {
+        using var db = CreateDb();
+        // 5 minutes past the scheduled start — even though the booking is still
+        // Confirmed (CompletionJob hasn't run yet), reminders must not fire.
+        Seed(db, DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        var notifier = Substitute.For<INotificationDispatcher>();
+        await Sut(db, notifier).RunAsync(default);
+
+        await notifier.DidNotReceiveWithAnyArgs().DispatchAsync(
+            default, default, default!, default, default, default);
+    }
+
+    // ─── Bookings outside the 24h horizon are skipped ────────────────────────
+
+    [Fact]
+    public async Task Skips_bookings_more_than_24h_away()
+    {
+        using var db = CreateDb();
+        Seed(db, DateTimeOffset.UtcNow.AddDays(3));
+
+        var notifier = Substitute.For<INotificationDispatcher>();
+        await Sut(db, notifier).RunAsync(default);
+
+        await notifier.DidNotReceiveWithAnyArgs().DispatchAsync(
+            default, default, default!, default, default, default);
+    }
+
+    // ─── Idempotency (real dispatcher, run twice) ────────────────────────────
+
+    [Fact]
+    public async Task Does_not_send_duplicate_24h_reminders_across_runs()
+    {
+        using var db = CreateDb();
+        var startAt = DateTimeOffset.UtcNow.AddHours(20);
+        var ids = Seed(db, startAt);
+
+        var notifier = new NotificationDispatcher(
+            db,
+            new NotificationCatalog(),
+            Substitute.For<IHubContext<NotificationHub>>(),
+            Substitute.For<IEmailService>(),
+            NullLogger<NotificationDispatcher>.Instance);
+
+        await Sut(db, notifier).RunAsync(default);
+        await Sut(db, notifier).RunAsync(default);
+
+        // First run: 2 recipients × 2 channels (InApp + Email) = 4 rows.
+        // Second run is deduped by IdempotencyKey, so the count stays at 4.
+        var rows = await db.Notifications
+            .Where(n => n.Type == NotificationType.BookingReminder)
+            .ToListAsync();
+        rows.Should().HaveCount(4);
+        rows.Select(r => r.IdempotencyKey).Distinct().Should().HaveCount(2)
+            .And.OnlyContain(k => k!.StartsWith($"booking-reminder:{ids.BookingId:N}:24h:"));
+    }
+
+    [Fact]
+    public async Task Does_not_send_duplicate_1h_reminders_across_runs()
+    {
+        using var db = CreateDb();
+        var startAt = DateTimeOffset.UtcNow.AddMinutes(30);
+        var ids = Seed(db, startAt);
+
+        var notifier = new NotificationDispatcher(
+            db,
+            new NotificationCatalog(),
+            Substitute.For<IHubContext<NotificationHub>>(),
+            Substitute.For<IEmailService>(),
+            NullLogger<NotificationDispatcher>.Instance);
+
+        await Sut(db, notifier).RunAsync(default);
+        await Sut(db, notifier).RunAsync(default);
+
+        var rows = await db.Notifications
+            .Where(n => n.Type == NotificationType.BookingReminder)
+            .ToListAsync();
+        rows.Should().HaveCount(4); // 2 recipients × 2 channels, no duplicates
+        rows.Select(r => r.IdempotencyKey).Distinct().Should().HaveCount(2)
+            .And.OnlyContain(k => k!.StartsWith($"booking-reminder:{ids.BookingId:N}:1h:"));
+    }
+
+    // ─── Idempotency keys are distinct per (kind, recipient) ─────────────────
+
+    [Fact]
+    public async Task Uses_distinct_idempotency_keys_per_kind_and_recipient()
+    {
+        using var db = CreateDb();
+        var keys = new List<string?>();
+        var notifier = Substitute.For<INotificationDispatcher>();
+        await notifier.DispatchAsync(
+            Arg.Any<Guid>(), Arg.Any<NotificationType>(), Arg.Any<NotificationParams>(),
+            Arg.Any<string?>(), Arg.Do<string?>(k => keys.Add(k)), Arg.Any<CancellationToken>());
+
+        // A booking in the 1h window dispatches one pair of (student/consultant)
+        // keys — both must be unique.
+        var ids = Seed(db, DateTimeOffset.UtcNow.AddMinutes(30));
+        await Sut(db, notifier).RunAsync(default);
+
+        keys.Should().HaveCount(2);
+        keys.Distinct().Should().HaveCount(2);
+        keys.Should().Contain($"booking-reminder:{ids.BookingId:N}:1h:student");
+        keys.Should().Contain($"booking-reminder:{ids.BookingId:N}:1h:consultant");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds scheduled booking reminder notifications for confirmed Consultant Booking sessions.
- Sends reminders to both Student and Consultant.
- Sends reminders 24 hours before and 1 hour before the scheduled session start.
- Runs the reminder job every 15 minutes using Hangfire.
- Uses existing `Notification.IdempotencyKey` to prevent duplicate reminders.
- Adds EN/AR notification templates for `BookingReminder`.
- Does not change payment, refund, Stripe, rating, payout, or booking status logic.

## Files changed
- `server/src/ScholarPath.Application/Common/Interfaces/IBookingReminderJob.cs`
- `server/src/ScholarPath.Infrastructure/Jobs/BookingReminderJob.cs`
- `server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingReminderJobTests.cs`
- `server/src/ScholarPath.Application/Notifications/NotificationParams.cs`
- `server/src/ScholarPath.Application/Notifications/NotificationCatalog.cs`
- `server/src/ScholarPath.Infrastructure/DependencyInjection.cs`
- `server/src/ScholarPath.API/Program.cs`

## Tests run
- `dotnet build server/ScholarPath.slnx` — passed, 0 warnings, 0 errors
- `BookingReminderJobTests` — 15/15 passed
- Notifications + ConsultantBookings tests — 138/138 passed
- Full unit test suite — 644/644 passed

## Known limitation
- Integration tests were not runnable because Docker/Testcontainers is not available in the sandbox. This is an environment limitation, not a code failure.
- Notification idempotency currently relies on app-level checking. A DB unique index on `Notification.IdempotencyKey` may be considered later if the platform scales to multiple Hangfire workers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4G8Jshwhq15HNPDrGDjwb)_