### PR TITLE
feat(ui): hide pricing section when payments are disabled

### DIFF
--- a/client/src/components/layout/PublicLayout.tsx
+++ b/client/src/components/layout/PublicLayout.tsx
@@ -8,6 +8,7 @@ import { LanguageSwitcher } from "@/components/common/LanguageSwitcher";
 import { ThemeToggle } from "@/components/common/ThemeToggle";
 import { useAuthStore } from "@/stores/authStore";
 import { postAuthPath } from "@/services/api/auth";
+import { usePaymentsEnabled } from "@/hooks/usePlatformStatus";
 
 /** Email address used for placeholder footer links until proper static pages ship. */
 const SUPPORT_EMAIL = "support@scholarpath.local";
@@ -216,6 +217,7 @@ export function PublicLayout({ children }: { children: ReactNode }) {
 function SiteFooter() {
   const { t } = useTranslation(["home", "common"]);
   const isAuthed = useAuthStore((s) => s.user !== null);
+  const paymentsEnabled = usePaymentsEnabled();
 
   // Product links lead to authenticated areas — anonymous users go through
   // /login?redirect=… so Login.tsx restores their intent post-auth.
@@ -241,7 +243,7 @@ function SiteFooter() {
           label: t("home:footer.product.community"),
           href: authedFooterHref("/student/community", isAuthed),
         },
-        { label: t("home:footer.product.pricing"), href: "/#pricing" },
+        ...(paymentsEnabled ? [{ label: t("home:footer.product.pricing"), href: "/#pricing" }] : []),
       ],
     },
     {

--- a/client/src/pages/public/Home.tsx
+++ b/client/src/pages/public/Home.tsx
@@ -16,6 +16,7 @@ import {
 import { motion } from "motion/react";
 import { useAuthStore } from "@/stores/authStore";
 import { postAuthPath } from "@/services/api/auth";
+import { usePaymentsEnabled } from "@/hooks/usePlatformStatus";
 
 export function Home() {
   const { t } = useTranslation(["home", "common"]);
@@ -367,6 +368,9 @@ export function Home() {
   // ─── Pricing ──────────────────────────────────────────────────────
 
   function PricingSection() {
+    const paymentsEnabled = usePaymentsEnabled();
+    if (!paymentsEnabled) return null;
+
     const tiers = [
       {
         key: "free",


### PR DESCRIPTION
The `#pricing` section on the home page showed hardcoded prices ($35, Custom) regardless of whether the platform's payments toggle was on or off.

**Fix:**
- `PricingSection` in `Home.tsx` now calls `usePaymentsEnabled()` — returns `null` when payments are off, so the section doesn't render at all
- `SiteFooter` in `PublicLayout.tsx` conditionally includes the `/#pricing` footer link — also hidden when payments are off

Both consumers reuse the existing `usePlatformStatus` hook which reads from the cached `GET /api/status` query (already mounted by `App.tsx`), so no extra API calls.

**Behaviour:**
- Admin sets `PaymentsEnabled = false` in platform settings → pricing section disappears from the public home page
- Admin re-enables payments → section reappears automatically (30-second poll interval)