### PR TITLE
fix(ai): trim blank entries from studentCountries in eligibility check

### DIFF
--- a/server/src/ScholarPath.Infrastructure/Services/LocalAiService.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/LocalAiService.cs
@@ -142,8 +142,11 @@ public sealed class LocalAiService(
         // CountryNormalizer folds ISO codes ("FR"), full names ("France") and
         // Arabic to a common key so the spelling/format no longer matters.
         var listingCountries = ParseJsonArray(scholarship.TargetCountriesJson);
-        var studentCountries = ParseJsonArray(profile?.PreferredCountriesJson).ToList();
-        var nationality = profile?.Nationality;
+        var studentCountries = ParseJsonArray(profile?.PreferredCountriesJson)
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())
+            .ToList();
+        var nationality = profile?.Nationality?.Trim();
         if (!string.IsNullOrWhiteSpace(nationality))
             studentCountries.Add(nationality);
 


### PR DESCRIPTION
Addresses the Copilot review comment on PR #34.

`studentCountries` was built from `PreferredCountriesJson` without trimming or filtering blank entries. If the JSON array contained whitespace values, `studentCountries.Count` would be non-zero, causing the criterion to be treated as "known" when it was effectively empty — and a blank entry could appear in `StudentValue`.

**Fix:** filter `Where(!IsNullOrWhiteSpace)` + `Select(Trim())` before building the list; also trim `Nationality` for the same reason.

Closes the last open Copilot comment from PR #34.