### PR TITLE
feat(payments): manual capture + retained commission + payout retry

### DIFF
--- a/client/src/components/application/SubmitConfirmation.tsx
+++ b/client/src/components/application/SubmitConfirmation.tsx
@@ -11,13 +11,19 @@ interface SubmitConfirmationProps {
   onCancel: () => void;
 }
 
+/**
+ * CompanyReview fee confirmation modal. Hosts the StripeCheckout widget
+ * configured for the CompanyReview manual-capture flow: the student
+ * authorizes a hold now and the company captures it when the review is
+ * accepted. (PB-005 v1.)
+ */
 export function ApplicationSubmitConfirmation({
   applicationId,
   scholarshipTitle,
   companyName,
   reviewFeeUsd,
   onPaymentSuccess,
-  onCancel
+  onCancel,
 }: SubmitConfirmationProps) {
   const { t } = useTranslation('company');
 
@@ -59,8 +65,11 @@ export function ApplicationSubmitConfirmation({
               {t('submit.paymentDetails')}
             </p>
             <StripeCheckout
-              bookingId={applicationId}
+              paymentType="CompanyReview"
+              applicationId={applicationId}
               amountCents={Math.round(reviewFeeUsd * 100)}
+              currency="USD"
+              returnUrlPath={`/student/applications/${applicationId}`}
               onSuccess={onPaymentSuccess}
             />
           </div>

--- a/client/src/components/common/StripeCheckout.tsx
+++ b/client/src/components/common/StripeCheckout.tsx
@@ -3,10 +3,21 @@ import { Elements, PaymentElement, useStripe, useElements } from "@stripe/react-
 import { loadStripe, type Stripe } from "@stripe/stripe-js";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { paymentsApi } from "@/services/api/payments";
+import { paymentsApi, type PaymentType } from "@/services/api/payments";
 
 interface StripeCheckoutProps {
-  bookingId: string;
+  /**
+   * Which payment kind this checkout authorises. ConsultantBooking and
+   * CompanyReview both use manual-capture intents; the capture happens
+   * server-side when the consultant accepts the booking or the company
+   * accepts the application review. Defaults to ConsultantBooking for
+   * legacy callers that pre-date the dual-flow rework.
+   */
+  paymentType?: PaymentType;
+  /** Consultant booking id — required when paymentType is ConsultantBooking. */
+  bookingId?: string;
+  /** Application id — required when paymentType is CompanyReview. */
+  applicationId?: string;
   amountCents: number;
   currency?: string;
   /**
@@ -16,21 +27,34 @@ interface StripeCheckoutProps {
    * (PB-006 gap report, Problem 1).
    */
   clientSecret?: string | null;
+  /** Path to redirect to after successful authorisation. Defaults match the type. */
+  returnUrlPath?: string;
   onSuccess?: () => void;
 }
 
 /**
- * Real Stripe Elements checkout for a consultant booking.
+ * Real Stripe Elements checkout for either a consultant booking or a company
+ * review (application) fee.
  *
- * Flow: create a manual-capture PaymentIntent for the booking → render the
- * Stripe PaymentElement → confirm → the session fee is authorized (held).
- * Capture happens server-side when the consultant accepts the booking.
+ * Flow (auto-create branch):
+ *   - Calls `POST /api/payments/intent` with the correct type + related id.
+ *   - Renders the Stripe PaymentElement.
+ *   - Student confirms → funds authorized (held) on the card.
+ *   - Capture happens server-side when the counterparty accepts.
+ *
+ * Flow (preset clientSecret branch):
+ *   - The intent was already created by the back-end (e.g. RequestBooking
+ *     returns one) and the caller passes its clientSecret — we never create a
+ *     second one.
  */
 export function StripeCheckout({
+  paymentType = "ConsultantBooking",
   bookingId,
+  applicationId,
   amountCents,
   currency = "USD",
   clientSecret: presetClientSecret,
+  returnUrlPath,
   onSuccess,
 }: StripeCheckoutProps) {
   const { t } = useTranslation("bookings");
@@ -45,18 +69,36 @@ export function StripeCheckout({
     [configured, publishableKey],
   );
 
+  // Compute the related-id once per render so the effect doesn't have to
+  // branch on payment type itself; this also lets us validate the props
+  // outside the effect (avoids react-hooks/set-state-in-effect).
+  const relatedBookingId =
+    paymentType === "ConsultantBooking" ? bookingId ?? null : null;
+  const relatedApplicationId =
+    paymentType === "CompanyReview" ? applicationId ?? null : null;
+
+  const propsError = !configured
+    ? null
+    : paymentType === "ConsultantBooking" && !relatedBookingId && !presetClientSecret
+      ? "Missing bookingId for ConsultantBooking checkout."
+      : paymentType === "CompanyReview" && !relatedApplicationId && !presetClientSecret
+        ? "Missing applicationId for CompanyReview checkout."
+        : null;
+
   useEffect(() => {
     // The booking flow passes an existing intent's client secret — the intent
     // is already created, so the widget must not create a second one
     // (PB-006 gap report, Problem 1).
-    if (!configured || presetClientSecret) return;
+    if (!configured || presetClientSecret || propsError) return;
+
     let cancelled = false;
     paymentsApi
       .createIntent({
-        type: "ConsultantBooking",
+        type: paymentType,
         amountCents,
         currency,
-        relatedBookingId: bookingId,
+        relatedBookingId,
+        relatedApplicationId,
       })
       .then((res) => {
         if (!cancelled) setClientSecret(res.clientSecret);
@@ -69,7 +111,19 @@ export function StripeCheckout({
     return () => {
       cancelled = true;
     };
-  }, [amountCents, currency, bookingId, configured, presetClientSecret, t]);
+  }, [
+    paymentType,
+    amountCents,
+    currency,
+    relatedBookingId,
+    relatedApplicationId,
+    configured,
+    presetClientSecret,
+    propsError,
+    t,
+  ]);
+
+  const effectiveError = error ?? propsError;
 
   if (!configured) {
     return (
@@ -79,10 +133,10 @@ export function StripeCheckout({
     );
   }
 
-  if (error) {
+  if (effectiveError) {
     return (
       <div className="rounded-lg border border-danger-200 bg-danger-50 p-4 text-sm text-danger-500">
-        {error}
+        {effectiveError}
       </div>
     );
   }
@@ -91,18 +145,24 @@ export function StripeCheckout({
     return <div className="text-sm text-text-tertiary">{t("checkout.payment.preparing")}</div>;
   }
 
+  const resolvedReturnPath =
+    returnUrlPath
+    ?? (paymentType === "CompanyReview" && applicationId
+      ? `/student/applications/${applicationId}`
+      : `/student/bookings/${bookingId ?? ""}`);
+
   return (
     <Elements stripe={stripePromise} options={{ clientSecret, appearance: { theme: "stripe" } }}>
-      <CheckoutInner bookingId={bookingId} onSuccess={onSuccess} />
+      <CheckoutInner returnUrlPath={resolvedReturnPath} onSuccess={onSuccess} />
     </Elements>
   );
 }
 
 function CheckoutInner({
-  bookingId,
+  returnUrlPath,
   onSuccess,
 }: {
-  bookingId: string;
+  returnUrlPath: string;
   onSuccess?: () => void;
 }) {
   const { t } = useTranslation("bookings");
@@ -119,7 +179,7 @@ function CheckoutInner({
     // Amazon Pay, etc.).  Without it Stripe returns a 400 for those methods even
     // when `redirect: "if_required"` is set — Stripe still needs a fallback URL
     // in case the payment method forces a redirect.
-    const returnUrl = `${window.location.origin}/student/bookings/${bookingId}`;
+    const returnUrl = `${window.location.origin}${returnUrlPath}`;
     const { error } = await stripe.confirmPayment({
       elements,
       redirect: "if_required",

--- a/client/src/pages/student/StudentApplicationDetail.tsx
+++ b/client/src/pages/student/StudentApplicationDetail.tsx
@@ -30,6 +30,7 @@ import {
   type DocumentCategory,
 } from "@/services/api/documents";
 import { ApiError, apiErrorMessage } from "@/services/api/client";
+import { ApplicationSubmitConfirmation } from "@/components/application/SubmitConfirmation";
 
 // ── Application-form schema ───────────────────────────────────────────────────
 // A scholarship's ApplicationFormSchemaJson is { "fields": [{ key, label, type,
@@ -486,6 +487,14 @@ function DraftApplicationForm({
       toast.error(apiErrorMessage(err, t("moderation:appDetail.form.saveError"))),
   });
 
+  // CompanyReview fee gating (PB-005 v1). When the scholarship configures a
+  // review fee the student must first authorise a manual-capture hold; only
+  // after Stripe confirms the authorization do we transition the application
+  // to Pending. For free scholarships the flow is unchanged.
+  const reviewFeeUsd = application.reviewFeeUsd ?? 0;
+  const requiresReviewFeePayment = reviewFeeUsd > 0;
+  const [showPaymentModal, setShowPaymentModal] = useState(false);
+
   const submitMut = useMutation({
     mutationFn: async () => {
       // Persist the current answers, then transition the draft to Pending.
@@ -494,6 +503,7 @@ function DraftApplicationForm({
     },
     onSuccess: () => {
       toast.success(t("moderation:appDetail.submittedToast"));
+      setShowPaymentModal(false);
       invalidate();
     },
     onError: (err: unknown) => {
@@ -528,6 +538,18 @@ function DraftApplicationForm({
       return;
     }
     setErrors({});
+    if (requiresReviewFeePayment) {
+      // Persist the answers so a Stripe redirect-based payment method doesn't
+      // lose the student's work, then open the payment modal. The modal calls
+      // submitMut after the hold is authorised.
+      void applicationsApi
+        .saveDraft(application.id, buildBody())
+        .then(() => setShowPaymentModal(true))
+        .catch((err) =>
+          toast.error(apiErrorMessage(err, t("moderation:appDetail.form.saveError"))),
+        );
+      return;
+    }
     submitMut.mutate();
   };
 
@@ -820,7 +842,57 @@ function DraftApplicationForm({
             : t("moderation:appDetail.submit")}
         </button>
       </div>
+
+      {showPaymentModal && requiresReviewFeePayment && (
+        <ReviewFeePaymentModal
+          applicationId={application.id}
+          scholarshipTitle={application.scholarshipTitleEn}
+          companyName={application.companyName ?? ""}
+          reviewFeeUsd={reviewFeeUsd}
+          onPaymentSuccess={() => submitMut.mutate()}
+          onCancel={() => setShowPaymentModal(false)}
+        />
+      )}
     </section>
+  );
+}
+
+// ── CompanyReview fee payment modal ──────────────────────────────────────────
+// Wraps ApplicationSubmitConfirmation in a backdrop so it can render inline
+// from the submit button without needing its own route.
+
+function ReviewFeePaymentModal({
+  applicationId,
+  scholarshipTitle,
+  companyName,
+  reviewFeeUsd,
+  onPaymentSuccess,
+  onCancel,
+}: {
+  applicationId: string;
+  scholarshipTitle: string;
+  companyName: string;
+  reviewFeeUsd: number;
+  onPaymentSuccess: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/40 px-4 py-8"
+    >
+      <div className="w-full max-w-2xl rounded-2xl bg-bg-base shadow-xl">
+        <ApplicationSubmitConfirmation
+          applicationId={applicationId}
+          scholarshipTitle={scholarshipTitle}
+          companyName={companyName}
+          reviewFeeUsd={reviewFeeUsd}
+          onPaymentSuccess={onPaymentSuccess}
+          onCancel={onCancel}
+        />
+      </div>
+    </div>
   );
 }
 

--- a/client/src/services/api/applications.ts
+++ b/client/src/services/api/applications.ts
@@ -87,6 +87,12 @@ export interface ApplicationDetail {
   submittedAt: string | null;
   reviewStartedAt: string | null;
   decisionAt: string | null;
+  /**
+   * CompanyReview fee in USD. Null/0 = no review fee, submit directly;
+   * > 0 = the submit flow must first collect a manual-capture payment held
+   * in escrow until the company finalises the review (PB-005 v1).
+   */
+  reviewFeeUsd: number | null;
 }
 
 /** Result of `POST /api/applications` — mirrors the server's StartApplicationResult. */

--- a/server/src/ScholarPath.Application/Applications/Commands/WithdrawApplication/WithdrawApplicationCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Applications/Commands/WithdrawApplication/WithdrawApplicationCommandHandler.cs
@@ -38,13 +38,24 @@ public sealed class WithdrawApplicationCommandHandler(
         application.Status = ApplicationStatus.Withdrawn;
         application.WithdrawnAt = DateTimeOffset.UtcNow;
 
-        var payment = await db.CompanyReviewPayments
-            .FirstOrDefaultAsync(p => p.ApplicationTrackerId == application.Id && p.Status == PaymentStatus.Held, ct);
+        // PB-005 v1: company-review payments live on the unified Payment table
+        // (Type = CompanyReview). A payment qualifies for the withdrawal refund
+        // flow only when it has not yet been finalised — i.e. it is still Held
+        // (pre-acceptance) or already Captured (post-acceptance, under review).
+        var payment = await db.Payments
+            .FirstOrDefaultAsync(p =>
+                p.Type == PaymentType.CompanyReview
+                && p.RelatedApplicationId == application.Id
+                && (p.Status == PaymentStatus.Held
+                    || p.Status == PaymentStatus.Pending
+                    || p.Status == PaymentStatus.Captured),
+                ct);
 
         if (payment != null)
         {
-            // Refund policy: withdraw before the company starts reviewing -> 100%;
-            // withdraw once it is already under review -> 50%.
+            // Refund policy: withdraw before the company starts reviewing -> 100%
+            // (hold cancelled, no charge), withdraw once it is already under review
+            // -> 50% (Stripe Refund issued).
             var isFullRefund = statusBeforeWithdrawal
                 is ApplicationStatus.Draft or ApplicationStatus.Pending;
             var refundCommand = new ScholarPath.Application.CompanyReviews.Commands.RefundCompanyReview.RefundCompanyReviewCommand(

--- a/server/src/ScholarPath.Application/Applications/Queries/GetApplicationDetail/GetApplicationDetailQuery.cs
+++ b/server/src/ScholarPath.Application/Applications/Queries/GetApplicationDetail/GetApplicationDetailQuery.cs
@@ -28,7 +28,10 @@ public sealed record ApplicationDetailDto(
     DateTimeOffset? UpdatedAt,
     DateTimeOffset? SubmittedAt,
     DateTimeOffset? ReviewStartedAt,
-    DateTimeOffset? DecisionAt);
+    DateTimeOffset? DecisionAt,
+    // Surfaced so the student UI can decide whether to gate "Submit" behind
+    // a CompanyReview payment confirmation. Null/0 = no fee required.
+    decimal? ReviewFeeUsd);
 
 // ─── Query ────────────────────────────────────────────────────────────────────
 
@@ -85,6 +88,7 @@ public sealed class GetApplicationDetailQueryHandler(
             application.UpdatedAt,
             application.SubmittedAt,
             application.ReviewStartedAt,
-            application.DecisionAt);
+            application.DecisionAt,
+            scholarship?.ReviewFeeUsd);
     }
 }

--- a/server/src/ScholarPath.Application/CompanyReviews/Commands/CaptureCompanyReviewPayment/CaptureCompanyReviewPaymentCommand.cs
+++ b/server/src/ScholarPath.Application/CompanyReviews/Commands/CaptureCompanyReviewPayment/CaptureCompanyReviewPaymentCommand.cs
@@ -1,19 +1,26 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Application.Common.Auditing;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.FinancialConfig;
 using ScholarPath.Application.Notifications;
 using ScholarPath.Domain.Enums;
 
-
 namespace ScholarPath.Application.CompanyReviews.Commands.CaptureCompanyReviewPayment;
-[Auditable(AuditAction.Update, "CompanyReviewPayment",
+
+[Auditable(AuditAction.PaymentCaptured, "Payment",
     TargetIdProperty = nameof(ApplicationId),
-    SummaryTemplate = "Captured payment for application {ApplicationId}")]
+    SummaryTemplate = "Captured CompanyReview payment for application {ApplicationId}")]
 public sealed record CaptureCompanyReviewPaymentCommand(
     Guid ApplicationId) : IRequest<bool>;
 
+/// <summary>
+/// Captures the held CompanyReview PaymentIntent on the unified
+/// <see cref="Domain.Entities.Payment"/> row identified by
+/// <c>Type == CompanyReview &amp;&amp; RelatedApplicationId == ApplicationId</c>.
+/// Called when the company finalises the application review (Accepted).
+/// </summary>
 public sealed class CaptureCompanyReviewPaymentCommandHandler(
     IApplicationDbContext db,
     IStripeService stripeService,
@@ -23,45 +30,85 @@ public sealed class CaptureCompanyReviewPaymentCommandHandler(
 {
     public async Task<bool> Handle(CaptureCompanyReviewPaymentCommand request, CancellationToken ct)
     {
-        var payment = await db.CompanyReviewPayments
-            .FirstOrDefaultAsync(p => p.ApplicationTrackerId == request.ApplicationId && p.Status == PaymentStatus.Held, ct);
+        // Look up the held CompanyReview Payment for this application. We accept
+        // Held *or* Pending because the Stripe `amount_capturable_updated`
+        // webhook may not have landed yet — the capture call itself proves the
+        // intent is in `requires_capture`.
+        var payment = await db.Payments
+            .FirstOrDefaultAsync(p =>
+                p.Type == PaymentType.CompanyReview
+                && p.RelatedApplicationId == request.ApplicationId
+                && (p.Status == PaymentStatus.Held || p.Status == PaymentStatus.Pending),
+                ct);
 
-        if (payment == null) return false;
+        if (payment is null)
+        {
+            logger.LogInformation(
+                "No held CompanyReview payment found for application {ApplicationId} — nothing to capture.",
+                request.ApplicationId);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(payment.StripePaymentIntentId))
+        {
+            logger.LogWarning(
+                "CompanyReview payment {PaymentId} has no Stripe PaymentIntent id; cannot capture.",
+                payment.Id);
+            return false;
+        }
 
         try
         {
             var stripeResult = await stripeService.CapturePaymentIntentAsync(
                 payment.StripePaymentIntentId,
-                null,
-                $"company-review-capture:{payment.Id:N}",
-                ct);
+                amountToCaptureCents: null,
+                idempotencyKey: $"company-review-capture:{payment.Id:N}",
+                ct: ct);
 
-            if (stripeResult.Status == "succeeded")
+            if (stripeResult.Status != "succeeded")
             {
-                payment.Status = PaymentStatus.Captured;
-                payment.CapturedAt = DateTimeOffset.UtcNow;
-
-                await db.SaveChangesAsync(ct).ConfigureAwait(false);
-
-                await notifications.DispatchAsync(
-                    payment.CompanyId,
-                    NotificationType.CompanyReviewPaymentSuccess,
-                    NotificationParams.Empty,
-                    null,
-                    null,
-                    ct);
-
-                return true;
+                logger.LogWarning(
+                    "Capture for application {ApplicationId} returned Stripe status {Status}; payment left as {Original}.",
+                    request.ApplicationId, stripeResult.Status, payment.Status);
+                return false;
             }
 
-            logger.LogWarning(
-                "Capture for application {ApplicationId} returned Stripe status {Status}; payment left as Held.",
-                request.ApplicationId, stripeResult.Status);
-            return false;
+            var nowUtc = DateTimeOffset.UtcNow;
+            payment.Status = PaymentStatus.Captured;
+            payment.CapturedAt = nowUtc;
+            if (!string.IsNullOrWhiteSpace(stripeResult.LatestChargeId))
+            {
+                payment.StripeChargeId = stripeResult.LatestChargeId;
+            }
+
+            // Re-resolve the split at capture time so the snapshot reflects the
+            // rule in force right now (an admin can change the active rule
+            // between intent creation and capture). PB-014 v1 = 10% default.
+            var split = await FinancialRuleResolver.ResolvePaymentSplitAsync(
+                db, payment.Type, payment.AmountCents, ct);
+            payment.ProfitShareAmountCents = split.PlatformTakeCents;
+            payment.PayeeAmountCents = split.PayeeNetCents;
+
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            if (payment.PayeeUserId is Guid payee)
+            {
+                await notifications.DispatchAsync(
+                    payee,
+                    NotificationType.CompanyReviewPaymentSuccess,
+                    NotificationParams.Empty,
+                    deepLink: null,
+                    idempotencyKey: $"company-review-paid:{payment.Id:N}",
+                    ct).ConfigureAwait(false);
+            }
+
+            return true;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to capture payment for application {ApplicationId}", request.ApplicationId);
+            logger.LogError(ex,
+                "Failed to capture CompanyReview payment for application {ApplicationId}",
+                request.ApplicationId);
             return false;
         }
     }

--- a/server/src/ScholarPath.Application/CompanyReviews/Commands/RefundCompanyReview/RefundCompanyReviewCommand.cs
+++ b/server/src/ScholarPath.Application/CompanyReviews/Commands/RefundCompanyReview/RefundCompanyReviewCommand.cs
@@ -1,17 +1,32 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using ScholarPath.Application.Common.Auditing;
+using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.FinancialConfig;
 using ScholarPath.Application.Notifications;
 using ScholarPath.Application.Payments;
 using ScholarPath.Domain.Enums;
 
 namespace ScholarPath.Application.CompanyReviews.Commands.RefundCompanyReview;
 
+[Auditable(AuditAction.PaymentRefunded, "Payment",
+    TargetIdProperty = nameof(ApplicationId),
+    SummaryTemplate = "Refunded CompanyReview payment for application {ApplicationId} — full={IsFullRefund}")]
 public sealed record RefundCompanyReviewCommand(
     Guid ApplicationId,
     bool IsFullRefund) : IRequest<bool>;
 
+/// <summary>
+/// Refunds (full or 50%) the CompanyReview payment for an application. Works
+/// off the unified <see cref="Domain.Entities.Payment"/> row, choosing the
+/// correct Stripe action based on the payment's current state:
+/// <list type="bullet">
+///   <item>Held — cancel the PaymentIntent (no charge ever lands).</item>
+///   <item>Captured — issue a full or 50% Stripe Refund.</item>
+/// </list>
+/// </summary>
 public sealed class RefundCompanyReviewCommandHandler(
     IApplicationDbContext db,
     IStripeService stripeService,
@@ -21,84 +36,135 @@ public sealed class RefundCompanyReviewCommandHandler(
 {
     public async Task<bool> Handle(RefundCompanyReviewCommand request, CancellationToken ct)
     {
-        var payment = await db.CompanyReviewPayments
-            .FirstOrDefaultAsync(p => p.ApplicationTrackerId == request.ApplicationId && p.Status == PaymentStatus.Held, ct);
+        var payment = await db.Payments
+            .FirstOrDefaultAsync(p =>
+                p.Type == PaymentType.CompanyReview
+                && p.RelatedApplicationId == request.ApplicationId
+                && (p.Status == PaymentStatus.Held
+                    || p.Status == PaymentStatus.Pending
+                    || p.Status == PaymentStatus.Captured
+                    || p.Status == PaymentStatus.PartiallyRefunded),
+                ct);
 
-        if (payment == null) return false;
+        if (payment is null)
+        {
+            logger.LogInformation(
+                "No refundable CompanyReview payment found for application {ApplicationId}.",
+                request.ApplicationId);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(payment.StripePaymentIntentId))
+        {
+            logger.LogWarning(
+                "CompanyReview payment {PaymentId} has no Stripe PaymentIntent id; cannot refund.",
+                payment.Id);
+            return false;
+        }
 
         var application = await db.Applications
             .FirstOrDefaultAsync(a => a.Id == request.ApplicationId, ct);
 
+        var nowUtc = DateTimeOffset.UtcNow;
+
         try
         {
-            if (request.IsFullRefund)
+            // PATH A — Held / Pending: cancel the intent (no charge).
+            if (payment.Status is PaymentStatus.Held or PaymentStatus.Pending)
             {
+                if (!request.IsFullRefund)
+                {
+                    throw new ConflictException(
+                        "Cannot issue a partial refund against a payment that has not been captured yet.");
+                }
+
                 await stripeService.CancelHeldPaymentAsync(
                     payment.StripePaymentIntentId,
-                    $"company-review-refund:{payment.Id:N}:full",
-                    ct);
+                    idempotencyKey: $"company-review-refund:{payment.Id:N}:cancel",
+                    ct: ct);
 
-                payment.Status = PaymentStatus.Refunded;
-                payment.RefundedAmountUsd = payment.AmountUsd;
-                payment.RefundReason = "System triggered full refund";
-
-                if (application != null)
-                {
-                    await notifications.DispatchAsync(
-                        application.StudentId,
-                        NotificationType.CompanyReviewRefunded,
-                        new NotificationParams { RefundKind = "Full" },
-                        null,
-                        null,
-                        ct);
-                }
+                payment.Status = PaymentStatus.Cancelled;
+                payment.RefundedAmountCents = 0;
+                payment.ProfitShareAmountCents = 0;
+                payment.PayeeAmountCents = 0;
+                payment.RefundedAt = null;
+                payment.RefundReason = request.IsFullRefund
+                    ? "Full refund — intent cancelled before capture"
+                    : "Cancelled";
             }
             else
             {
-                long refundAmountCents = (long)(payment.AmountUsd * 50m);
-                var captureAmountCents = (long)(payment.AmountUsd * 100m) - refundAmountCents;
+                // PATH B — Captured / PartiallyRefunded: Stripe Refund.
+                var refundAmountCents = request.IsFullRefund
+                    ? payment.AmountCents - payment.RefundedAmountCents
+                    : payment.AmountCents / 2;
 
-                var stripeResult = await stripeService.CapturePaymentIntentAsync(
-                    payment.StripePaymentIntentId,
-                    captureAmountCents,
-                    $"company-review-refund:{payment.Id:N}:partial",
-                    ct);
-
-                if (stripeResult.Status == "succeeded")
+                if (payment.RefundedAmountCents + refundAmountCents > payment.AmountCents)
                 {
-                    payment.Status = PaymentStatus.PartiallyRefunded;
-                    payment.CapturedAt = DateTimeOffset.UtcNow;
-                    payment.RefundedAmountUsd = payment.AmountUsd - (captureAmountCents / 100m);
-                    payment.RefundReason = "System triggered partial (50%) refund";
-
-                    if (application != null)
-                    {
-                        await notifications.DispatchAsync(
-                            application.StudentId,
-                            NotificationType.CompanyReviewRefunded,
-                            new NotificationParams { RefundKind = "Partial" },
-                            null,
-                            null,
-                            ct);
-                    }
+                    throw new ConflictException(
+                        "Refund would exceed the captured amount of this payment.");
                 }
-                else
+
+                var idempotencyKey = request.IsFullRefund
+                    ? $"company-review-refund:{payment.Id:N}:full"
+                    : $"company-review-refund:{payment.Id:N}:partial";
+
+                var refundResult = await stripeService.RefundPaymentAsync(
+                    paymentIntentId: payment.StripePaymentIntentId,
+                    amountCents: refundAmountCents,
+                    reason: "requested_by_customer",
+                    idempotencyKey: idempotencyKey,
+                    ct: ct);
+
+                if (refundResult.Status != "succeeded")
                 {
-                    // Stripe did not confirm the partial capture — leave the payment
-                    // as Held (don't persist a fake refund) and let the caller retry.
                     logger.LogError(
-                        "Partial refund for application {ApplicationId} did not succeed (Stripe status {Status}). Payment left as Held.",
-                        request.ApplicationId, stripeResult.Status);
+                        "Refund for application {ApplicationId} did not succeed (Stripe status {Status}). Payment unchanged.",
+                        request.ApplicationId, refundResult.Status);
                     return false;
                 }
+
+                payment.RefundedAmountCents += refundResult.AmountCents;
+                payment.RefundedAt = nowUtc;
+                payment.RefundReason = request.IsFullRefund
+                    ? "Full refund — Stripe Refund issued"
+                    : "Partial (50%) refund — Stripe Refund issued";
+
+                payment.Status = payment.RefundedAmountCents >= payment.AmountCents
+                    ? PaymentStatus.Refunded
+                    : PaymentStatus.PartiallyRefunded;
+
+                // PB-014 v1: commission tracks retained amount, not gross.
+                var retainedSplit = await FinancialRuleResolver.ResolveSplitFromRetainedAsync(
+                    db, payment.Type, payment.AmountCents, payment.RefundedAmountCents, ct);
+                payment.ProfitShareAmountCents = retainedSplit.PlatformTakeCents;
+                payment.PayeeAmountCents = retainedSplit.PayeeNetCents;
             }
 
             await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            if (application is not null)
+            {
+                await notifications.DispatchAsync(
+                    application.StudentId,
+                    NotificationType.CompanyReviewRefunded,
+                    new NotificationParams { RefundKind = request.IsFullRefund ? "Full" : "Partial" },
+                    deepLink: null,
+                    idempotencyKey: $"company-review-refund-notice:{payment.Id:N}:{(request.IsFullRefund ? "full" : "partial")}",
+                    ct).ConfigureAwait(false);
+            }
+
             return true;
+        }
+        catch (ConflictException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to refund company review payment for application {ApplicationId}", request.ApplicationId);
+            logger.LogError(ex,
+                "Failed to refund CompanyReview payment for application {ApplicationId}",
+                request.ApplicationId);
             return false;
         }
     }

--- a/server/src/ScholarPath.Application/CompanyReviews/Commands/RejectCompanyReviewPayment/RejectCompanyReviewPaymentCommand.cs
+++ b/server/src/ScholarPath.Application/CompanyReviews/Commands/RejectCompanyReviewPayment/RejectCompanyReviewPaymentCommand.cs
@@ -1,0 +1,95 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ScholarPath.Application.Common.Auditing;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Application.Payments;
+using ScholarPath.Domain.Enums;
+
+namespace ScholarPath.Application.CompanyReviews.Commands.RejectCompanyReviewPayment;
+
+[Auditable(AuditAction.Update, "Payment",
+    TargetIdProperty = nameof(ApplicationId),
+    SummaryTemplate = "Cancelled CompanyReview payment hold for rejected application {ApplicationId}")]
+public sealed record RejectCompanyReviewPaymentCommand(
+    Guid ApplicationId) : IRequest<bool>;
+
+/// <summary>
+/// Cancels the held CompanyReview PaymentIntent when a company rejects an
+/// application before any capture has occurred. No money changes hands. Used
+/// by <c>ApplicationStatusChangedEventHandler</c> on the Rejected transition.
+/// </summary>
+public sealed class RejectCompanyReviewPaymentCommandHandler(
+    IApplicationDbContext db,
+    IStripeService stripeService,
+    INotificationDispatcher notifications,
+    ILogger<RejectCompanyReviewPaymentCommandHandler> logger)
+    : IRequestHandler<RejectCompanyReviewPaymentCommand, bool>
+{
+    public async Task<bool> Handle(RejectCompanyReviewPaymentCommand request, CancellationToken ct)
+    {
+        var payment = await db.Payments
+            .FirstOrDefaultAsync(p =>
+                p.Type == PaymentType.CompanyReview
+                && p.RelatedApplicationId == request.ApplicationId
+                && (p.Status == PaymentStatus.Held || p.Status == PaymentStatus.Pending),
+                ct);
+
+        // If no held payment exists, the rejection has nothing to cancel —
+        // not all applications carry a review fee.
+        if (payment is null)
+        {
+            logger.LogInformation(
+                "No held CompanyReview payment to cancel for rejected application {ApplicationId}.",
+                request.ApplicationId);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(payment.StripePaymentIntentId))
+        {
+            logger.LogWarning(
+                "CompanyReview payment {PaymentId} has no Stripe PaymentIntent id; cannot cancel.",
+                payment.Id);
+            return false;
+        }
+
+        try
+        {
+            await stripeService.CancelHeldPaymentAsync(
+                payment.StripePaymentIntentId,
+                idempotencyKey: $"company-review-reject:{payment.Id:N}",
+                ct: ct).ConfigureAwait(false);
+
+            payment.Status = PaymentStatus.Cancelled;
+            payment.RefundedAmountCents = 0;
+            payment.ProfitShareAmountCents = 0;
+            payment.PayeeAmountCents = 0;
+            payment.FailureReason = "company_rejected_application";
+
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            var application = await db.Applications
+                .FirstOrDefaultAsync(a => a.Id == request.ApplicationId, ct);
+            if (application is not null)
+            {
+                await notifications.DispatchAsync(
+                    application.StudentId,
+                    NotificationType.CompanyReviewRefunded,
+                    new NotificationParams { RefundKind = "Rejection" },
+                    deepLink: null,
+                    idempotencyKey: $"company-review-reject-notice:{payment.Id:N}",
+                    ct).ConfigureAwait(false);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to cancel CompanyReview payment hold for rejected application {ApplicationId}",
+                request.ApplicationId);
+            return false;
+        }
+    }
+}

--- a/server/src/ScholarPath.Application/CompanyReviews/EventHandlers/ApplicationStatusChangedEventHandler.cs
+++ b/server/src/ScholarPath.Application/CompanyReviews/EventHandlers/ApplicationStatusChangedEventHandler.cs
@@ -1,11 +1,21 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ScholarPath.Application.CompanyReviews.Commands.CaptureCompanyReviewPayment;
+using ScholarPath.Application.CompanyReviews.Commands.RejectCompanyReviewPayment;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Events;
 
 namespace ScholarPath.Application.CompanyReviews.EventHandlers;
 
+/// <summary>
+/// Drives the CompanyReview payment outcome from the application's final status:
+/// <list type="bullet">
+///   <item>Accepted — capture the held PaymentIntent (company earns the fee).</item>
+///   <item>Rejected — cancel the held PaymentIntent (no charge ever lands).</item>
+/// </list>
+/// Other intermediate states (UnderReview, Shortlisted, …) are ignored — the
+/// hold remains in place while the company reviews.
+/// </summary>
 public sealed class ApplicationStatusChangedEventHandler(
     ISender sender,
     ILogger<ApplicationStatusChangedEventHandler> logger)
@@ -13,13 +23,23 @@ public sealed class ApplicationStatusChangedEventHandler(
 {
     public async Task Handle(ApplicationStatusChangedEvent notification, CancellationToken ct)
     {
-        if (notification.NewStatus is ApplicationStatus.Accepted or ApplicationStatus.Rejected)
+        switch (notification.NewStatus)
         {
-            logger.LogInformation("Application {ApplicationId} reached final status {Status}. Triggering review payment capture.", 
-                notification.ApplicationId, notification.NewStatus);
+            case ApplicationStatus.Accepted:
+                logger.LogInformation(
+                    "Application {ApplicationId} accepted — capturing CompanyReview payment.",
+                    notification.ApplicationId);
+                await sender.Send(
+                    new CaptureCompanyReviewPaymentCommand(notification.ApplicationId), ct);
+                break;
 
-            var captureCommand = new CaptureCompanyReviewPaymentCommand(notification.ApplicationId);
-            await sender.Send(captureCommand, ct);
+            case ApplicationStatus.Rejected:
+                logger.LogInformation(
+                    "Application {ApplicationId} rejected — cancelling held CompanyReview payment.",
+                    notification.ApplicationId);
+                await sender.Send(
+                    new RejectCompanyReviewPaymentCommand(notification.ApplicationId), ct);
+                break;
         }
     }
 }

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/CancelBooking/CancelBookingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/CancelBooking/CancelBookingCommandHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Application.ConsultantBookings.Services;
+using ScholarPath.Application.FinancialConfig;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Events;
 using ScholarPath.Domain.Exceptions;
@@ -137,21 +138,16 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
                     ? PaymentStatus.Refunded
                     : PaymentStatus.PartiallyRefunded;
 
-                // Recompute payee net after partial refund so the payout job pays
-                // the consultant the kept portion minus the platform's locked-in
-                // profit share. Preserves invariant: refunded + payee <= gross.
-                // (FR-090: partial refund leaves consultant earning the kept half.)
-                if (payment.Status == PaymentStatus.PartiallyRefunded)
-                {
-                    payment.PayeeAmountCents = Math.Max(
-                        0,
-                        payment.AmountCents - payment.RefundedAmountCents - payment.ProfitShareAmountCents);
-                }
-                else
-                {
-                    // Full refund — consultant earns nothing.
-                    payment.PayeeAmountCents = 0;
-                }
+                // PB-014 v1: commission applies to retained amount, not gross.
+                // Re-resolve the split off (gross - refunded) so platform take
+                // and payee net shrink together with the refund. The resolver
+                // returns zero/zero for a full refund.
+                var retainedSplit = await FinancialRuleResolver.ResolveSplitFromRetainedAsync(
+                    _context, payment.Type,
+                    payment.AmountCents, payment.RefundedAmountCents,
+                    cancellationToken);
+                payment.ProfitShareAmountCents = retainedSplit.PlatformTakeCents;
+                payment.PayeeAmountCents = retainedSplit.PayeeNetCents;
             }
             else
             {

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
@@ -109,13 +109,16 @@ public sealed class MarkNoShowCommandHandler : IRequestHandler<MarkNoShowCommand
             }
 
             // FR-090/193: a consultant no-show fully refunds the student, so the
-            // internal Payment row is marked Refunded for the gross amount.
+            // internal Payment row is marked Refunded for the gross amount and
+            // both commission and payee net are zeroed (retained = 0).
             if (booking.Payment is { } payment)
             {
                 payment.Status = PaymentStatus.Refunded;
                 payment.RefundedAmountCents = payment.AmountCents;
                 payment.RefundedAt = nowUtc;
                 payment.RefundReason = CancellationReason.ConsultantNoShow.ToString();
+                payment.ProfitShareAmountCents = 0;
+                payment.PayeeAmountCents = 0;
             }
 
             booking.IsNoShowConsultant = true;

--- a/server/src/ScholarPath.Application/FinancialConfig/FinancialRuleResolver.cs
+++ b/server/src/ScholarPath.Application/FinancialConfig/FinancialRuleResolver.cs
@@ -48,6 +48,27 @@ public static class FinancialRuleResolver
         var platformTake = Math.Min(breakdown.PlatformTotalCents, grossAmountCents);
         return new PaymentSplit(platformTake, grossAmountCents - platformTake);
     }
+
+    /// <summary>
+    /// Recomputes the platform take and payee net from the amount the payee
+    /// actually keeps after refunds — gross minus refunded. Called after any
+    /// refund so commission shrinks proportionally with retained revenue
+    /// (PB-014 v1: commission applies to the final retained amount, not the
+    /// captured-at-acceptance amount). Returns zero/zero when fully refunded.
+    /// </summary>
+    public static Task<PaymentSplit> ResolveSplitFromRetainedAsync(
+        IApplicationDbContext db,
+        PaymentType type,
+        long grossAmountCents,
+        long refundedAmountCents,
+        CancellationToken ct)
+    {
+        var retained = grossAmountCents - refundedAmountCents;
+        if (retained <= 0)
+            return Task.FromResult(new PaymentSplit(0, 0));
+
+        return ResolvePaymentSplitAsync(db, type, retained, ct);
+    }
 }
 
 /// <summary>The platform take and payee net for a payment, summing to the gross.</summary>

--- a/server/src/ScholarPath.Application/Payments/Commands/CreatePaymentIntent/CreatePaymentIntentCommand.cs
+++ b/server/src/ScholarPath.Application/Payments/Commands/CreatePaymentIntent/CreatePaymentIntentCommand.cs
@@ -86,10 +86,32 @@ public sealed class CreatePaymentIntentCommandHandler(
         var split = await FinancialRuleResolver
             .ResolvePaymentSplitAsync(db, request.Type, request.AmountCents, ct);
 
-        // 2. Capture method per type
-        var captureMethod = request.Type == PaymentType.ConsultantBooking
-            ? "manual"      // hold until consultant accepts
-            : "automatic";  // charge immediately for company reviews
+        // 2. Both payment types use a manual-capture hold: funds are authorized on
+        //    the student's card now and captured only when the counterparty
+        //    confirms (consultant accepts a booking, or company accepts an
+        //    application review). This matches FR-080 (consultant) and FR-066/068
+        //    (company review escrow).
+        const string captureMethod = "manual";
+
+        // 2b. For CompanyReview, resolve PayeeUserId server-side from the
+        //     scholarship's owning company — never trust a client-supplied id
+        //     to choose who gets paid.
+        Guid? payeeUserId = request.PayeeUserId;
+        if (request.Type == PaymentType.CompanyReview)
+        {
+            var resolved = await db.Applications
+                .Where(a => a.Id == request.RelatedApplicationId)
+                .Select(a => a.Scholarship!.OwnerCompanyId)
+                .FirstOrDefaultAsync(ct);
+
+            if (resolved is null)
+            {
+                throw new ConflictException(
+                    "Cannot create a CompanyReview payment for an application whose scholarship has no owning company.");
+            }
+
+            payeeUserId = resolved;
+        }
 
         // 3. Deterministic idempotency key
         var relatedId = (request.RelatedBookingId ?? request.RelatedApplicationId)!.Value;
@@ -138,7 +160,7 @@ public sealed class CreatePaymentIntentCommandHandler(
             PayeeAmountCents = split.PayeeNetCents,
             RefundedAmountCents = 0,
             PayerUserId = payerUserId,
-            PayeeUserId = request.PayeeUserId,
+            PayeeUserId = payeeUserId,
             StripePaymentIntentId = stripeResult.Id,
             StripeChargeId = stripeResult.LatestChargeId,
             IdempotencyKey = idempotencyKey,

--- a/server/src/ScholarPath.Application/Payments/Commands/ProcessStripeWebhook/ProcessStripeWebhookCommand.cs
+++ b/server/src/ScholarPath.Application/Payments/Commands/ProcessStripeWebhook/ProcessStripeWebhookCommand.cs
@@ -235,6 +235,22 @@ public sealed class ProcessStripeWebhookCommandHandler(
                     payout.Status = PayoutStatus.Failed;
                     var reason = request.PayoutFailureMessage ?? "payout.failed";
                     payout.FailureReason = reason.Length > 500 ? reason[..500] : reason;
+
+                    // PB-013 recovery: release every payment that was pre-claimed
+                    // into this payout so the nightly StripePayoutJob can pick
+                    // them up again on its next run. Without this clearing, the
+                    // payments would be orphaned to the failed Payout forever.
+                    var orphanedPayments = await db.Payments
+                        .Where(p => p.PayoutId == payout.Id)
+                        .ToListAsync(ct).ConfigureAwait(false);
+                    foreach (var p in orphanedPayments)
+                    {
+                        p.PayoutId = null;
+                    }
+
+                    logger.LogInformation(
+                        "Payout {PayoutId} failed — released {Count} payment(s) for retry.",
+                        request.PayoutId, orphanedPayments.Count);
                 }
 
                 logger.LogInformation(

--- a/server/src/ScholarPath.Application/Payments/Commands/RefundPayment/RefundPaymentCommand.cs
+++ b/server/src/ScholarPath.Application/Payments/Commands/RefundPayment/RefundPaymentCommand.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Auditing;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.FinancialConfig;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Interfaces;
 
@@ -98,6 +99,8 @@ public sealed class RefundPaymentCommandHandler(
             payment.RefundedAmountCents = payment.AmountCents;
             payment.RefundedAt = DateTimeOffset.UtcNow;
             payment.RefundReason = request.Reason ?? "Full refund — intent cancelled";
+            payment.ProfitShareAmountCents = 0;
+            payment.PayeeAmountCents = 0;
         }
         // 3b. Full or partial refund on a Captured payment → Stripe Refund API
         else
@@ -136,18 +139,17 @@ public sealed class RefundPaymentCommandHandler(
                 ? PaymentStatus.Refunded
                 : PaymentStatus.PartiallyRefunded;
 
-            // Recompute payee net so the consultant earns the kept portion minus
-            // the locked-in profit share. Preserves invariant: refunded + payee <= gross.
-            if (payment.Status == PaymentStatus.PartiallyRefunded)
-            {
-                payment.PayeeAmountCents = Math.Max(
-                    0,
-                    payment.AmountCents - payment.RefundedAmountCents - payment.ProfitShareAmountCents);
-            }
-            else
-            {
-                payment.PayeeAmountCents = 0;
-            }
+            // PB-014 v1: platform commission applies to the retained amount, not
+            // the captured-at-acceptance amount. Resolving the split off
+            // (gross - refunded) shrinks both commission and payee share
+            // proportionally and keeps the invariant
+            //   refunded + commission + payee == gross
+            // (except for sub-cent rounding which the resolver assigns to the
+            // payee — same rule as the original capture-time split).
+            var retainedSplit = await FinancialRuleResolver.ResolveSplitFromRetainedAsync(
+                db, payment.Type, payment.AmountCents, payment.RefundedAmountCents, ct);
+            payment.ProfitShareAmountCents = retainedSplit.PlatformTakeCents;
+            payment.PayeeAmountCents = retainedSplit.PayeeNetCents;
         }
 
         // 4. Persist

--- a/server/src/ScholarPath.Infrastructure/Jobs/CompanyReviewTimeoutRefundJob.cs
+++ b/server/src/ScholarPath.Infrastructure/Jobs/CompanyReviewTimeoutRefundJob.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.FinancialConfig;
 using ScholarPath.Application.Notifications;
 using ScholarPath.Application.Payments;
 using ScholarPath.Domain.Enums;
@@ -14,8 +15,14 @@ public interface ICompanyReviewTimeoutRefundJob
 }
 
 /// <summary>
-/// Daily job to auto-refund review fees for applications that companies failed
-/// to review within 14 days of the deadline.
+/// Daily job that refunds review fees for applications the company failed to
+/// review within 14 days of the scholarship deadline (PB-005 AC#3 / FR-068).
+/// Operates on the unified <see cref="Domain.Entities.Payment"/> table. The
+/// refund action depends on the payment's current state:
+/// <list type="bullet">
+///   <item>Held — cancel the PaymentIntent (no charge).</item>
+///   <item>Captured — issue a full Stripe Refund.</item>
+/// </list>
 /// </summary>
 public sealed class CompanyReviewTimeoutRefundJob(
     ApplicationDbContext db,
@@ -27,9 +34,8 @@ public sealed class CompanyReviewTimeoutRefundJob(
     {
         var now = DateTimeOffset.UtcNow;
 
-        // Find applications where Status is Pending or UnderReview,
-        // the scholarship deadline has passed by 14 days,
-        // and there is a held payment.
+        // Applications still awaiting a decision whose scholarship deadline
+        // passed at least 14 days ago.
         var expiredApplications = await db.Applications
             .Include(a => a.Scholarship)
             .Where(a => (a.Status == ApplicationStatus.Pending || a.Status == ApplicationStatus.UnderReview)
@@ -38,51 +44,98 @@ public sealed class CompanyReviewTimeoutRefundJob(
             .ToListAsync(ct)
             .ConfigureAwait(false);
 
+        if (expiredApplications.Count == 0)
+        {
+            return;
+        }
+
+        int refunded = 0;
+
         foreach (var app in expiredApplications)
         {
-            var payment = await db.CompanyReviewPayments
-                .FirstOrDefaultAsync(p => p.ApplicationTrackerId == app.Id && p.Status == PaymentStatus.Held, ct);
+            var payment = await db.Payments
+                .FirstOrDefaultAsync(p =>
+                    p.Type == PaymentType.CompanyReview
+                    && p.RelatedApplicationId == app.Id
+                    && (p.Status == PaymentStatus.Held
+                        || p.Status == PaymentStatus.Pending
+                        || p.Status == PaymentStatus.Captured),
+                    ct);
 
-            if (payment != null)
+            if (payment is null) continue;
+            if (string.IsNullOrWhiteSpace(payment.StripePaymentIntentId)) continue;
+
+            try
             {
-                try
+                if (payment.Status is PaymentStatus.Held or PaymentStatus.Pending)
                 {
-                    // Refund 100% — release the card hold; throws if Stripe does
-                    // not confirm, so a failed cancel is retried on the next run.
+                    // Refund 100% by cancelling the hold — no charge ever lands.
                     await stripeService.CancelHeldPaymentAsync(
                         payment.StripePaymentIntentId,
-                        $"company-review-timeout-refund:{payment.Id:N}",
-                        ct);
+                        idempotencyKey: $"company-review-timeout-refund:{payment.Id:N}:cancel",
+                        ct: ct).ConfigureAwait(false);
 
-                    payment.Status = PaymentStatus.Refunded;
-                    payment.RefundedAmountUsd = payment.AmountUsd;
+                    payment.Status = PaymentStatus.Cancelled;
+                    payment.RefundedAmountCents = 0;
+                    payment.ProfitShareAmountCents = 0;
+                    payment.PayeeAmountCents = 0;
                     payment.RefundReason = "Company failed to review within 14 days after deadline";
-
-                    // Notify student
-                    await notifications.DispatchAsync(
-                        app.StudentId,
-                        NotificationType.CompanyReviewRefunded,
-                        new NotificationParams { RefundKind = "Timeout" },
-                        null,
-                        null,
-                        ct);
-
-                    // Mark application as expired or something.
-                    // Let's just set it to Withdrawn, or maybe we just leave it?
-                    // We'll leave it pending/under review but refunded, or maybe we reject it automatically?
-                    // Let's just leave the status but note that the payment is refunded.
                 }
-                catch (Exception ex)
+                else
                 {
-                    logger.LogError(ex, "Failed to refund expired review for application {ApplicationId}", app.Id);
+                    // Captured — issue a full Stripe Refund.
+                    var refundAmountCents = payment.AmountCents - payment.RefundedAmountCents;
+                    if (refundAmountCents <= 0) continue;
+
+                    var refundResult = await stripeService.RefundPaymentAsync(
+                        paymentIntentId: payment.StripePaymentIntentId,
+                        amountCents: refundAmountCents,
+                        reason: "requested_by_customer",
+                        idempotencyKey: $"company-review-timeout-refund:{payment.Id:N}:full",
+                        ct: ct).ConfigureAwait(false);
+
+                    if (refundResult.Status != "succeeded")
+                    {
+                        logger.LogError(
+                            "Timeout refund for application {ApplicationId} returned Stripe status {Status}; left unchanged.",
+                            app.Id, refundResult.Status);
+                        continue;
+                    }
+
+                    payment.RefundedAmountCents += refundResult.AmountCents;
+                    payment.RefundedAt = now;
+                    payment.RefundReason = "Company failed to review within 14 days after deadline";
+                    payment.Status = payment.RefundedAmountCents >= payment.AmountCents
+                        ? PaymentStatus.Refunded
+                        : PaymentStatus.PartiallyRefunded;
+
+                    var retainedSplit = await FinancialRuleResolver.ResolveSplitFromRetainedAsync(
+                        db, payment.Type, payment.AmountCents, payment.RefundedAmountCents, ct);
+                    payment.ProfitShareAmountCents = retainedSplit.PlatformTakeCents;
+                    payment.PayeeAmountCents = retainedSplit.PayeeNetCents;
                 }
+
+                await notifications.DispatchAsync(
+                    app.StudentId,
+                    NotificationType.CompanyReviewRefunded,
+                    new NotificationParams { RefundKind = "Timeout" },
+                    deepLink: null,
+                    idempotencyKey: $"company-review-timeout-refund-notice:{payment.Id:N}",
+                    ct).ConfigureAwait(false);
+
+                refunded++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to refund expired review for application {ApplicationId}",
+                    app.Id);
             }
         }
 
-        if (expiredApplications.Any())
-        {
-            await db.SaveChangesAsync(ct).ConfigureAwait(false);
-            logger.LogInformation("Processed {Count} expired application reviews and refunded fees.", expiredApplications.Count);
-        }
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        logger.LogInformation(
+            "CompanyReviewTimeoutRefundJob — scanned {Scanned} expired applications, refunded {Refunded}.",
+            expiredApplications.Count, refunded);
     }
 }

--- a/server/src/ScholarPath.Infrastructure/Jobs/StripePayoutJob.cs
+++ b/server/src/ScholarPath.Infrastructure/Jobs/StripePayoutJob.cs
@@ -120,6 +120,17 @@ public sealed class StripePayoutJob(
 
                 payout.Status = PayoutStatus.Failed;
                 payout.FailureReason = Truncate(ex.Message, 500);
+
+                // PB-013 recovery: the payments were pre-claimed (PayoutId set)
+                // before we called Stripe. The Stripe call failed, so release
+                // them — otherwise the next nightly run will skip them forever
+                // because PayoutId != null. Payees with restricted Connect
+                // accounts are still gated by the verified-status check above.
+                foreach (var p in payments)
+                {
+                    p.PayoutId = null;
+                }
+
                 await db.SaveChangesAsync(ct).ConfigureAwait(false);
 
                 await SafeNotifyAsync(payeeId, NotificationType.PayoutFailed,

--- a/server/tests/ScholarPath.UnitTests/CompanyReviews/ApplicationStatusChangedEventHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/CompanyReviews/ApplicationStatusChangedEventHandlerTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.CompanyReviews.Commands.CaptureCompanyReviewPayment;
+using ScholarPath.Application.CompanyReviews.Commands.RejectCompanyReviewPayment;
+using ScholarPath.Application.CompanyReviews.EventHandlers;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Events;
+using Xunit;
+
+namespace ScholarPath.UnitTests.CompanyReviews;
+
+/// <summary>
+/// PB-005 v1: only an Accepted application captures the held review fee;
+/// a Rejected application cancels the hold. Intermediate states (UnderReview
+/// etc.) and external-tracking states must not touch the payment.
+/// </summary>
+public sealed class ApplicationStatusChangedEventHandlerTests
+{
+    private readonly ISender _sender = Substitute.For<ISender>();
+    private readonly ApplicationStatusChangedEventHandler _handler;
+
+    public ApplicationStatusChangedEventHandlerTests()
+    {
+        _handler = new ApplicationStatusChangedEventHandler(
+            _sender,
+            NullLogger<ApplicationStatusChangedEventHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Accepted_status_triggers_CaptureCompanyReviewPayment()
+    {
+        var appId = Guid.NewGuid();
+        var evt = new ApplicationStatusChangedEvent(
+            appId, Guid.NewGuid(), Guid.NewGuid(),
+            ApplicationStatus.UnderReview, ApplicationStatus.Accepted);
+
+        await _handler.Handle(evt, default);
+
+        await _sender.Received(1).Send(
+            Arg.Is<CaptureCompanyReviewPaymentCommand>(c => c.ApplicationId == appId),
+            Arg.Any<CancellationToken>());
+        await _sender.DidNotReceive().Send(
+            Arg.Any<RejectCompanyReviewPaymentCommand>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Rejected_status_triggers_RejectCompanyReviewPayment_not_capture()
+    {
+        var appId = Guid.NewGuid();
+        var evt = new ApplicationStatusChangedEvent(
+            appId, Guid.NewGuid(), Guid.NewGuid(),
+            ApplicationStatus.UnderReview, ApplicationStatus.Rejected);
+
+        await _handler.Handle(evt, default);
+
+        await _sender.Received(1).Send(
+            Arg.Is<RejectCompanyReviewPaymentCommand>(c => c.ApplicationId == appId),
+            Arg.Any<CancellationToken>());
+        await _sender.DidNotReceive().Send(
+            Arg.Any<CaptureCompanyReviewPaymentCommand>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(ApplicationStatus.UnderReview)]
+    [InlineData(ApplicationStatus.Shortlisted)]
+    [InlineData(ApplicationStatus.Pending)]
+    [InlineData(ApplicationStatus.Withdrawn)]
+    [InlineData(ApplicationStatus.Intending)]
+    public async Task Non_terminal_status_does_not_touch_payment(ApplicationStatus status)
+    {
+        var evt = new ApplicationStatusChangedEvent(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+            ApplicationStatus.Draft, status);
+
+        await _handler.Handle(evt, default);
+
+        await _sender.DidNotReceive().Send(
+            Arg.Any<CaptureCompanyReviewPaymentCommand>(),
+            Arg.Any<CancellationToken>());
+        await _sender.DidNotReceive().Send(
+            Arg.Any<RejectCompanyReviewPaymentCommand>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/CompanyReviews/CaptureCompanyReviewPaymentCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/CompanyReviews/CaptureCompanyReviewPaymentCommandHandlerTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.CompanyReviews.Commands.CaptureCompanyReviewPayment;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.CompanyReviews;
+
+/// <summary>
+/// PB-005 v1: CompanyReview capture must operate on the unified <see cref="Payment"/>
+/// table and reset the platform/payee split using the rule in force at capture time.
+/// </summary>
+public sealed class CaptureCompanyReviewPaymentCommandHandlerTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IStripeService _stripe = Substitute.For<IStripeService>();
+    private readonly INotificationDispatcher _notifications = Substitute.For<INotificationDispatcher>();
+    private readonly CaptureCompanyReviewPaymentCommandHandler _handler;
+
+    public CaptureCompanyReviewPaymentCommandHandlerTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        _handler = new CaptureCompanyReviewPaymentCommandHandler(
+            _db, _stripe, _notifications,
+            NullLogger<CaptureCompanyReviewPaymentCommandHandler>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task Captures_Held_CompanyReview_payment_and_locks_in_v1_split()
+    {
+        var appId = Guid.NewGuid();
+        var payment = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.CompanyReview,
+            Status = PaymentStatus.Held,
+            AmountCents = 10_000,
+            // Pre-capture snapshot from intent-creation — handler should overwrite.
+            ProfitShareAmountCents = 0,
+            PayeeAmountCents = 0,
+            Currency = "USD",
+            PayerUserId = Guid.NewGuid(),
+            PayeeUserId = Guid.NewGuid(),
+            StripePaymentIntentId = "pi_test",
+            IdempotencyKey = "k_test",
+            RelatedApplicationId = appId,
+        };
+        _db.Payments.Add(payment);
+        await _db.SaveChangesAsync();
+
+        _stripe.CapturePaymentIntentAsync(
+                "pi_test", null, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult("pi_test", "succeeded", null, "ch_test"));
+
+        var result = await _handler.Handle(new CaptureCompanyReviewPaymentCommand(appId), default);
+
+        result.Should().BeTrue();
+        payment.Status.Should().Be(PaymentStatus.Captured);
+        payment.CapturedAt.Should().NotBeNull();
+        payment.StripeChargeId.Should().Be("ch_test");
+        // Default v1: commission = 10%, payee = 90%.
+        payment.ProfitShareAmountCents.Should().Be(1_000);
+        payment.PayeeAmountCents.Should().Be(9_000);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_no_held_CompanyReview_payment_exists()
+    {
+        var result = await _handler.Handle(
+            new CaptureCompanyReviewPaymentCommand(Guid.NewGuid()), default);
+
+        result.Should().BeFalse();
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .CapturePaymentIntentAsync(default!, default, default!, default);
+    }
+
+    [Fact]
+    public async Task Does_not_capture_ConsultantBooking_payment_with_matching_id()
+    {
+        var appId = Guid.NewGuid();
+        _db.Payments.Add(new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.ConsultantBooking, // wrong type
+            Status = PaymentStatus.Held,
+            AmountCents = 10_000,
+            Currency = "USD",
+            PayerUserId = Guid.NewGuid(),
+            StripePaymentIntentId = "pi_boo",
+            IdempotencyKey = "k_boo",
+            RelatedApplicationId = appId,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _handler.Handle(new CaptureCompanyReviewPaymentCommand(appId), default);
+
+        result.Should().BeFalse();
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .CapturePaymentIntentAsync(default!, default, default!, default);
+    }
+
+    [Fact]
+    public async Task Leaves_payment_untouched_when_Stripe_capture_does_not_succeed()
+    {
+        var appId = Guid.NewGuid();
+        var payment = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.CompanyReview,
+            Status = PaymentStatus.Held,
+            AmountCents = 5_000,
+            Currency = "USD",
+            PayerUserId = Guid.NewGuid(),
+            StripePaymentIntentId = "pi_x",
+            IdempotencyKey = "k_x",
+            RelatedApplicationId = appId,
+        };
+        _db.Payments.Add(payment);
+        await _db.SaveChangesAsync();
+
+        _stripe.CapturePaymentIntentAsync(
+                "pi_x", null, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult("pi_x", "requires_action", null, null));
+
+        var result = await _handler.Handle(new CaptureCompanyReviewPaymentCommand(appId), default);
+
+        result.Should().BeFalse();
+        payment.Status.Should().Be(PaymentStatus.Held);
+        payment.CapturedAt.Should().BeNull();
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/CompanyReviews/CompanyReviewTimeoutRefundJobTests.cs
+++ b/server/tests/ScholarPath.UnitTests/CompanyReviews/CompanyReviewTimeoutRefundJobTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Infrastructure.Jobs;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.CompanyReviews;
+
+/// <summary>
+/// PB-005 v1: the timeout job refunds CompanyReview payments on the unified
+/// <see cref="Payment"/> table when the company misses the 14-day review
+/// window after the scholarship deadline.
+/// </summary>
+public sealed class CompanyReviewTimeoutRefundJobTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IStripeService _stripe = Substitute.For<IStripeService>();
+    private readonly INotificationDispatcher _notifications = Substitute.For<INotificationDispatcher>();
+    private readonly CompanyReviewTimeoutRefundJob _job;
+
+    public CompanyReviewTimeoutRefundJobTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+        _job = new CompanyReviewTimeoutRefundJob(
+            _db, _stripe, _notifications,
+            NullLogger<CompanyReviewTimeoutRefundJob>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private (ApplicationTracker app, Payment payment) SeedExpired(
+        PaymentStatus status,
+        long amountCents = 10_000)
+    {
+        var scholarshipId = Guid.NewGuid();
+        var appId = Guid.NewGuid();
+        _db.Scholarships.Add(new Scholarship
+        {
+            Id = scholarshipId,
+            TitleEn = "S", TitleAr = "س",
+            Slug = $"s-{Guid.NewGuid():N}",
+            DescriptionEn = "d", DescriptionAr = "د",
+            Deadline = DateTimeOffset.UtcNow.AddDays(-30),
+            OwnerCompanyId = Guid.NewGuid(),
+        });
+        var app = new ApplicationTracker
+        {
+            Id = appId,
+            StudentId = Guid.NewGuid(),
+            ScholarshipId = scholarshipId,
+            Status = ApplicationStatus.UnderReview,
+        };
+        _db.Applications.Add(app);
+        var payment = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.CompanyReview,
+            Status = status,
+            AmountCents = amountCents,
+            ProfitShareAmountCents = amountCents / 10,
+            PayeeAmountCents = amountCents - amountCents / 10,
+            Currency = "USD",
+            PayerUserId = app.StudentId,
+            PayeeUserId = Guid.NewGuid(),
+            StripePaymentIntentId = $"pi_{Guid.NewGuid():N}",
+            IdempotencyKey = $"k_{Guid.NewGuid():N}",
+            RelatedApplicationId = appId,
+            CapturedAt = status == PaymentStatus.Captured ? DateTimeOffset.UtcNow.AddDays(-20) : null,
+        };
+        _db.Payments.Add(payment);
+        return (app, payment);
+    }
+
+    [Fact]
+    public async Task Cancels_held_PaymentIntent_for_expired_application()
+    {
+        var (_, payment) = SeedExpired(PaymentStatus.Held);
+        await _db.SaveChangesAsync();
+
+        _stripe.CancelPaymentIntentAsync(
+                payment.StripePaymentIntentId!, Arg.Any<string?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult(
+                payment.StripePaymentIntentId!, "canceled", null, null));
+
+        await _job.RunAsync(default);
+
+        payment.Status.Should().Be(PaymentStatus.Cancelled);
+        payment.ProfitShareAmountCents.Should().Be(0);
+        payment.PayeeAmountCents.Should().Be(0);
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .RefundPaymentAsync(default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task Refunds_captured_payment_in_full_after_timeout()
+    {
+        var (_, payment) = SeedExpired(PaymentStatus.Captured, 10_000);
+        await _db.SaveChangesAsync();
+
+        _stripe.RefundPaymentAsync(
+                payment.StripePaymentIntentId!, 10_000, Arg.Any<string?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_to", "succeeded", 10_000));
+
+        await _job.RunAsync(default);
+
+        payment.Status.Should().Be(PaymentStatus.Refunded);
+        payment.RefundedAmountCents.Should().Be(10_000);
+        payment.ProfitShareAmountCents.Should().Be(0);
+        payment.PayeeAmountCents.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Does_not_touch_applications_whose_deadline_is_in_the_window()
+    {
+        var scholarshipId = Guid.NewGuid();
+        var appId = Guid.NewGuid();
+        _db.Scholarships.Add(new Scholarship
+        {
+            Id = scholarshipId,
+            TitleEn = "S", TitleAr = "س",
+            Slug = $"s-{Guid.NewGuid():N}",
+            DescriptionEn = "d", DescriptionAr = "د",
+            Deadline = DateTimeOffset.UtcNow.AddDays(-5), // < 14 days ago
+        });
+        _db.Applications.Add(new ApplicationTracker
+        {
+            Id = appId,
+            StudentId = Guid.NewGuid(),
+            ScholarshipId = scholarshipId,
+            Status = ApplicationStatus.UnderReview,
+        });
+        var payment = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.CompanyReview,
+            Status = PaymentStatus.Held,
+            AmountCents = 5_000,
+            Currency = "USD",
+            PayerUserId = Guid.NewGuid(),
+            StripePaymentIntentId = "pi_fresh",
+            IdempotencyKey = "k_fresh",
+            RelatedApplicationId = appId,
+        };
+        _db.Payments.Add(payment);
+        await _db.SaveChangesAsync();
+
+        await _job.RunAsync(default);
+
+        payment.Status.Should().Be(PaymentStatus.Held);
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .CancelPaymentIntentAsync(default!, default, default!, default);
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/CompanyReviews/RefundCompanyReviewCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/CompanyReviews/RefundCompanyReviewCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Infrastructure.Persistence;
@@ -11,12 +12,18 @@ using ScholarPath.Application.CompanyReviews.Commands.RefundCompanyReview;
 
 namespace ScholarPath.UnitTests.CompanyReviews;
 
+/// <summary>
+/// Verifies PB-005 v1 CompanyReview refund behaviour against the unified
+/// <see cref="Payment"/> table (the legacy <c>CompanyReviewPayment</c> table
+/// is no longer used for the active flow).
+/// </summary>
 public sealed class RefundCompanyReviewCommandHandlerTests : IDisposable
 {
     private readonly ApplicationDbContext _db;
     private readonly IStripeService _stripe = Substitute.For<IStripeService>();
     private readonly INotificationDispatcher _notifications = Substitute.For<INotificationDispatcher>();
-    private readonly ILogger<RefundCompanyReviewCommandHandler> _logger = Substitute.For<ILogger<RefundCompanyReviewCommandHandler>>();
+    private readonly ILogger<RefundCompanyReviewCommandHandler> _logger =
+        Substitute.For<ILogger<RefundCompanyReviewCommandHandler>>();
     private readonly RefundCompanyReviewCommandHandler _handler;
 
     public RefundCompanyReviewCommandHandlerTests()
@@ -27,77 +34,164 @@ public sealed class RefundCompanyReviewCommandHandlerTests : IDisposable
         _db = new ApplicationDbContext(options);
 
         _handler = new RefundCompanyReviewCommandHandler(
-            _db,
-            _stripe,
-            _notifications,
-            _logger);
+            _db, _stripe, _notifications, _logger);
     }
 
     public void Dispose() => _db.Dispose();
 
-    [Fact]
-    public async Task Handle_FullRefund_CancelsPaymentIntent()
+    private Payment SeedHeldPayment(Guid applicationId, long amountCents = 10_000)
     {
-        // Arrange
-        var appId = Guid.NewGuid();
-        var payment = new CompanyReviewPayment
+        var payment = new Payment
         {
             Id = Guid.NewGuid(),
-            ApplicationTrackerId = appId,
+            Type = PaymentType.CompanyReview,
             Status = PaymentStatus.Held,
-            StripePaymentIntentId = "pi_123",
-            AmountUsd = 100m,
-            IdempotencyKey = $"test-idem-{appId:N}"
+            AmountCents = amountCents,
+            Currency = "USD",
+            ProfitShareAmountCents = amountCents / 10,
+            PayeeAmountCents = amountCents - amountCents / 10,
+            RefundedAmountCents = 0,
+            PayerUserId = Guid.NewGuid(),
+            PayeeUserId = Guid.NewGuid(),
+            StripePaymentIntentId = $"pi_{Guid.NewGuid():N}",
+            IdempotencyKey = $"key_{Guid.NewGuid():N}",
+            RelatedApplicationId = applicationId,
         };
+        _db.Payments.Add(payment);
+        return payment;
+    }
 
-        _db.CompanyReviewPayments.Add(payment);
-        await _db.SaveChangesAsync();
-
-        _stripe.CancelPaymentIntentAsync("pi_123", "requested_by_customer", Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new StripePaymentIntentResult("pi_123", "canceled", null, null));
-
-        var command = new RefundCompanyReviewCommand(appId, IsFullRefund: true);
-
-        // Act
-        var result = await _handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        result.Should().BeTrue();
-        payment.Status.Should().Be(PaymentStatus.Refunded);
-        payment.RefundedAmountUsd.Should().Be(100m);
-        await _stripe.Received(1).CancelPaymentIntentAsync("pi_123", "requested_by_customer", Arg.Any<string>(), Arg.Any<CancellationToken>());
+    private Payment SeedCapturedPayment(Guid applicationId, long amountCents = 10_000)
+    {
+        var payment = SeedHeldPayment(applicationId, amountCents);
+        payment.Status = PaymentStatus.Captured;
+        payment.CapturedAt = DateTimeOffset.UtcNow;
+        return payment;
     }
 
     [Fact]
-    public async Task Handle_PartialRefund_CapturesHalfAndReleasesRest()
+    public async Task Full_refund_on_Held_payment_cancels_intent_and_marks_Cancelled()
     {
-        // Arrange
         var appId = Guid.NewGuid();
-        var payment = new CompanyReviewPayment
+        var payment = SeedHeldPayment(appId);
+        _db.Applications.Add(new ApplicationTracker
         {
-            Id = Guid.NewGuid(),
-            ApplicationTrackerId = appId,
-            Status = PaymentStatus.Held,
-            StripePaymentIntentId = "pi_123",
-            AmountUsd = 100m,
-            IdempotencyKey = $"test-idem-{appId:N}"
-        };
-
-        _db.CompanyReviewPayments.Add(payment);
+            Id = appId, StudentId = Guid.NewGuid(), Status = ApplicationStatus.Pending,
+        });
         await _db.SaveChangesAsync();
 
-        _stripe.CapturePaymentIntentAsync("pi_123", 5000, Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new StripePaymentIntentResult("pi_123", "succeeded", null, null));
+        _stripe.CancelPaymentIntentAsync(
+                payment.StripePaymentIntentId!, Arg.Any<string?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult(
+                payment.StripePaymentIntentId!, "canceled", null, null));
 
-        var command = new RefundCompanyReviewCommand(appId, IsFullRefund: false);
+        var result = await _handler.Handle(
+            new RefundCompanyReviewCommand(appId, IsFullRefund: true), default);
 
-        // Act
-        var result = await _handler.Handle(command, CancellationToken.None);
+        result.Should().BeTrue();
+        payment.Status.Should().Be(PaymentStatus.Cancelled);
+        payment.RefundedAmountCents.Should().Be(0);
+        payment.ProfitShareAmountCents.Should().Be(0);
+        payment.PayeeAmountCents.Should().Be(0);
+        await _stripe.Received(1).CancelPaymentIntentAsync(
+            payment.StripePaymentIntentId!, Arg.Any<string?>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .RefundPaymentAsync(default!, default, default, default!, default);
+    }
 
-        // Assert
+    [Fact]
+    public async Task Full_refund_on_Captured_payment_issues_full_Stripe_refund()
+    {
+        var appId = Guid.NewGuid();
+        var payment = SeedCapturedPayment(appId, 10_000);
+        _db.Applications.Add(new ApplicationTracker
+        {
+            Id = appId, StudentId = Guid.NewGuid(), Status = ApplicationStatus.UnderReview,
+        });
+        await _db.SaveChangesAsync();
+
+        _stripe.RefundPaymentAsync(
+                payment.StripePaymentIntentId!, 10_000, Arg.Any<string?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_full", "succeeded", 10_000));
+
+        var result = await _handler.Handle(
+            new RefundCompanyReviewCommand(appId, IsFullRefund: true), default);
+
+        result.Should().BeTrue();
+        payment.Status.Should().Be(PaymentStatus.Refunded);
+        payment.RefundedAmountCents.Should().Be(10_000);
+        payment.ProfitShareAmountCents.Should().Be(0);
+        payment.PayeeAmountCents.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Partial_refund_on_Captured_payment_refunds_50_percent_and_recomputes_split()
+    {
+        var appId = Guid.NewGuid();
+        var payment = SeedCapturedPayment(appId, 10_000);
+        _db.Applications.Add(new ApplicationTracker
+        {
+            Id = appId, StudentId = Guid.NewGuid(), Status = ApplicationStatus.UnderReview,
+        });
+        await _db.SaveChangesAsync();
+
+        _stripe.RefundPaymentAsync(
+                payment.StripePaymentIntentId!, 5_000, Arg.Any<string?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_half", "succeeded", 5_000));
+
+        var result = await _handler.Handle(
+            new RefundCompanyReviewCommand(appId, IsFullRefund: false), default);
+
         result.Should().BeTrue();
         payment.Status.Should().Be(PaymentStatus.PartiallyRefunded);
-        payment.RefundedAmountUsd.Should().Be(50m);
-        await _stripe.Received(1).CapturePaymentIntentAsync("pi_123", 5000, Arg.Any<string>(), Arg.Any<CancellationToken>());
+        payment.RefundedAmountCents.Should().Be(5_000);
+        // Retained = 5000; default v1 split = 10% / 90%.
+        payment.ProfitShareAmountCents.Should().Be(500);
+        payment.PayeeAmountCents.Should().Be(4_500);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_no_companyreview_payment_exists()
+    {
+        var result = await _handler.Handle(
+            new RefundCompanyReviewCommand(Guid.NewGuid(), IsFullRefund: true), default);
+
+        result.Should().BeFalse();
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .CancelPaymentIntentAsync(default!, default, default!, default);
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .RefundPaymentAsync(default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task Does_not_touch_unrelated_ConsultantBooking_payments()
+    {
+        var appId = Guid.NewGuid();
+        _db.Payments.Add(new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.ConsultantBooking,
+            Status = PaymentStatus.Held,
+            AmountCents = 10_000,
+            Currency = "USD",
+            ProfitShareAmountCents = 1_000,
+            PayeeAmountCents = 9_000,
+            PayerUserId = Guid.NewGuid(),
+            StripePaymentIntentId = "pi_booking",
+            IdempotencyKey = "k_booking",
+            RelatedApplicationId = appId,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _handler.Handle(
+            new RefundCompanyReviewCommand(appId, IsFullRefund: true), default);
+
+        result.Should().BeFalse();
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .CancelPaymentIntentAsync(default!, default, default!, default);
     }
 }

--- a/server/tests/ScholarPath.UnitTests/CompanyReviews/RejectCompanyReviewPaymentCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/CompanyReviews/RejectCompanyReviewPaymentCommandHandlerTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.CompanyReviews.Commands.RejectCompanyReviewPayment;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.CompanyReviews;
+
+/// <summary>
+/// PB-005 v1: a company rejection on an application with a held review fee
+/// must cancel the PaymentIntent — the student is never charged.
+/// </summary>
+public sealed class RejectCompanyReviewPaymentCommandHandlerTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IStripeService _stripe = Substitute.For<IStripeService>();
+    private readonly INotificationDispatcher _notifications = Substitute.For<INotificationDispatcher>();
+    private readonly RejectCompanyReviewPaymentCommandHandler _handler;
+
+    public RejectCompanyReviewPaymentCommandHandlerTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        _handler = new RejectCompanyReviewPaymentCommandHandler(
+            _db, _stripe, _notifications,
+            NullLogger<RejectCompanyReviewPaymentCommandHandler>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task Cancels_held_CompanyReview_PaymentIntent_on_rejection()
+    {
+        var appId = Guid.NewGuid();
+        var studentId = Guid.NewGuid();
+        var payment = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.CompanyReview,
+            Status = PaymentStatus.Held,
+            AmountCents = 10_000,
+            ProfitShareAmountCents = 1_000,
+            PayeeAmountCents = 9_000,
+            Currency = "USD",
+            PayerUserId = studentId,
+            StripePaymentIntentId = "pi_reject",
+            IdempotencyKey = "k_reject",
+            RelatedApplicationId = appId,
+        };
+        _db.Payments.Add(payment);
+        _db.Applications.Add(new ApplicationTracker
+        {
+            Id = appId, StudentId = studentId, Status = ApplicationStatus.Rejected,
+        });
+        await _db.SaveChangesAsync();
+
+        _stripe.CancelPaymentIntentAsync(
+                "pi_reject", Arg.Any<string?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult("pi_reject", "canceled", null, null));
+
+        var result = await _handler.Handle(
+            new RejectCompanyReviewPaymentCommand(appId), default);
+
+        result.Should().BeTrue();
+        payment.Status.Should().Be(PaymentStatus.Cancelled);
+        payment.ProfitShareAmountCents.Should().Be(0);
+        payment.PayeeAmountCents.Should().Be(0);
+        payment.RefundedAmountCents.Should().Be(0);
+        payment.FailureReason.Should().Be("company_rejected_application");
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .CapturePaymentIntentAsync(default!, default, default!, default);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_no_held_payment_exists()
+    {
+        var result = await _handler.Handle(
+            new RejectCompanyReviewPaymentCommand(Guid.NewGuid()), default);
+
+        result.Should().BeFalse();
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .CancelPaymentIntentAsync(default!, default, default!, default);
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingPaymentSyncTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingPaymentSyncTests.cs
@@ -210,6 +210,13 @@ public sealed class BookingPaymentSyncTests : IDisposable
         var start = DateTimeOffset.UtcNow.AddHours(-2);
         var booking = await SeedAsync(
             BookingStatus.Confirmed, PaymentStatus.Captured, start, start.AddHours(1));
+        // Simulate a pre-existing snapshot from the capture-time split so we
+        // can prove the no-show refund zeroes both commission and payee.
+        var captured = await PaymentForAsync(booking.Id);
+        captured.ProfitShareAmountCents = 1_000;
+        captured.PayeeAmountCents = 9_000;
+        await _db.SaveChangesAsync();
+
         _stripe.RefundPaymentAsync(
                 Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<CancellationToken>())
@@ -221,6 +228,41 @@ public sealed class BookingPaymentSyncTests : IDisposable
         var payment = await PaymentForAsync(booking.Id);
         payment.Status.Should().Be(PaymentStatus.Refunded);
         payment.RefundedAmountCents.Should().Be(10_000);
+        payment.ProfitShareAmountCents.Should().Be(0);
+        payment.PayeeAmountCents.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Cancel_confirmed_booking_within_24h_recomputes_commission_from_retained()
+    {
+        // PB-014 v1: a <24h student cancel triggers a 50% refund; commission
+        // and payee net must recompute off the retained amount, not stay locked
+        // at the original 10% of gross.
+        _currentUser.IsAuthenticated.Returns(true);
+        _currentUser.UserId.Returns(_studentId); // student cancels <24h
+        var booking = await SeedAsync(
+            BookingStatus.Confirmed, PaymentStatus.Captured,
+            start: DateTimeOffset.UtcNow.AddHours(6));
+        var captured = await PaymentForAsync(booking.Id);
+        captured.ProfitShareAmountCents = 1_000;
+        captured.PayeeAmountCents = 9_000;
+        await _db.SaveChangesAsync();
+
+        _stripe.RefundPaymentAsync(
+                Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_50", "succeeded", 5_000));
+
+        var handler = new CancelBookingCommandHandler(
+            _db, _currentUser, _stripe, new RefundCalculatorService(), _publisher);
+        await handler.Handle(new CancelBookingCommand(booking.Id), default);
+
+        var payment = await PaymentForAsync(booking.Id);
+        payment.Status.Should().Be(PaymentStatus.PartiallyRefunded);
+        payment.RefundedAmountCents.Should().Be(5_000);
+        // Retained 5000, default 10% / 90% split.
+        payment.ProfitShareAmountCents.Should().Be(500);
+        payment.PayeeAmountCents.Should().Be(4_500);
     }
 
     [Fact]

--- a/server/tests/ScholarPath.UnitTests/Payments/CreatePaymentIntentCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Payments/CreatePaymentIntentCommandHandlerTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Payments.Commands.CreatePaymentIntent;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.Payments;
+
+/// <summary>
+/// PB-005 / PB-013: every payment intent must be created with manual capture
+/// so the counterparty (consultant or company) actually has to accept before
+/// the student is charged. PayeeUserId for a CompanyReview intent is resolved
+/// server-side from the scholarship's owning company.
+/// </summary>
+public class CreatePaymentIntentCommandHandlerTests
+{
+    private static ApplicationDbContext CreateDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static ICurrentUserService AuthenticatedUser(Guid id)
+    {
+        var u = Substitute.For<ICurrentUserService>();
+        u.UserId.Returns(id);
+        return u;
+    }
+
+    [Fact]
+    public async Task ConsultantBooking_intent_is_created_with_manual_capture()
+    {
+        using var db = CreateDb();
+        var stripe = Substitute.For<IStripeService>();
+        stripe.CreatePaymentIntentAsync(
+                Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IDictionary<string, string>?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult("pi_b", "requires_payment_method", "cs_b", null));
+
+        var handler = new CreatePaymentIntentCommandHandler(
+            db, stripe, AuthenticatedUser(Guid.NewGuid()),
+            NullLogger<CreatePaymentIntentCommandHandler>.Instance);
+
+        var result = await handler.Handle(
+            new CreatePaymentIntentCommand(
+                PaymentType.ConsultantBooking,
+                AmountCents: 10_000,
+                Currency: "USD",
+                PayeeUserId: Guid.NewGuid(),
+                RelatedBookingId: Guid.NewGuid(),
+                RelatedApplicationId: null),
+            default);
+
+        result.PaymentId.Should().NotBe(Guid.Empty);
+        await stripe.Received(1).CreatePaymentIntentAsync(
+            10_000, "usd", "manual",
+            Arg.Any<IDictionary<string, string>?>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompanyReview_intent_is_created_with_manual_capture_not_automatic()
+    {
+        using var db = CreateDb();
+        var companyId = Guid.NewGuid();
+        var appId = Guid.NewGuid();
+        var scholarshipId = Guid.NewGuid();
+        db.Scholarships.Add(new Scholarship
+        {
+            Id = scholarshipId,
+            TitleEn = "S",
+            TitleAr = "س",
+            Slug = $"s-{Guid.NewGuid():N}",
+            DescriptionEn = "d",
+            DescriptionAr = "د",
+            Deadline = DateTimeOffset.UtcNow.AddDays(30),
+            OwnerCompanyId = companyId,
+            ReviewFeeUsd = 50m,
+        });
+        db.Applications.Add(new ApplicationTracker
+        {
+            Id = appId,
+            StudentId = Guid.NewGuid(),
+            ScholarshipId = scholarshipId,
+            Status = ApplicationStatus.Draft,
+        });
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        stripe.CreatePaymentIntentAsync(
+                Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IDictionary<string, string>?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult("pi_cr", "requires_payment_method", "cs_cr", null));
+
+        var handler = new CreatePaymentIntentCommandHandler(
+            db, stripe, AuthenticatedUser(Guid.NewGuid()),
+            NullLogger<CreatePaymentIntentCommandHandler>.Instance);
+
+        await handler.Handle(
+            new CreatePaymentIntentCommand(
+                PaymentType.CompanyReview,
+                AmountCents: 5_000,
+                Currency: "USD",
+                PayeeUserId: null,
+                RelatedBookingId: null,
+                RelatedApplicationId: appId),
+            default);
+
+        await stripe.Received(1).CreatePaymentIntentAsync(
+            5_000, "usd", "manual",
+            Arg.Any<IDictionary<string, string>?>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        // PayeeUserId must be the scholarship's owning company, NOT the
+        // (null) PayeeUserId supplied in the command.
+        var stored = await db.Payments.SingleAsync();
+        stored.PayeeUserId.Should().Be(companyId);
+        stored.Type.Should().Be(PaymentType.CompanyReview);
+        stored.RelatedApplicationId.Should().Be(appId);
+        stored.Status.Should().Be(PaymentStatus.Pending);
+    }
+
+    [Fact]
+    public async Task CompanyReview_throws_when_scholarship_has_no_owning_company()
+    {
+        using var db = CreateDb();
+        var appId = Guid.NewGuid();
+        var scholarshipId = Guid.NewGuid();
+        db.Scholarships.Add(new Scholarship
+        {
+            Id = scholarshipId,
+            TitleEn = "S", TitleAr = "س",
+            Slug = $"s-{Guid.NewGuid():N}",
+            DescriptionEn = "d", DescriptionAr = "د",
+            Deadline = DateTimeOffset.UtcNow.AddDays(30),
+            OwnerCompanyId = null, // admin-created, no company
+        });
+        db.Applications.Add(new ApplicationTracker
+        {
+            Id = appId,
+            StudentId = Guid.NewGuid(),
+            ScholarshipId = scholarshipId,
+            Status = ApplicationStatus.Draft,
+        });
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        var handler = new CreatePaymentIntentCommandHandler(
+            db, stripe, AuthenticatedUser(Guid.NewGuid()),
+            NullLogger<CreatePaymentIntentCommandHandler>.Instance);
+
+        var act = () => handler.Handle(
+            new CreatePaymentIntentCommand(
+                PaymentType.CompanyReview,
+                AmountCents: 1_000,
+                Currency: "USD",
+                PayeeUserId: null,
+                RelatedBookingId: null,
+                RelatedApplicationId: appId),
+            default);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        await stripe.DidNotReceiveWithAnyArgs().CreatePaymentIntentAsync(
+            default, default!, default!, default, default!, default);
+    }
+
+    [Fact]
+    public void Validator_requires_RelatedApplicationId_for_CompanyReview()
+    {
+        var validator = new CreatePaymentIntentCommandValidator();
+
+        var result = validator.Validate(new CreatePaymentIntentCommand(
+            PaymentType.CompanyReview, 100, "USD", null,
+            RelatedBookingId: null,
+            RelatedApplicationId: null));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CreatePaymentIntentCommand.RelatedApplicationId));
+    }
+
+    [Fact]
+    public void Validator_requires_RelatedBookingId_for_ConsultantBooking()
+    {
+        var validator = new CreatePaymentIntentCommandValidator();
+
+        var result = validator.Validate(new CreatePaymentIntentCommand(
+            PaymentType.ConsultantBooking, 100, "USD", null,
+            RelatedBookingId: null,
+            RelatedApplicationId: null));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CreatePaymentIntentCommand.RelatedBookingId));
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/Payments/ProcessStripeWebhookConnectTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Payments/ProcessStripeWebhookConnectTests.cs
@@ -119,6 +119,99 @@ public class ProcessStripeWebhookConnectTests
     }
 
     [Fact]
+    public async Task Payout_failed_releases_linked_payments_for_retry()
+    {
+        // PB-013 recovery: when Stripe reports a payout failed, every Payment
+        // pre-claimed into it must have PayoutId cleared so the next nightly
+        // run can include them in a fresh batch. Otherwise the payments are
+        // orphaned forever.
+        using var db = CreateDb();
+        var payee = Guid.NewGuid();
+        var payout = new Payout
+        {
+            Id = Guid.NewGuid(),
+            PayeeUserId = payee,
+            AmountCents = 7500,
+            Currency = "USD",
+            Status = PayoutStatus.InTransit,
+            StripePayoutId = "po_fail",
+        };
+        db.Payouts.Add(payout);
+
+        var p1 = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.ConsultantBooking,
+            Status = PaymentStatus.Captured,
+            AmountCents = 5000, Currency = "USD",
+            PayerUserId = Guid.NewGuid(), PayeeUserId = payee,
+            PayeeAmountCents = 4500, ProfitShareAmountCents = 500,
+            StripePaymentIntentId = "pi_a",
+            IdempotencyKey = "k_a",
+            PayoutId = payout.Id,
+        };
+        var p2 = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.ConsultantBooking,
+            Status = PaymentStatus.Captured,
+            AmountCents = 3000, Currency = "USD",
+            PayerUserId = Guid.NewGuid(), PayeeUserId = payee,
+            PayeeAmountCents = 2700, ProfitShareAmountCents = 300,
+            StripePaymentIntentId = "pi_b",
+            IdempotencyKey = "k_b",
+            PayoutId = payout.Id,
+        };
+        db.Payments.AddRange(p1, p2);
+        await db.SaveChangesAsync();
+
+        await Sut(db).Handle(new ProcessStripeWebhookCommand(
+            "evt_release", "payout.failed", null, null, null, "{}",
+            PayoutId: "po_fail", PayoutFailureMessage: "account closed"), default);
+
+        var refreshed1 = await db.Payments.FindAsync(p1.Id);
+        var refreshed2 = await db.Payments.FindAsync(p2.Id);
+        refreshed1!.PayoutId.Should().BeNull();
+        refreshed2!.PayoutId.Should().BeNull();
+
+        var refreshedPayout = await db.Payouts.FindAsync(payout.Id);
+        refreshedPayout!.Status.Should().Be(PayoutStatus.Failed);
+    }
+
+    [Fact]
+    public async Task Payout_paid_does_not_release_linked_payments()
+    {
+        using var db = CreateDb();
+        var payout = new Payout
+        {
+            Id = Guid.NewGuid(),
+            PayeeUserId = Guid.NewGuid(),
+            AmountCents = 5000, Currency = "USD",
+            Status = PayoutStatus.InTransit,
+            StripePayoutId = "po_ok",
+        };
+        db.Payouts.Add(payout);
+        var p = new Payment
+        {
+            Id = Guid.NewGuid(),
+            Type = PaymentType.ConsultantBooking,
+            Status = PaymentStatus.Captured,
+            AmountCents = 5000, Currency = "USD",
+            PayerUserId = Guid.NewGuid(),
+            StripePaymentIntentId = "pi_z", IdempotencyKey = "k_z",
+            PayoutId = payout.Id,
+        };
+        db.Payments.Add(p);
+        await db.SaveChangesAsync();
+
+        await Sut(db).Handle(new ProcessStripeWebhookCommand(
+            "evt_paid", "payout.paid", null, null, null, "{}",
+            PayoutId: "po_ok"), default);
+
+        (await db.Payments.FindAsync(p.Id))!.PayoutId.Should().Be(payout.Id);
+    }
+
+    [Fact]
     public async Task Charge_dispute_created_marks_payment_disputed_and_alerts_admins()
     {
         using var db = CreateDb();

--- a/server/tests/ScholarPath.UnitTests/Payments/RefundPaymentCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Payments/RefundPaymentCommandHandlerTests.cs
@@ -216,4 +216,155 @@ public class RefundPaymentCommandHandlerTests
         v.Validate(new RefundPaymentCommand(Guid.NewGuid(), null, null))
             .IsValid.Should().BeTrue();
     }
+
+    // ── PB-014 v1: commission applies to RETAINED amount, not to gross ──────
+
+    [Fact]
+    public async Task Full_refund_on_Held_zeroes_commission_and_payee()
+    {
+        using var db = CreateDb();
+        var payment = MakePayment(PaymentStatus.Held, 10_000);
+        payment.ProfitShareAmountCents = 1_000;
+        payment.PayeeAmountCents = 9_000;
+        db.Payments.Add(payment);
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        stripe.CancelPaymentIntentAsync(
+                Arg.Any<string>(), Arg.Any<string?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult(
+                payment.StripePaymentIntentId!, "canceled", null, null));
+
+        var sut = new RefundPaymentCommandHandler(
+            db, stripe, AdminUser(), NullLogger<RefundPaymentCommandHandler>.Instance);
+
+        var ok = await sut.Handle(new RefundPaymentCommand(payment.Id, null, "full"), default);
+
+        ok.Should().BeTrue();
+        var updated = await db.Payments.FindAsync(payment.Id);
+        updated!.ProfitShareAmountCents.Should().Be(0);
+        updated.PayeeAmountCents.Should().Be(0);
+        updated.RefundedAmountCents.Should().Be(10_000);
+    }
+
+    [Fact]
+    public async Task Full_refund_on_Captured_zeroes_commission_and_payee()
+    {
+        using var db = CreateDb();
+        var payment = MakePayment(PaymentStatus.Captured, 10_000);
+        payment.ProfitShareAmountCents = 1_000;
+        payment.PayeeAmountCents = 9_000;
+        db.Payments.Add(payment);
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        stripe.RefundPaymentAsync(
+                Arg.Any<string>(), Arg.Any<long?>(),
+                Arg.Any<string?>(), Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_full", "succeeded", 10_000));
+
+        var sut = new RefundPaymentCommandHandler(
+            db, stripe, AdminUser(), NullLogger<RefundPaymentCommandHandler>.Instance);
+
+        await sut.Handle(new RefundPaymentCommand(payment.Id, null, "full"), default);
+
+        var updated = await db.Payments.FindAsync(payment.Id);
+        updated!.Status.Should().Be(PaymentStatus.Refunded);
+        updated.RefundedAmountCents.Should().Be(10_000);
+        updated.ProfitShareAmountCents.Should().Be(0);
+        updated.PayeeAmountCents.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Partial_refund_50pct_recomputes_commission_from_retained()
+    {
+        // Gross 10000, refund 5000 → retained 5000.
+        // Default v1 split = 10% / 90% → commission 500, payee 4500.
+        using var db = CreateDb();
+        var payment = MakePayment(PaymentStatus.Captured, 10_000);
+        payment.ProfitShareAmountCents = 1_000;
+        payment.PayeeAmountCents = 9_000;
+        db.Payments.Add(payment);
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        stripe.RefundPaymentAsync(
+                Arg.Any<string>(), Arg.Any<long?>(),
+                Arg.Any<string?>(), Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_half", "succeeded", 5_000));
+
+        var sut = new RefundPaymentCommandHandler(
+            db, stripe, AdminUser(), NullLogger<RefundPaymentCommandHandler>.Instance);
+
+        await sut.Handle(new RefundPaymentCommand(payment.Id, 5_000, "partial"), default);
+
+        var updated = await db.Payments.FindAsync(payment.Id);
+        updated!.Status.Should().Be(PaymentStatus.PartiallyRefunded);
+        updated.RefundedAmountCents.Should().Be(5_000);
+        updated.ProfitShareAmountCents.Should().Be(500);
+        updated.PayeeAmountCents.Should().Be(4_500);
+        (updated.RefundedAmountCents + updated.ProfitShareAmountCents + updated.PayeeAmountCents)
+            .Should().Be(updated.AmountCents);
+    }
+
+    [Fact]
+    public async Task Partial_refund_30pct_recomputes_commission_from_retained()
+    {
+        // Gross 10000, refund 3000 → retained 7000.
+        // 10% commission = 700, payee = 6300.
+        using var db = CreateDb();
+        var payment = MakePayment(PaymentStatus.Captured, 10_000);
+        payment.ProfitShareAmountCents = 1_000;
+        payment.PayeeAmountCents = 9_000;
+        db.Payments.Add(payment);
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        stripe.RefundPaymentAsync(
+                Arg.Any<string>(), Arg.Any<long?>(),
+                Arg.Any<string?>(), Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_30", "succeeded", 3_000));
+
+        var sut = new RefundPaymentCommandHandler(
+            db, stripe, AdminUser(), NullLogger<RefundPaymentCommandHandler>.Instance);
+
+        await sut.Handle(new RefundPaymentCommand(payment.Id, 3_000, "30pct"), default);
+
+        var updated = await db.Payments.FindAsync(payment.Id);
+        updated!.ProfitShareAmountCents.Should().Be(700);
+        updated.PayeeAmountCents.Should().Be(6_300);
+    }
+
+    [Fact]
+    public async Task Tiny_amount_refund_handles_rounding_safely()
+    {
+        // Gross 1c, fully refunded → retained 0 → commission 0, payee 0.
+        using var db = CreateDb();
+        var payment = MakePayment(PaymentStatus.Captured, 1);
+        payment.ProfitShareAmountCents = 0;
+        payment.PayeeAmountCents = 1;
+        db.Payments.Add(payment);
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        stripe.RefundPaymentAsync(
+                Arg.Any<string>(), Arg.Any<long?>(),
+                Arg.Any<string?>(), Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new StripeRefundResult("re_tiny", "succeeded", 1));
+
+        var sut = new RefundPaymentCommandHandler(
+            db, stripe, AdminUser(), NullLogger<RefundPaymentCommandHandler>.Instance);
+
+        await sut.Handle(new RefundPaymentCommand(payment.Id, null, null), default);
+
+        var updated = await db.Payments.FindAsync(payment.Id);
+        updated!.Status.Should().Be(PaymentStatus.Refunded);
+        updated.ProfitShareAmountCents.Should().Be(0);
+        updated.PayeeAmountCents.Should().Be(0);
+    }
 }

--- a/server/tests/ScholarPath.UnitTests/Payments/StripePayoutJobTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Payments/StripePayoutJobTests.cs
@@ -132,4 +132,30 @@ public class StripePayoutJobTests
         payout.Status.Should().Be(PayoutStatus.Failed);
         payout.FailureReason.Should().Contain("stripe down");
     }
+
+    [Fact]
+    public async Task Stripe_failure_releases_payments_for_next_run()
+    {
+        // PB-013 recovery: pre-claimed payments must be released when Stripe
+        // rejects the payout, otherwise PayoutId != null prevents future runs
+        // from ever paying them again.
+        using var db = CreateDb();
+        var payeeId = Guid.NewGuid();
+        db.UserProfiles.Add(Payee(payeeId, StripeConnectStatus.Verified));
+        var p1 = CapturedPayment(payeeId, 4000);
+        var p2 = CapturedPayment(payeeId, 1500);
+        db.Payments.AddRange(p1, p2);
+        await db.SaveChangesAsync();
+
+        var stripe = Substitute.For<IStripeService>();
+        stripe.CreatePayoutAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("stripe down"));
+
+        await Sut(db, stripe, Substitute.For<INotificationDispatcher>()).RunAsync(default);
+
+        (await db.Payments.FindAsync(p1.Id))!.PayoutId.Should().BeNull();
+        (await db.Payments.FindAsync(p2.Id))!.PayoutId.Should().BeNull();
+        db.Payouts.Single().Status.Should().Be(PayoutStatus.Failed);
+    }
 }


### PR DESCRIPTION
CompanyReview payments now use a manual-capture PaymentIntent on the unified Payment table — the hold is taken when the student submits and captured only when the company accepts the review. Rejection cancels the hold, withdrawal pre-acceptance cancels it, post-acceptance refunds 50%, and the 14-day timeout cancels Held or fully refunds Captured.

Platform commission (v1 default 10%) now recomputes off the retained amount on every refund — booking partial cancellations, CompanyReview 50% refunds, and admin refunds all shrink commission together with payee net so refunded + commission + payee = gross.

payout.failed (webhook and StripePayoutJob catch path) now releases Payment.PayoutId so the next nightly run can retry. Verified-only Connect account check still gates the retry.

Wires the apply-now submit flow through ApplicationSubmitConfirmation when the scholarship has a configured review fee; StripeCheckout now takes paymentType/applicationId/bookingId props and routes the intent correctly.

Adds tests for: manual-capture for both types, server-resolved PayeeUserId, the new Capture/Reject CompanyReview handlers, ApplicationStatusChanged event routing, the timeout job on the unified table, retained-based commission recalc (full / 50% / 30% / 1-cent), and payout.failed retry recovery (webhook + job catch).

Replaces dead-table queries in WithdrawApplicationCommandHandler, CaptureCompanyReviewPaymentCommandHandler, RefundCompanyReviewCommandHandler, and CompanyReviewTimeoutRefundJob.

## What / Why

<!-- 1–2 sentences. What does this PR do, and why? -->

## SRS traceability

- FRs: FR-xxx, FR-yyy
- User stories: US-xxx
- Epic: PB-xxx

## Checklist

- [ ] Tests added/updated for new logic
- [ ] Module coverage stays ≥70%
- [ ] EN + AR translations added for any user-facing strings
- [ ] `dotnet build` (server) — 0 warnings, 0 errors
- [ ] `npm run typecheck` + `npm run lint` + `npm run test` (client) — all green
- [ ] Manual smoke test via `/scalar/v1` (API) or dev UI
- [ ] Docs updated (`docs/*.md`) if public contract changed
- [ ] No secrets / tokens / PII in code or logs

## Screenshots / demo (UI changes only)

<!-- Drag in before/after screenshots. For interactions, record a <10s clip. -->

## Deployment notes

<!-- Migrations? Feature flags? Environment variables? Config changes? -->
