### PR TITLE
Fix scholarship file upload for company + consultant availability preview

### DIFF
--- a/client/src/locales/ar/consultantPortal.json
+++ b/client/src/locales/ar/consultantPortal.json
@@ -128,7 +128,10 @@
     "stats": {
       "activeDays": "الأيام النشطة",
       "adHocSlots": "مواعيد فردية",
-      "timezone": "المنطقة الزمنية"
+      "timezone": "المنطقة الزمنية",
+      "upcomingSlots": "المواعيد المرئية (28 يوماً)",
+      "nextSlot": "التالي",
+      "previewError": "المعاينة غير متاحة"
     },
     "weeklySchedule": {
       "title": "الجدول الأسبوعي",

--- a/client/src/locales/en/consultantPortal.json
+++ b/client/src/locales/en/consultantPortal.json
@@ -128,7 +128,10 @@
     "stats": {
       "activeDays": "Active days",
       "adHocSlots": "One-off slots",
-      "timezone": "Timezone"
+      "timezone": "Timezone",
+      "upcomingSlots": "Visible slots (next 28 days)",
+      "nextSlot": "Next",
+      "previewError": "Preview unavailable"
     },
     "weeklySchedule": {
       "title": "Weekly schedule",

--- a/client/src/pages/company/ApplicationsReview.tsx
+++ b/client/src/pages/company/ApplicationsReview.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { CheckCircle, XCircle, Eye, Clock, Search, Filter } from "lucide-react";
+import { CheckCircle, XCircle, Eye, Clock, Search, Filter, Download, FileText, Loader2 } from "lucide-react";
 import {
   applicationsApi,
   type CompanyApplicationRow,
   type ApplicationStatus,
 } from "@/services/api/applications";
+import { documentsApi } from "@/services/api/documents";
 import { apiErrorMessage } from "@/services/api/client";
 import { PromptDialog } from "@/components/ui/PromptDialog";
 
@@ -302,86 +303,209 @@ export function ApplicationsReview() {
 
       {/* View-details drawer — opened by the eye icon on each row */}
       {viewTarget && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-text-primary/30 p-4 backdrop-blur-sm"
-          onClick={() => setViewTarget(null)}
-          role="presentation"
-        >
-          <div
-            className="w-full max-w-md rounded-2xl border border-border-subtle bg-bg-elevated p-6 shadow-elevation-3"
-            onClick={(e) => e.stopPropagation()}
-            role="dialog"
-            aria-modal="true"
-          >
-            <div className="mb-4 flex items-start justify-between gap-4">
-              <h2 className="text-lg font-bold text-text-primary">
-                {t("companyReview.detail.title", "Application details")}
-              </h2>
-              <button
-                type="button"
-                onClick={() => setViewTarget(null)}
-                className="rounded-md p-1 text-text-tertiary hover:bg-bg-subtle hover:text-text-primary"
-                aria-label={t("companyReview.detail.close", "Close")}
-              >
-                <XCircle size={20} />
-              </button>
-            </div>
-            <dl className="space-y-3 text-sm">
-              <div className="flex flex-col gap-0.5">
-                <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.student")}</dt>
-                <dd className="font-medium text-text-primary">{viewTarget.studentName}</dd>
-              </div>
-              <div className="flex flex-col gap-0.5">
-                <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.scholarship")}</dt>
-                <dd className="text-text-primary">{viewTarget.scholarshipTitle}</dd>
-              </div>
-              <div className="flex flex-col gap-0.5">
-                <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.status")}</dt>
-                <dd className="text-text-primary">
-                  {t(`companyReview.status.${viewTarget.status}`, { defaultValue: viewTarget.status })}
-                </dd>
-              </div>
-              <div className="flex flex-col gap-0.5">
-                <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.submitted")}</dt>
-                <dd className="text-text-primary">
-                  {viewTarget.submittedAt
-                    ? new Date(viewTarget.submittedAt).toLocaleDateString(lang)
-                    : "—"}
-                </dd>
-              </div>
-            </dl>
-            {/* Accept / Reject from inside the detail drawer (QA BUG-019 — the
-                popup previously showed details only, with no way to act). Hidden
-                once the application is in a terminal state. */}
-            {!["Accepted", "Rejected", "Withdrawn"].includes(viewTarget.status) && (
-              <div className="mt-5 flex justify-end gap-2 border-t border-border-subtle pt-4">
-                <button
-                  type="button"
-                  onClick={() => {
-                    const target = viewTarget;
-                    setViewTarget(null);
-                    handleDecisionClick(target.applicationId, "Rejected");
-                  }}
-                  className="rounded-lg border border-danger-200 px-3 py-1.5 text-sm font-medium text-danger-600 transition hover:border-danger-400 hover:bg-danger-50"
-                >
-                  {t("companyReview.actions.reject")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const target = viewTarget;
-                    setViewTarget(null);
-                    handleDecisionClick(target.applicationId, "Accepted");
-                  }}
-                  className="rounded-lg bg-success-500 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-success-600"
-                >
-                  {t("companyReview.actions.accept")}
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
+        <ApplicationDetailModal
+          row={viewTarget}
+          lang={lang}
+          t={t}
+          onClose={() => setViewTarget(null)}
+          onDecision={(id, status) => {
+            setViewTarget(null);
+            handleDecisionClick(id, status);
+          }}
+        />
       )}
+    </div>
+  );
+}
+
+// ── Application detail modal ──────────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function ApplicationDetailModal({
+  row,
+  lang,
+  t,
+  onClose,
+  onDecision,
+}: {
+  row: CompanyApplicationRow;
+  lang: string;
+  t: ReturnType<typeof useTranslation<"applications">>["t"];
+  onClose: () => void;
+  onDecision: (id: string, status: "Accepted" | "Rejected") => void;
+}) {
+  const { data: details, isLoading } = useQuery({
+    queryKey: ["company", "application", "detail", row.applicationId],
+    queryFn: () => applicationsApi.getCompanyApplicationDetails(row.applicationId),
+  });
+
+  const handleDownload = async (docId: string, fileName: string) => {
+    try {
+      const blob = await documentsApi.download(docId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      // silent — the download icon just fails to trigger, no toast needed here
+    }
+  };
+
+  // Parse flat {key: value} form data for display
+  const formEntries: [string, string][] = (() => {
+    if (!details?.formDataJson) return [];
+    try {
+      const parsed = JSON.parse(details.formDataJson) as Record<string, unknown>;
+      return Object.entries(parsed).map(([k, v]) => [k, v == null ? "" : String(v)]);
+    } catch {
+      return [];
+    }
+  })();
+
+  const isTerminal = ["Accepted", "Rejected", "Withdrawn"].includes(row.status);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-text-primary/30 p-4 backdrop-blur-sm"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-border-subtle bg-bg-elevated shadow-elevation-3"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 border-b border-border-subtle p-6 pb-4">
+          <h2 className="text-lg font-bold text-text-primary">
+            {t("companyReview.detail.title", "Application details")}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-text-tertiary hover:bg-bg-subtle hover:text-text-primary"
+            aria-label={t("companyReview.detail.close", "Close")}
+          >
+            <XCircle size={20} />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto p-6 pt-4 space-y-5">
+          {/* Summary */}
+          <dl className="space-y-3 text-sm">
+            <div className="flex flex-col gap-0.5">
+              <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.student")}</dt>
+              <dd className="font-medium text-text-primary">{row.studentName}</dd>
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.scholarship")}</dt>
+              <dd className="text-text-primary">{row.scholarshipTitle}</dd>
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.status")}</dt>
+              <dd className="text-text-primary">
+                {t(`companyReview.status.${row.status}`, { defaultValue: row.status })}
+              </dd>
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <dt className="text-xs uppercase tracking-wide text-text-tertiary">{t("companyReview.table.submitted")}</dt>
+              <dd className="text-text-primary">
+                {row.submittedAt ? new Date(row.submittedAt).toLocaleDateString(lang) : "—"}
+              </dd>
+            </div>
+          </dl>
+
+          {isLoading && (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 size={20} className="animate-spin text-text-tertiary" />
+            </div>
+          )}
+
+          {/* Form answers */}
+          {!isLoading && formEntries.length > 0 && (
+            <div>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+                {t("companyReview.detail.formAnswers", "Form answers")}
+              </h3>
+              <dl className="space-y-2 rounded-lg border border-border-subtle bg-bg-canvas p-3 text-sm">
+                {formEntries.map(([key, value]) => (
+                  <div key={key}>
+                    <dt className="text-xs text-text-tertiary capitalize">{key.replace(/_/g, " ")}</dt>
+                    <dd className="text-text-primary whitespace-pre-wrap">{value || "—"}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          )}
+
+          {/* Uploaded documents */}
+          {!isLoading && details && details.documents.length > 0 && (
+            <div>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+                {t("companyReview.detail.documents", "Documents")}
+              </h3>
+              <ul className="space-y-2">
+                {details.documents.map((doc) => (
+                  <li
+                    key={doc.id}
+                    className="flex items-center gap-3 rounded-lg border border-border-subtle bg-bg-canvas p-3 text-sm"
+                  >
+                    <FileText size={16} className="shrink-0 text-text-tertiary" />
+                    <span className="flex-1 truncate text-text-primary">{doc.fileName}</span>
+                    <span className="text-xs text-text-tertiary">{formatBytes(doc.sizeBytes)}</span>
+                    <button
+                      type="button"
+                      onClick={() => void handleDownload(doc.id, doc.fileName)}
+                      title={t("companyReview.detail.download", "Download")}
+                      className="rounded-md p-1.5 text-text-tertiary transition hover:bg-bg-subtle hover:text-brand-600"
+                    >
+                      <Download size={15} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* No documents hint */}
+          {!isLoading && details && details.documents.length === 0 && !details.formDataJson && (
+            <p className="text-sm text-text-tertiary">
+              {t("companyReview.detail.noContent", "No form answers or documents were submitted.")}
+            </p>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        {!isTerminal && (
+          <div className="flex justify-end gap-2 border-t border-border-subtle p-4">
+            <button
+              type="button"
+              onClick={() => onDecision(row.applicationId, "Rejected")}
+              className="rounded-lg border border-danger-200 px-3 py-1.5 text-sm font-medium text-danger-600 transition hover:border-danger-400 hover:bg-danger-50"
+            >
+              {t("companyReview.actions.reject")}
+            </button>
+            <button
+              type="button"
+              onClick={() => onDecision(row.applicationId, "Accepted")}
+              className="rounded-lg bg-success-500 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-success-600"
+            >
+              {t("companyReview.actions.accept")}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/client/src/pages/consultant/ConsultantAvailability.tsx
+++ b/client/src/pages/consultant/ConsultantAvailability.tsx
@@ -7,6 +7,7 @@ import {
   useMyAvailabilityQuery,
   useUpdateAvailabilityMutation,
 } from "@/hooks/useBookingsQuery";
+import { useConsultantAvailabilityQuery } from "@/hooks/useConsultantsQuery";
 import type {
   AvailabilityInput,
   AvailabilityRule,
@@ -14,6 +15,7 @@ import type {
 } from "@/services/api/bookings";
 import { formatDate, formatTime } from "@/lib/bookingFormat";
 import { apiErrorMessage } from "@/services/api/client";
+import { useAuthStore } from "@/stores/authStore";
 
 // ── Weekly schedule editor state ──────────────────────────────────────────────
 //
@@ -119,6 +121,15 @@ export function ConsultantAvailability() {
 
   const { data, isLoading, isError } = useMyAvailabilityQuery();
   const updateMutation = useUpdateAvailabilityMutation();
+
+  // Preview: show the consultant exactly how many slots students currently see.
+  // Uses the same public endpoint students call, so the count is authoritative.
+  const consultantId = useAuthStore((s) => s.user?.id);
+  const {
+    data: previewSlots,
+    isLoading: isPreviewLoading,
+    isError: isPreviewError,
+  } = useConsultantAvailabilityQuery(consultantId);
 
   const [rows, setRows] = useState<DayRow[]>(() => buildRows([]));
   const [timezone, setTimezone] = useState("Africa/Cairo");
@@ -289,7 +300,7 @@ export function ConsultantAvailability() {
           </div>
         ) : (
           <>
-            <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
               <div className="rounded-xl border border-border-subtle bg-bg-elevated p-5 shadow-sm">
                 <div className="inline-flex rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-600">
                   {t("availability.stats.activeDays")}
@@ -313,6 +324,35 @@ export function ConsultantAvailability() {
                   {t("availability.stats.timezone")}
                 </div>
                 <p className="mt-4 text-sm font-semibold text-text-primary">{timezone}</p>
+              </div>
+
+              {/* Live preview — how many slots students actually see right now */}
+              <div className="rounded-xl border border-brand-200 bg-brand-50/30 p-5 shadow-sm">
+                <div className="inline-flex rounded-full bg-brand-100 px-3 py-1 text-xs font-medium text-brand-700">
+                  {t("availability.stats.upcomingSlots")}
+                </div>
+                {isPreviewLoading ? (
+                  <p className="mt-4 text-3xl font-semibold tracking-[-0.02em] text-text-primary">
+                    …
+                  </p>
+                ) : isPreviewError ? (
+                  <p className="mt-4 text-sm font-medium text-danger-500">
+                    {t("availability.stats.previewError")}
+                  </p>
+                ) : (
+                  <>
+                    <p className="mt-4 text-3xl font-semibold tracking-[-0.02em] text-text-primary">
+                      {previewSlots?.length ?? 0}
+                    </p>
+                    {previewSlots?.[0] ? (
+                      <p className="mt-1 text-xs text-text-secondary">
+                        {t("availability.stats.nextSlot")}:{" "}
+                        {formatDate(previewSlots[0].startAt, lang)}{" "}
+                        {formatTime(previewSlots[0].startAt, lang)}
+                      </p>
+                    ) : null}
+                  </>
+                )}
               </div>
             </div>
 

--- a/client/src/services/api/applications.ts
+++ b/client/src/services/api/applications.ts
@@ -67,6 +67,28 @@ export interface CompanyApplicationRow {
   submittedAt: string | null;
 }
 
+export interface CompanyDocumentInfo {
+  id: string;
+  fileName: string;
+  contentType: string;
+  sizeBytes: number;
+}
+
+/** Full application details visible to the company reviewer. */
+export interface CompanyApplicationDetails {
+  applicationId: string;
+  studentId: string;
+  studentName: string;
+  scholarshipId: string;
+  scholarshipTitle: string;
+  status: ApplicationStatus;
+  submittedAt: string | null;
+  formDataJson: string | null;
+  attachedDocumentsJson: string | null;
+  /** Vault documents uploaded by the student for this application (with IDs). */
+  documents: CompanyDocumentInfo[];
+}
+
 export interface ApplicationDetail {
   id: string;
   scholarshipId: string | null;
@@ -145,8 +167,8 @@ export const applicationsApi = {
     return data;
   },
 
-  async getCompanyApplicationDetails(id: string): Promise<CompanyApplicationRow> {
-    const { data } = await apiClient.get<CompanyApplicationRow>(`/api/applications/company/${id}`);
+  async getCompanyApplicationDetails(id: string): Promise<CompanyApplicationDetails> {
+    const { data } = await apiClient.get<CompanyApplicationDetails>(`/api/applications/company/${id}`);
     return data;
   },
 

--- a/server/src/ScholarPath.Application/Applications/DTOs/ApplicationDTOs.cs
+++ b/server/src/ScholarPath.Application/Applications/DTOs/ApplicationDTOs.cs
@@ -9,6 +9,13 @@ public record CompanyApplicationRow(
     Domain.Enums.ApplicationStatus Status,
     DateTimeOffset? SubmittedAt);
 
+/// <summary>A document attached to an application, visible to the company reviewer.</summary>
+public record CompanyDocumentInfo(
+    Guid Id,
+    string FileName,
+    string ContentType,
+    long SizeBytes);
+
 public record CompanyApplicationDetailsDto(
     Guid ApplicationId,
     Guid StudentId,
@@ -18,6 +25,7 @@ public record CompanyApplicationDetailsDto(
     Domain.Enums.ApplicationStatus Status,
     DateTimeOffset? SubmittedAt,
     string? FormDataJson,
-    string? AttachedDocumentsJson);
+    string? AttachedDocumentsJson,
+    IReadOnlyList<CompanyDocumentInfo> Documents);
 
 public record PagedResult<T>(IReadOnlyList<T> Items, int Page, int PageSize, int TotalCount);

--- a/server/src/ScholarPath.Application/Applications/Queries/GetCompanyApplicationDetails/GetCompanyApplicationDetailsQueryHandler.cs
+++ b/server/src/ScholarPath.Application/Applications/Queries/GetCompanyApplicationDetails/GetCompanyApplicationDetailsQueryHandler.cs
@@ -26,6 +26,12 @@ public sealed class GetCompanyApplicationDetailsQueryHandler(
             throw new ForbiddenAccessException();
         }
 
+        var documents = await db.Documents
+            .AsNoTracking()
+            .Where(d => d.ApplicationTrackerId == application.Id && !d.IsDeleted)
+            .Select(d => new CompanyDocumentInfo(d.Id, d.FileName, d.ContentType, d.SizeBytes))
+            .ToListAsync(ct);
+
         return new CompanyApplicationDetailsDto(
             application.Id,
             application.StudentId,
@@ -37,7 +43,8 @@ public sealed class GetCompanyApplicationDetailsQueryHandler(
             application.Status,
             application.SubmittedAt,
             application.FormDataJson,
-            application.AttachedDocumentsJson
+            application.AttachedDocumentsJson,
+            documents
         );
     }
 }

--- a/server/src/ScholarPath.Application/Documents/Queries/DownloadDocument/DownloadDocumentQuery.cs
+++ b/server/src/ScholarPath.Application/Documents/Queries/DownloadDocument/DownloadDocumentQuery.cs
@@ -34,7 +34,24 @@ public sealed class DownloadDocumentQueryHandler(
 
         var isAdmin = currentUser.IsInRole("Admin") || currentUser.IsInRole("SuperAdmin");
         if (document.OwnerUserId != userId && !isAdmin)
-            throw new ForbiddenAccessException("You can only download your own documents.");
+        {
+            // A company reviewer may download documents that are attached to an
+            // application submitted against one of their own scholarships.
+            var isCompanyReviewer = currentUser.IsInRole("Company")
+                && document.ApplicationTrackerId.HasValue
+                && await db.Applications
+                    .AsNoTracking()
+                    .Include(a => a.Scholarship)
+                    .AnyAsync(
+                        a => a.Id == document.ApplicationTrackerId.Value
+                          && a.Scholarship != null
+                          && a.Scholarship.OwnerCompanyId == userId,
+                        ct)
+                    .ConfigureAwait(false);
+
+            if (!isCompanyReviewer)
+                throw new ForbiddenAccessException("You can only download your own documents.");
+        }
 
         // Demo / seeded documents store a placeholder StoragePath that doesn't
         // exist in the real blob container. Return a friendly text placeholder


### PR DESCRIPTION
## Summary

### Fix 1: Company can view and download student documents (previous commit)
- **Company review modal now shows form answers and uploaded documents** — previously the eye-icon popup showed only 4 fields. It now fetches full application details and renders form answers + a downloadable document list.
- **Company can download student documents** — `DownloadDocumentQueryHandler` now allows a Company user to download a document if it is attached to an application on one of their own scholarships.
- **`GetCompanyApplicationDetails` returns structured documents with IDs** — the handler queries `Documents` by `ApplicationTrackerId` and returns `CompanyDocumentInfo` objects.

### Fix 2: Consultant availability — live student-view slot preview
Consultants couldn't tell whether their saved availability rules were actually producing bookable slots visible to students.

- **New "Visible slots (next 28 days)" stat card** on the consultant availability page calls the exact same public `GET /api/consultants/{id}/availability` endpoint that students use — so the count shown is authoritative.
- When the count is 0 after saving, the consultant immediately knows students see no slots (likely because session duration > availability window, or all slots are in the past).
- The card shows the next upcoming slot's date and time.
- Auto-refreshes after every save via the existing `["consultants"]` query invalidation.

## Files changed

| File | Change |
|------|--------|
| `ApplicationDTOs.cs` | Added `CompanyDocumentInfo` record; added `Documents` field to `CompanyApplicationDetailsDto` |
| `GetCompanyApplicationDetailsQueryHandler.cs` | Query `db.Documents` by `ApplicationTrackerId` and include in response |
| `DownloadDocumentQuery.cs` | Company bypass: allow download when document belongs to their scholarship's application |
| `applications.ts` | Added `CompanyDocumentInfo` / `CompanyApplicationDetails` types; fixed return type |
| `ApplicationsReview.tsx` | Replaced static modal with full detail modal showing form answers + downloadable documents |
| `ConsultantAvailability.tsx` | Added live slot preview card using auth store user ID + public consultant API |
| `en/consultantPortal.json` | Added `upcomingSlots`, `nextSlot`, `previewError` translation keys |
| `ar/consultantPortal.json` | Same keys in Arabic |

## Test plan

- [ ] Student uploads a document while filling in a scholarship application → submits
- [ ] Company opens Applications Review, clicks eye icon → modal shows form answers + documents with download buttons
- [ ] Company clicks download → file downloads successfully; different company gets 403
- [ ] Consultant opens Availability page → sees "Visible slots (next 28 days)" card with current slot count
- [ ] Consultant enables days and saves → card immediately refreshes and shows the updated slot count
- [ ] If count is 0 after saving, verify session duration ≤ window duration in profile settings