### PR TITLE
Fix landing-page refresh loop (maintenance status reload)

### DIFF
--- a/client/src/pages/MaintenancePage.tsx
+++ b/client/src/pages/MaintenancePage.tsx
@@ -17,24 +17,27 @@ async function fetchStatus(): Promise<StatusResponse> {
 
 /**
  * Full-screen maintenance page shown while `maintenance.enabled = "true"` in
- * PlatformSettings.  Polls GET /api/status every 30 s and automatically
- * navigates to the app root as soon as maintenance ends.
+ * PlatformSettings.  Polls GET /api/status every 30 s; as soon as maintenance
+ * ends, `App.tsx`'s own status gate stops rendering this page and swaps in the
+ * router — no page reload required.
  */
 export function MaintenancePage() {
   const { t } = useTranslation("errors");
 
+  // Keep the shared status query warm so the App-level gate flips back to the
+  // app the moment maintenance ends.
+  //
+  // We deliberately do NOT call window.location.reload() here. It used to live
+  // inside this query's `select`, but `select` must be pure and can run on
+  // every render — when the status endpoint briefly reported "off" (e.g. one
+  // App Service instance lagging behind another), the reload fired in a loop
+  // and the landing page refreshed endlessly. Letting App.tsx re-render into
+  // the router on the next poll is loop-proof and needs no reload.
   useQuery({
     queryKey: ["platform", "status"],
     queryFn: fetchStatus,
     refetchInterval: 30_000,
     retry: false,
-    select: (data) => {
-      if (!data.maintenanceModeEnabled) {
-        // Maintenance is over — hard-reload so the full app bootstraps cleanly.
-        window.location.reload();
-      }
-      return data;
-    },
   });
 
   return (


### PR DESCRIPTION
## Summary

The landing/home page was refreshing in a loop. Root cause: `MaintenancePage.tsx` called `window.location.reload()` **inside the React Query `select` callback** of its `/api/status` poll.

`select` must be a pure function and can run on every render. Whenever `/api/status` briefly reported maintenance **off** — e.g. one Azure App Service instance lagging behind another, or the setting transitioning — the reload fired repeatedly, producing an endless page refresh and the burst of `/api/status` requests observed in production.

## Fix

Remove the `reload()` entirely. The reload was never necessary: when maintenance ends, `App.tsx`'s own shared `["platform","status"]` poll receives `maintenanceModeEnabled: false` on its next tick and stops rendering `<MaintenancePage>`, swapping in the router. That transition is loop-proof and needs no hard reload.

`MaintenancePage` keeps polling (to keep the shared query warm) but no longer has any side effect in `select`.

## Files changed

| File | Change |
|------|--------|
| `client/src/pages/MaintenancePage.tsx` | Drop `window.location.reload()` from the status query's `select`; keep the poll pure |

## Test plan

- [ ] With maintenance **off**, the landing page loads once and does not refresh on a timer
- [ ] Turn maintenance **on** → users see the maintenance page (no loop)
- [ ] Turn maintenance **off** → within ~30s the app swaps back in automatically, no reload loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsnwowJTZ8LKHgbQ7QN2Cc)_