### PR TITLE
fix: eligibility country matching, profile save UX, payment refunds, blob storage

### DIFF
--- a/client/src/pages/profile/Profile.tsx
+++ b/client/src/pages/profile/Profile.tsx
@@ -1133,19 +1133,22 @@ export function Profile() {
   const feeError =
     feeNumber == null
       ? null
-      : !Number.isFinite(feeNumber) || feeNumber <= 0
+      : !Number.isFinite(feeNumber) || feeNumber < 0
         ? t("profile:validation.sessionFeePositive")
         : Math.round(feeNumber * 100) !== feeNumber * 100
           ? t("profile:validation.sessionFeeDecimals")
           : null;
 
-  const hasClientErrors = Boolean(
-    linkedInError || websiteError || orgWebsiteError || gpaError || feeError,
-  );
-
   const onSave = () => {
-    if (hasClientErrors) {
-      toast.error(t("profile:error"));
+    // Surface the first *specific* reason a save is blocked. Falling back to
+    // the generic "couldn't save your profile" toast hid which field was at
+    // fault — and the offending field is often in a section that isn't on
+    // screen (e.g. a stale session-fee), so the save looked like an
+    // unexplained server error.
+    const firstError =
+      linkedInError ?? websiteError ?? orgWebsiteError ?? gpaError ?? feeError;
+    if (firstError) {
+      toast.error(firstError);
       return;
     }
     updateMut.mutate(toRequest(form), {

--- a/client/src/services/api/client.ts
+++ b/client/src/services/api/client.ts
@@ -92,8 +92,15 @@ apiClient.interceptors.response.use(
       useAuthStore.getState().clear();
     }
 
-    if (error.response?.data) {
-      throw new ApiError(error.response.data);
+    // Use the server body only when it's a real ProblemDetails object. A
+    // platform-level 500/502 (e.g. an App Service HTML error page) arrives as a
+    // string, which would otherwise wrap into an ApiError with no usable
+    // title/detail and surface as a misleading generic message. Falling back to
+    // axios's message ("Request failed with status code 500") tells the user
+    // it's a server error, not a validation problem.
+    const data = error.response?.data;
+    if (data && typeof data === "object" && "status" in data) {
+      throw new ApiError(data as ApiErrorPayload);
     }
     throw new ApiError({
       title: error.message || "Unknown error",

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -290,6 +290,39 @@ resource redis 'Microsoft.Cache/redis@2024-03-01' = if (deployRedis) {
   }
 }
 
+// ─── Storage Account (document vault — FR-216) ──────────────────────────────
+// The document vault writes uploaded files to Blob storage. Storage account
+// names are globally unique, 3-24 chars, lowercase alphanumeric (no hyphens).
+
+var storageAccountName = take('st${replace(nameSuffix, '-', '')}${uniqueSuffix}', 24)
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: tags
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+// Blob connection string secret. The API reads it via a Key Vault reference
+// (resolved at runtime by the App Service managed identity), exactly like the
+// SQL connection string — the key never appears in App Service configuration.
+resource storageConnectionSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'Storage--AzureBlob--ConnectionString'
+  properties: {
+    value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccount.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
+    contentType: 'text/plain'
+  }
+}
+
 // ─── App Service Plan + API App Service ─────────────────────────────────────
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
@@ -391,6 +424,17 @@ resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
           name: 'ApplicationInsights__ConnectionString'
           value: appInsights.properties.ConnectionString
         }
+        // Document vault → Azure Blob storage (FR-216). Without these the API
+        // falls back to the Local provider and writes to the App Service's
+        // ephemeral/read-only filesystem, which fails in production.
+        {
+          name: 'Storage__Provider'
+          value: 'AzureBlob'
+        }
+        {
+          name: 'Storage__AzureBlob__ConnectionString'
+          value: '@Microsoft.KeyVault(SecretUri=${storageConnectionSecret.properties.secretUri})'
+        }
       ], deployRedis ? [
         {
           name: 'Redis__ConnectionString'
@@ -491,6 +535,9 @@ output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
 
 @description('Name of the Azure SQL database.')
 output sqlDatabaseName string = sqlDatabase.name
+
+@description('Name of the Storage Account backing the document vault.')
+output storageAccountName string = storageAccount.name
 
 @description('Key Vault name.')
 output keyVaultName string = keyVault.name

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/CancelBooking/CancelBookingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/CancelBooking/CancelBookingCommandHandler.cs
@@ -68,6 +68,11 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
         // calculator and Stripe steps don't apply — just flip state.
         if (booking.PriceUsd == 0m && booking.Payment is null)
         {
+            // Capture the lifecycle phase BEFORE mutating Status — otherwise the
+            // reason check below always reads "Cancelled" and every free-booking
+            // cancellation is mis-recorded as a consultant-side cancellation.
+            var wasRequested = booking.Status == BookingStatus.Requested;
+
             booking.Status = BookingStatus.Cancelled;
             booking.CancelledAt = DateTimeOffset.UtcNow;
             booking.CancelledByUserId = currentUserId;
@@ -76,7 +81,7 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
             // Consultant initiated) classify as the consultant-side reason so
             // the booking's audit trail still shows a meaningful cause even
             // though no money moved.
-            booking.CancellationReason = isStudent && booking.Status == BookingStatus.Requested
+            booking.CancellationReason = isStudent && wasRequested
                 ? CancellationReason.StudentCancelledBeforeAcceptance
                 : CancellationReason.ConsultantCancelledAfterAcceptance;
 

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
@@ -91,10 +91,14 @@ public sealed class MarkNoShowCommandHandler : IRequestHandler<MarkNoShowCommand
                     throw new BookingDomainException("Booking has no Stripe payment intent to refund.");
                 }
 
-                var amountCents = (long)decimal.Round(
-                    booking.PriceUsd * 100m,
-                    0,
-                    MidpointRounding.AwayFromZero);
+                // Refund the amount that was actually captured (the Payment row
+                // is the source of truth), not a re-derivation from PriceUsd —
+                // the two can diverge if the booking was re-priced after payment,
+                // which would otherwise over- or under-refund on Stripe while the
+                // Payment row claims a full refund.
+                var amountCents = booking.Payment is { } capturedPayment
+                    ? capturedPayment.AmountCents
+                    : (long)decimal.Round(booking.PriceUsd * 100m, 0, MidpointRounding.AwayFromZero);
 
                 if (amountCents < 0)
                 {

--- a/server/src/ScholarPath.Infrastructure/Services/CountryNormalizer.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/CountryNormalizer.cs
@@ -1,0 +1,171 @@
+using System.Globalization;
+using System.Text;
+
+namespace ScholarPath.Infrastructure.Services;
+
+/// <summary>
+/// Reconciles the two country representations the platform stores. Scholarships
+/// persist <c>TargetCountriesJson</c> as ISO 3166-1 alpha-2 codes
+/// (<c>["EG","JO","AE"]</c>), while a student's nationality / preferred-country
+/// values are full English names ("Egypt") or free-typed text (possibly Arabic,
+/// e.g. "مصر"). A naive string compare of "EG" against "Egypt" never matches,
+/// which made the eligibility "Country" criterion always read <c>no</c>.
+///
+/// <see cref="ToKey"/> collapses any of those forms to a single canonical key
+/// (the uppercase ISO alpha-2 code when the country is known), so both sides of
+/// a comparison line up. Unknown values fall back to a trimmed, case- and
+/// diacritic-folded form, so two equal free-text values still match.
+/// </summary>
+public static class CountryNormalizer
+{
+    /// <summary>Canonical key for two countries being "the same" place.</summary>
+    public static bool Matches(string? a, string? b)
+    {
+        var ka = ToKey(a);
+        var kb = ToKey(b);
+        return ka.Length > 0 && string.Equals(ka, kb, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Maps an ISO alpha-2 code, full English name, common alias, or Arabic
+    /// name to the uppercase ISO alpha-2 code. Returns a folded form of the
+    /// input when the country is unrecognised, and "" for null/blank.
+    /// </summary>
+    public static string ToKey(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+
+        var trimmed = value.Trim();
+        var folded = Fold(trimmed);
+
+        // Known name / alias / Arabic name wins first, so two-letter aliases that
+        // are NOT their own ISO code (e.g. "UK" → GB) resolve correctly.
+        if (Lookup.TryGetValue(folded, out var iso))
+            return iso;
+
+        // Otherwise a two-letter token is taken to be an ISO alpha-2 code (the
+        // scholarship storage form, e.g. "EG").
+        if (trimmed.Length == 2 && trimmed.All(char.IsLetter))
+            return trimmed.ToUpperInvariant();
+
+        return folded;
+    }
+
+    /// <summary>
+    /// Case-folds (to upper-invariant — CA1308's recommended direction for
+    /// normalization keys), trims, collapses whitespace and strips diacritics.
+    /// </summary>
+    private static string Fold(string value)
+    {
+        var cased = value.ToUpperInvariant().Trim();
+
+        var decomposed = cased.Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(decomposed.Length);
+        var lastWasSpace = false;
+        foreach (var ch in decomposed)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
+                continue;
+            if (char.IsWhiteSpace(ch))
+            {
+                if (!lastWasSpace && sb.Length > 0) sb.Append(' ');
+                lastWasSpace = true;
+                continue;
+            }
+            sb.Append(ch);
+            lastWasSpace = false;
+        }
+
+        return sb.ToString().TrimEnd().Normalize(NormalizationForm.FormC);
+    }
+
+    // Folded name / alias / Arabic name → ISO alpha-2. Built once.
+    private static readonly IReadOnlyDictionary<string, string> Lookup = BuildLookup();
+
+    private static Dictionary<string, string> BuildLookup()
+    {
+        // Canonical English name → ISO alpha-2 (mirrors the client COUNTRIES list).
+        var names = new (string Name, string Iso)[]
+        {
+            ("Afghanistan","AF"),("Albania","AL"),("Algeria","DZ"),("Argentina","AR"),
+            ("Armenia","AM"),("Australia","AU"),("Austria","AT"),("Azerbaijan","AZ"),
+            ("Bahrain","BH"),("Bangladesh","BD"),("Belarus","BY"),("Belgium","BE"),
+            ("Bolivia","BO"),("Bosnia and Herzegovina","BA"),("Brazil","BR"),
+            ("Bulgaria","BG"),("Cambodia","KH"),("Cameroon","CM"),("Canada","CA"),
+            ("Chile","CL"),("China","CN"),("Colombia","CO"),("Croatia","HR"),
+            ("Cuba","CU"),("Czech Republic","CZ"),("Denmark","DK"),("Ecuador","EC"),
+            ("Egypt","EG"),("Ethiopia","ET"),("Finland","FI"),("France","FR"),
+            ("Georgia","GE"),("Germany","DE"),("Ghana","GH"),("Greece","GR"),
+            ("Guatemala","GT"),("Hungary","HU"),("India","IN"),("Indonesia","ID"),
+            ("Iran","IR"),("Iraq","IQ"),("Ireland","IE"),("Italy","IT"),
+            ("Japan","JP"),("Jordan","JO"),("Kazakhstan","KZ"),("Kenya","KE"),
+            ("Kuwait","KW"),("Kyrgyzstan","KG"),("Lebanon","LB"),("Libya","LY"),
+            ("Malaysia","MY"),("Mexico","MX"),("Morocco","MA"),("Myanmar","MM"),
+            ("Nepal","NP"),("Netherlands","NL"),("New Zealand","NZ"),("Nigeria","NG"),
+            ("Norway","NO"),("Oman","OM"),("Pakistan","PK"),("Palestine","PS"),
+            ("Peru","PE"),("Philippines","PH"),("Poland","PL"),("Portugal","PT"),
+            ("Qatar","QA"),("Romania","RO"),("Russia","RU"),("Saudi Arabia","SA"),
+            ("Senegal","SN"),("Serbia","RS"),("South Africa","ZA"),("South Korea","KR"),
+            ("Spain","ES"),("Sri Lanka","LK"),("Sudan","SD"),("Sweden","SE"),
+            ("Switzerland","CH"),("Syria","SY"),("Taiwan","TW"),("Tajikistan","TJ"),
+            ("Tanzania","TZ"),("Thailand","TH"),("Tunisia","TN"),("Turkey","TR"),
+            ("Turkmenistan","TM"),("Uganda","UG"),("Ukraine","UA"),
+            ("United Arab Emirates","AE"),("United Kingdom","GB"),("United States","US"),
+            ("Uruguay","UY"),("Uzbekistan","UZ"),("Venezuela","VE"),("Vietnam","VN"),
+            ("Yemen","YE"),("Zimbabwe","ZW"),
+        };
+
+        // Common English aliases / abbreviations users actually type.
+        var aliases = new (string Alias, string Iso)[]
+        {
+            ("usa","US"),("u.s.a","US"),("u.s","US"),("us","US"),("america","US"),
+            ("united states of america","US"),
+            ("uk","GB"),("u.k","GB"),("britain","GB"),("great britain","GB"),
+            ("england","GB"),("united kingdom of great britain and northern ireland","GB"),
+            ("uae","AE"),("emirates","AE"),("the emirates","AE"),
+            ("ksa","SA"),("kingdom of saudi arabia","SA"),
+            ("russian federation","RU"),("korea","KR"),("republic of korea","KR"),
+            ("south korea","KR"),("czechia","CZ"),("holland","NL"),
+            ("the netherlands","NL"),("turkiye","TR"),("türkiye","TR"),
+        };
+
+        // Arabic names → ISO alpha-2 (mirrors the client COUNTRY_AR map), so a
+        // free-typed Arabic tag like "مصر" still resolves.
+        var arabic = new (string Name, string Iso)[]
+        {
+            ("أفغانستان","AF"),("ألبانيا","AL"),("الجزائر","DZ"),("الأرجنتين","AR"),
+            ("أرمينيا","AM"),("أستراليا","AU"),("النمسا","AT"),("أذربيجان","AZ"),
+            ("البحرين","BH"),("بنغلاديش","BD"),("بيلاروسيا","BY"),("بلجيكا","BE"),
+            ("بوليفيا","BO"),("البوسنة والهرسك","BA"),("البرازيل","BR"),("بلغاريا","BG"),
+            ("كمبوديا","KH"),("الكاميرون","CM"),("كندا","CA"),("تشيلي","CL"),
+            ("الصين","CN"),("كولومبيا","CO"),("كرواتيا","HR"),("كوبا","CU"),
+            ("التشيك","CZ"),("الدنمارك","DK"),("الإكوادور","EC"),("مصر","EG"),
+            ("إثيوبيا","ET"),("فنلندا","FI"),("فرنسا","FR"),("جورجيا","GE"),
+            ("ألمانيا","DE"),("غانا","GH"),("اليونان","GR"),("غواتيمالا","GT"),
+            ("المجر","HU"),("الهند","IN"),("إندونيسيا","ID"),("إيران","IR"),
+            ("العراق","IQ"),("أيرلندا","IE"),("إيطاليا","IT"),("اليابان","JP"),
+            ("الأردن","JO"),("كازاخستان","KZ"),("كينيا","KE"),("الكويت","KW"),
+            ("قيرغيزستان","KG"),("لبنان","LB"),("ليبيا","LY"),("ماليزيا","MY"),
+            ("المكسيك","MX"),("المغرب","MA"),("ميانمار","MM"),("نيبال","NP"),
+            ("هولندا","NL"),("نيوزيلندا","NZ"),("نيجيريا","NG"),("النرويج","NO"),
+            ("عمان","OM"),("عُمان","OM"),("باكستان","PK"),("فلسطين","PS"),("بيرو","PE"),
+            ("الفلبين","PH"),("بولندا","PL"),("البرتغال","PT"),("قطر","QA"),
+            ("رومانيا","RO"),("روسيا","RU"),("السعودية","SA"),
+            ("المملكة العربية السعودية","SA"),("السنغال","SN"),("صربيا","RS"),
+            ("جنوب أفريقيا","ZA"),("كوريا الجنوبية","KR"),("إسبانيا","ES"),
+            ("سريلانكا","LK"),("السودان","SD"),("السويد","SE"),("سويسرا","CH"),
+            ("سوريا","SY"),("تايوان","TW"),("طاجيكستان","TJ"),("تنزانيا","TZ"),
+            ("تايلاند","TH"),("تونس","TN"),("تركيا","TR"),("تركمانستان","TM"),
+            ("أوغندا","UG"),("أوكرانيا","UA"),("الإمارات العربية المتحدة","AE"),
+            ("الإمارات","AE"),("المملكة المتحدة","GB"),("الولايات المتحدة","US"),
+            ("الأوروغواي","UY"),("أوزبكستان","UZ"),("فنزويلا","VE"),("فيتنام","VN"),
+            ("اليمن","YE"),("زيمبابوي","ZW"),
+        };
+
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (name, iso) in names) map[Fold(name)] = iso;
+        foreach (var (alias, iso) in aliases) map[Fold(alias)] = iso;
+        foreach (var (name, iso) in arabic) map[Fold(name)] = iso;
+        return map;
+    }
+}

--- a/server/src/ScholarPath.Infrastructure/Services/LocalAiService.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/LocalAiService.cs
@@ -70,7 +70,9 @@ public sealed class LocalAiService(
 
             if (userLevel.HasValue && userLevel.Value == c.TargetLevel) score += 30;
             score += OverlapScore(preferredFields, fosFields, maxPoints: 40);
-            score += OverlapScore(preferredCountries, countries, maxPoints: 25);
+            // Countries are compared on their canonical ISO key so a preferred
+            // "Egypt" / "مصر" overlaps a scholarship's "EG".
+            score += OverlapScore(NormalizeCountries(preferredCountries), NormalizeCountries(countries), maxPoints: 25);
 
             // Funding bonus — bigger awards nudge up by a few points
             if (c.FundingAmountUsd >= 10_000) score += 5;
@@ -130,17 +132,31 @@ public sealed class LocalAiService(
             Match: profile?.AcademicLevel == scholarship.TargetLevel ? "yes"
                 : profile?.AcademicLevel is null ? "unknown" : "no"));
 
-        // Country match (nullable)
+        // Country match. A scholarship's target country is where the award lets
+        // you study; the UI asks students for exactly that as "preferred study
+        // destinations" (preferredCountries) and promises to "match scholarships
+        // in those countries with you". So the listing is matched against the
+        // student's preferred destinations AND their nationality (some awards
+        // are nationality-restricted) — not nationality alone, which made an
+        // Egyptian who wants to study in France read "no" on a France award.
+        // CountryNormalizer folds ISO codes ("FR"), full names ("France") and
+        // Arabic to a common key so the spelling/format no longer matters.
         var listingCountries = ParseJsonArray(scholarship.TargetCountriesJson);
-        var studentCountry = profile?.Nationality ?? string.Empty;
+        var studentCountries = ParseJsonArray(profile?.PreferredCountriesJson).ToList();
+        var nationality = profile?.Nationality;
+        if (!string.IsNullOrWhiteSpace(nationality))
+            studentCountries.Add(nationality);
+
         criteria.Add(new AiEligibilityCriterion(
             NameEn: "Country",
             NameAr: "الدولة",
-            StudentValue: string.IsNullOrWhiteSpace(studentCountry) ? "unknown" : studentCountry,
+            StudentValue: studentCountries.Count == 0
+                ? "unknown"
+                : string.Join(", ", studentCountries.Distinct(StringComparer.OrdinalIgnoreCase)),
             ListingRequirement: listingCountries.Count == 0 ? "any" : string.Join(", ", listingCountries),
             Match: listingCountries.Count == 0 ? "yes"
-                : string.IsNullOrWhiteSpace(studentCountry) ? "unknown"
-                : listingCountries.Any(c => string.Equals(c, studentCountry, StringComparison.OrdinalIgnoreCase)) ? "yes" : "no"));
+                : studentCountries.Count == 0 ? "unknown"
+                : listingCountries.Any(lc => studentCountries.Any(sc => CountryNormalizer.Matches(lc, sc))) ? "yes" : "no"));
 
         // Field of study — use dedicated FieldsOfStudyJson; fall back to tags only if not set
         var fosFields = ParseJsonArray(scholarship.FieldsOfStudyJson);
@@ -286,6 +302,11 @@ public sealed class LocalAiService(
             return Array.Empty<string>();
         }
     }
+
+    // Fold a country list to its canonical ISO keys, dropping blanks, so
+    // overlap is measured on "the same place" rather than identical spelling.
+    private static IReadOnlyList<string> NormalizeCountries(IReadOnlyList<string> countries)
+        => countries.Select(CountryNormalizer.ToKey).Where(k => k.Length > 0).ToList();
 
     private static int OverlapScore(IReadOnlyList<string> a, IReadOnlyList<string> b, int maxPoints)
     {

--- a/server/src/ScholarPath.Infrastructure/Services/StripeService.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/StripeService.cs
@@ -413,7 +413,12 @@ public sealed class StripeService(
                 case Charge ch:
                     chargeId = ch.Id;
                     paymentIntentId = ch.PaymentIntentId;
-                    amountCents = ch.Amount;
+                    // For `charge.refunded` this must be the CUMULATIVE amount
+                    // refunded on the charge — using ch.Amount (the gross charge)
+                    // made every partial refund record as a full refund and flip
+                    // the status to Refunded. ch.AmountRefunded is the only
+                    // consumer of this value for a Charge.
+                    amountCents = ch.AmountRefunded;
                     break;
                 case Account acct:
                     connectAccountId = acct.Id;

--- a/server/tests/ScholarPath.UnitTests/Ai/EligibilityVerdictTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Ai/EligibilityVerdictTests.cs
@@ -64,7 +64,8 @@ public sealed class EligibilityVerdictTests : IDisposable
     }
 
     private async Task SeedProfileAsync(
-        Guid userId, AcademicLevel? level, string? nationality, string? fieldOfStudy)
+        Guid userId, AcademicLevel? level, string? nationality, string? fieldOfStudy,
+        string? preferredCountriesJson = null)
     {
         _db.UserProfiles.Add(new UserProfile
         {
@@ -73,6 +74,7 @@ public sealed class EligibilityVerdictTests : IDisposable
             AcademicLevel = level,
             Nationality = nationality,
             FieldOfStudy = fieldOfStudy,
+            PreferredCountriesJson = preferredCountriesJson,
         });
         await _db.SaveChangesAsync();
     }
@@ -118,6 +120,58 @@ public sealed class EligibilityVerdictTests : IDisposable
         var result = await _ai.CheckEligibilityAsync(userId, scholarshipId, CancellationToken.None);
 
         result.Verdict.Should().Be(EligibilityVerdict.PartiallyEligible);
+    }
+
+    [Fact]
+    public async Task IsoCodeCountry_MatchesFullNameNationality()
+    {
+        // Real-world data shape: scholarships store ISO alpha-2 codes while the
+        // profile stores a full country name. Before normalization "EG" never
+        // equalled "Egypt", so the country criterion always read "no" and pulled
+        // the verdict down to NotEligible.
+        var userId = Guid.NewGuid();
+        var scholarshipId = await SeedScholarshipAsync(
+            AcademicLevel.Masters, "[\"EG\",\"JO\",\"AE\"]", "[\"Engineering\"]");
+        await SeedProfileAsync(userId, AcademicLevel.Masters, "Egypt", "Engineering");
+
+        var result = await _ai.CheckEligibilityAsync(userId, scholarshipId, CancellationToken.None);
+
+        result.Criteria.Single(c => c.NameEn == "Country").Match.Should().Be("yes");
+        result.Verdict.Should().Be(EligibilityVerdict.Eligible);
+    }
+
+    [Fact]
+    public async Task PreferredDestination_MatchesScholarshipCountry_EvenWhenNationalityDiffers()
+    {
+        // The exact reported case: an Egyptian student who wants to study in
+        // France, against a France scholarship. The award's country is a study
+        // destination, so it must match the student's preferred destination —
+        // not their nationality. Before the fix the criterion read "no".
+        var userId = Guid.NewGuid();
+        var scholarshipId = await SeedScholarshipAsync(
+            AcademicLevel.Masters, "[\"France\"]", "[\"Computer Science\"]");
+        await SeedProfileAsync(
+            userId, AcademicLevel.Masters, nationality: "Egypt",
+            fieldOfStudy: "Computer Science", preferredCountriesJson: "[\"France\"]");
+
+        var result = await _ai.CheckEligibilityAsync(userId, scholarshipId, CancellationToken.None);
+
+        result.Criteria.Single(c => c.NameEn == "Country").Match.Should().Be("yes");
+        result.Verdict.Should().Be(EligibilityVerdict.Eligible);
+    }
+
+    [Fact]
+    public async Task IsoCodeCountry_NonMatchingNationality_ReadsNo()
+    {
+        var userId = Guid.NewGuid();
+        var scholarshipId = await SeedScholarshipAsync(
+            AcademicLevel.Masters, "[\"EG\",\"JO\"]", "[\"Engineering\"]");
+        await SeedProfileAsync(userId, AcademicLevel.Masters, "Germany", "Engineering");
+
+        var result = await _ai.CheckEligibilityAsync(userId, scholarshipId, CancellationToken.None);
+
+        result.Criteria.Single(c => c.NameEn == "Country").Match.Should().Be("no");
+        result.Verdict.Should().Be(EligibilityVerdict.NotEligible);
     }
 
     [Fact]

--- a/server/tests/ScholarPath.UnitTests/Common/CountryNormalizerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Common/CountryNormalizerTests.cs
@@ -1,0 +1,55 @@
+using ScholarPath.Infrastructure.Services;
+using Xunit;
+using FluentAssertions;
+
+namespace ScholarPath.UnitTests.Common;
+
+/// <summary>
+/// Country values reach the matcher in three shapes: ISO alpha-2 codes (how
+/// scholarships store them, e.g. "EG"), full English names (the profile
+/// nationality selector, "Egypt"), and free-typed text including Arabic ("مصر").
+/// <see cref="CountryNormalizer"/> must fold all three to one key.
+/// </summary>
+public sealed class CountryNormalizerTests
+{
+    [Theory]
+    [InlineData("EG", "Egypt")]
+    [InlineData("eg", "egypt")]
+    [InlineData("Egypt", "مصر")]
+    [InlineData("EG", "مصر")]
+    [InlineData("United States", "US")]
+    [InlineData("USA", "us")]
+    [InlineData("UK", "United Kingdom")]   // "UK" is an alias, not its own ISO code (GB)
+    [InlineData("United Arab Emirates", "AE")]
+    [InlineData("  Egypt  ", "EG")]
+    public void Matches_EquivalentForms_AreEqual(string a, string b)
+        => CountryNormalizer.Matches(a, b).Should().BeTrue();
+
+    [Theory]
+    [InlineData("EG", "DE")]
+    [InlineData("Egypt", "Germany")]
+    [InlineData("US", "GB")]
+    [InlineData("UK", "US")]
+    public void Matches_DifferentCountries_AreNotEqual(string a, string b)
+        => CountryNormalizer.Matches(a, b).Should().BeFalse();
+
+    [Theory]
+    [InlineData("Egypt", "EG")]
+    [InlineData("مصر", "EG")]
+    [InlineData("USA", "US")]
+    [InlineData("UK", "GB")]
+    [InlineData("united kingdom", "GB")]
+    public void ToKey_ResolvesToIsoCode(string input, string expected)
+        => CountryNormalizer.ToKey(input).Should().Be(expected);
+
+    [Fact]
+    public void ToKey_BlankOrNull_ReturnsEmpty()
+    {
+        CountryNormalizer.ToKey(null).Should().BeEmpty();
+        CountryNormalizer.ToKey("   ").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Matches_BothBlank_IsFalse()
+        => CountryNormalizer.Matches("", "").Should().BeFalse();
+}


### PR DESCRIPTION
Batch of fixes from a focused review. **822 backend tests pass (0 fail), client production build clean.**

## Fixed (verified)
- **Eligibility country matching** — scholarships store ISO codes (`EG`), profiles store names (`Egypt`)/Arabic, so the check always read *not matching*. Added `CountryNormalizer` to fold any form to a canonical key, and the check now matches a scholarship's country against the student's **preferred study destinations** as well as nationality (so an Egyptian wanting to study in France matches a France award).
- **Profile save** — the save gate showed a generic toast hiding which field blocked it; now surfaces the specific field. Session fee `0` (free) is accepted, matching the backend. API client no longer turns a non-JSON 500 into a misleading generic message.
- **Payments** — `charge.refunded` used the gross charge amount instead of the refunded amount (partial refunds recorded as full); no-show refund now uses the captured `payment.AmountCents`; a free-booking cancel no longer mis-records the cancellation reason.
- **Infra** — provision a Storage Account + Key Vault connection string and switch the document vault to Azure Blob (prod was on the ephemeral local disk, so uploads failed).

## Not in this PR — needs decisions / config
- **SSO login (Google/Microsoft)** fails in prod because the OAuth credentials are not configured, so the app falls back to a stub that builds an invalid consent URL. Needs the real `Authentication__{Google,Microsoft}__{ClientId,ClientSecret}` set + redirect URIs registered.
- **SSO security**: the OAuth `state` is generated but never validated (CSRF), and SSO sign-in links to any existing same-email account without verification. Need design decisions.
- Other prod config gaps (Stripe, Email, ACS, PowerBI, file-scanning) and minor auth hardening.