### PR TITLE
Fix: enforce consultant eligibility for role switch, availability, marketplace & booking

### DIFF
--- a/client/src/components/layout/AuthenticatedLayout.tsx
+++ b/client/src/components/layout/AuthenticatedLayout.tsx
@@ -37,14 +37,12 @@ import { toast } from "sonner";
 import { LanguageSwitcher } from "@/components/common/LanguageSwitcher";
 import { ThemeToggle } from "@/components/common/ThemeToggle";
 import { useAuthStore } from "@/stores/authStore";
-import { authApi, applyAuthSession, postAuthPath } from "@/services/api/auth";
+import { authApi, applyAuthSession, postAuthPath, switchableRoles } from "@/services/api/auth";
 import { apiErrorMessage } from "@/services/api/client";
 import { useNotificationHub } from "@/hooks/useNotificationHub";
 import { notificationsApi, UNREAD_COUNT_QUERY_KEY } from "@/services/api/notifications";
 import { cn } from "@/lib/utils";
 import { userPhotoUrl } from "@/lib/userPhoto";
-
-const SWITCHABLE_ROLES = ["Student", "Consultant", "Company", "Admin"] as const;
 
 function ProfileMenu() {
   const { t, i18n } = useTranslation(["common", "nav"]);
@@ -71,9 +69,7 @@ function ProfileMenu() {
 
   if (!user) return null;
   const activeRole = user.activeRole ?? user.roles[0] ?? null;
-  const switchTargets = user.roles.filter(
-    (r) => r !== activeRole && (SWITCHABLE_ROLES as readonly string[]).includes(r),
-  );
+  const switchTargets = switchableRoles(user).filter((r) => r !== activeRole);
 
   const onSignOut = () => {
     clear();

--- a/client/src/pages/profile/Profile.tsx
+++ b/client/src/pages/profile/Profile.tsx
@@ -36,15 +36,13 @@ import {
 } from "@/services/api/profile";
 import { useAuthStore } from "@/stores/authStore";
 import { usePaymentsEnabled } from "@/hooks/usePlatformStatus";
-import { authApi, applyAuthSession, postAuthPath } from "@/services/api/auth";
+import { authApi, applyAuthSession, postAuthPath, switchableRoles } from "@/services/api/auth";
 import { userPhotoUrl } from "@/lib/userPhoto";
 import { apiErrorMessage } from "@/services/api/client";
 import { DatePicker } from "@/components/ui/DatePicker";
 import { cn } from "@/lib/utils";
 import { COUNTRIES, countryLabel } from "@/lib/countryLabel";
 import { ConsultantUpgradeModal } from "@/components/profile/ConsultantUpgradeModal";
-
-const SWITCHABLE_ROLES = ["Student", "Consultant", "Company", "Admin"] as const;
 
 const PROFILE_KEY = ["profile", "me"] as const;
 
@@ -729,10 +727,8 @@ function ActiveRoleSwitcher() {
   const activeRole = user.activeRole ?? user.roles[0] ?? null;
   if (!activeRole) return null;
 
-  const switchableRoles = user.roles.filter((r) =>
-    (SWITCHABLE_ROLES as readonly string[]).includes(r),
-  );
-  const hasMultiple = switchableRoles.length > 1;
+  const availableRoles = switchableRoles(user);
+  const hasMultiple = availableRoles.length > 1;
   const activeLabel = t(`common:roles.${activeRole}`, activeRole);
 
   if (!hasMultiple) {
@@ -746,7 +742,7 @@ function ActiveRoleSwitcher() {
     );
   }
 
-  const targets = switchableRoles.filter((r) => r !== activeRole);
+  const targets = availableRoles.filter((r) => r !== activeRole);
 
   return (
     <DropdownMenu.Root dir={isRtl ? "rtl" : "ltr"}>

--- a/client/src/services/api/auth.ts
+++ b/client/src/services/api/auth.ts
@@ -145,6 +145,24 @@ export function applyAuthSession(res: AuthTokensResponse): CurrentUser {
   return res.user;
 }
 
+/** Roles that a dual-role account is allowed to make its active session role. */
+const SWITCHABLE_ROLES = ["Student", "Consultant", "Company", "Admin"] as const;
+
+/**
+ * The roles the user may switch their active session to. Consultant is special:
+ * it is only offered when the backend confirms eligibility (`canActAsConsultant`),
+ * never on a raw — and possibly stale/unapproved — Consultant role row. The
+ * backend enforces the same rule on POST /api/auth/switch-role, so this only
+ * keeps the UI honest.
+ */
+export function switchableRoles(user: CurrentUser): string[] {
+  return user.roles.filter((role) => {
+    if (!(SWITCHABLE_ROLES as readonly string[]).includes(role)) return false;
+    if (role === "Consultant") return user.canActAsConsultant === true;
+    return true;
+  });
+}
+
 /** Where to send the user after a successful sign-in. */
 export function postAuthPath(user: CurrentUser): string {
   if (!user.isOnboardingComplete) return "/onboarding";

--- a/client/src/stores/authStore.ts
+++ b/client/src/stores/authStore.ts
@@ -19,6 +19,12 @@ export interface CurrentUser {
   // resubmission or approval has cleared them server-side).
   lastOnboardingRejectionReason?: string | null;
   lastOnboardingRejectedAt?: string | null;
+  // Backend-confirmed consultant eligibility. True only when the user may
+  // actually act as a Consultant (verified/approved), NOT merely because a
+  // Consultant role row exists. The role-switch UI relies on this so a stale or
+  // unapproved Consultant role can never expose the "switch to Consultant"
+  // option. Optional for backward compatibility with older cached sessions.
+  canActAsConsultant?: boolean;
 }
 
 export interface AuthTokens {

--- a/client/src/test/ProfileMenu.test.tsx
+++ b/client/src/test/ProfileMenu.test.tsx
@@ -61,7 +61,11 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 import { AuthenticatedLayout } from "@/components/layout/AuthenticatedLayout";
 import { useAuthStore } from "@/stores/authStore";
 
-function seedUser(roles: string[], activeRole: string) {
+function seedUser(
+  roles: string[],
+  activeRole: string,
+  opts: { canActAsConsultant?: boolean } = {},
+) {
   useAuthStore.setState({
     user: {
       id: "user-1",
@@ -75,6 +79,7 @@ function seedUser(roles: string[], activeRole: string) {
       roles,
       activeRole,
       preferredLanguage: "en",
+      canActAsConsultant: opts.canActAsConsultant ?? false,
     },
     tokens: {
       accessToken: "a",
@@ -114,8 +119,8 @@ describe("ProfileMenu — role switcher", () => {
     expect(screen.queryByRole("menuitem", { name: /switch to/i })).not.toBeInTheDocument();
   });
 
-  it("shows the other role as a switch option for a dual-role user", async () => {
-    seedUser(["Student", "Consultant"], "Student");
+  it("shows the Consultant switch option only when the backend confirms eligibility", async () => {
+    seedUser(["Student", "Consultant"], "Student", { canActAsConsultant: true });
     renderLayout();
     const trigger = await screen.findByRole("button", { name: /profile/i });
     await userEvent.click(trigger);
@@ -124,8 +129,21 @@ describe("ProfileMenu — role switcher", () => {
     expect(screen.queryByRole("menuitem", { name: /switch to student/i })).not.toBeInTheDocument();
   });
 
+  it("hides the Consultant switch option when the account is not consultant-eligible", async () => {
+    // Stale/unapproved Consultant role row: the backend says canActAsConsultant
+    // is false, so the switch option must not surface (defence-in-depth on top
+    // of the server-side block).
+    seedUser(["Student", "Consultant"], "Student", { canActAsConsultant: false });
+    renderLayout();
+    const trigger = await screen.findByRole("button", { name: /profile/i });
+    await userEvent.click(trigger);
+    expect(screen.queryByRole("menuitem", { name: /switch to consultant/i })).not.toBeInTheDocument();
+    // The identity card still renders — the menu just has no Consultant target.
+    expect(screen.getByText("u@example.com")).toBeInTheDocument();
+  });
+
   it("calls the switch-role API when a target role is picked", async () => {
-    seedUser(["Student", "Consultant"], "Student");
+    seedUser(["Student", "Consultant"], "Student", { canActAsConsultant: true });
     renderLayout();
     const trigger = await screen.findByRole("button", { name: /profile/i });
     await userEvent.click(trigger);

--- a/server/src/ScholarPath.Application/Admin/Commands/ApproveOnboarding/ReviewOnboardingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/ApproveOnboarding/ReviewOnboardingCommandHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 
 namespace ScholarPath.Application.Admin.Commands.ApproveOnboarding;
@@ -50,6 +51,25 @@ public sealed class ReviewOnboardingCommandHandler(
         {
             if (!string.IsNullOrWhiteSpace(user.ActiveRole))
                 await admin.AddRoleAsync(request.UserId, user.ActiveRole, ct).ConfigureAwait(false);
+
+            // A direct/standalone Consultant becomes an eligible consultant only
+            // once approved here — stamp the official verification marker so they
+            // pass IConsultantEligibilityService, mirroring the upgrade-approval
+            // path. Idempotent (keeps any earlier verification timestamp).
+            if (string.Equals(user.ActiveRole, "Consultant", StringComparison.OrdinalIgnoreCase))
+            {
+                if (user.Profile is null)
+                {
+                    user.Profile = new UserProfile
+                    {
+                        UserId = user.Id,
+                        CreatedAt = DateTimeOffset.UtcNow,
+                    };
+                    db.UserProfiles.Add(user.Profile);
+                }
+
+                user.Profile.ConsultantVerifiedAt ??= DateTimeOffset.UtcNow;
+            }
 
             user.IsOnboardingComplete = true;
             // Approval clears any stale rejection feedback so a future onboarding

--- a/server/src/ScholarPath.Application/Admin/Commands/ReviewUpgradeRequest/ReviewUpgradeRequestCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/ReviewUpgradeRequest/ReviewUpgradeRequestCommandHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Interfaces;
 
@@ -52,6 +53,15 @@ public sealed class ReviewUpgradeRequestCommandHandler(
             await admin.SetAccountStatusAsync(req.UserId, AccountStatus.Active,
                 $"Upgrade to {targetRole} approved.", ct).ConfigureAwait(false);
 
+            // Granting the Consultant role is not enough — stamp the official
+            // verification marker so the user passes IConsultantEligibilityService
+            // (role switch, availability, marketplace). This keeps the approval a
+            // single, atomic act of "you are now a consultant".
+            if (req.Target == UpgradeTarget.Consultant)
+            {
+                await MarkConsultantVerifiedAsync(req.UserId, now, ct).ConfigureAwait(false);
+            }
+
             logger.LogInformation("Approved upgrade {RequestId}: user {UserId} → {Role}",
                 req.Id, req.UserId, targetRole);
         }
@@ -80,5 +90,26 @@ public sealed class ReviewUpgradeRequestCommandHandler(
             ct).ConfigureAwait(false);
 
         return true;
+    }
+
+    /// <summary>
+    /// Sets <see cref="Domain.Entities.UserProfile.ConsultantVerifiedAt"/> — the
+    /// official consultant approval marker — creating the profile row if the
+    /// user somehow has none. Idempotent: an already-verified consultant keeps
+    /// their original verification timestamp.
+    /// </summary>
+    private async Task MarkConsultantVerifiedAsync(Guid userId, DateTimeOffset now, CancellationToken ct)
+    {
+        var profile = await db.UserProfiles
+            .FirstOrDefaultAsync(p => p.UserId == userId, ct)
+            .ConfigureAwait(false);
+
+        if (profile is null)
+        {
+            profile = new UserProfile { UserId = userId, CreatedAt = now };
+            db.UserProfiles.Add(profile);
+        }
+
+        profile.ConsultantVerifiedAt ??= now;
     }
 }

--- a/server/src/ScholarPath.Application/Auth/AuthDtoFactory.cs
+++ b/server/src/ScholarPath.Application/Auth/AuthDtoFactory.cs
@@ -7,7 +7,11 @@ namespace ScholarPath.Application.Auth;
 /// <summary>Builds the <see cref="AuthTokensDto"/> returned by register/login/refresh.</summary>
 internal static class AuthDtoFactory
 {
-    public static AuthTokensDto Build(TokenPair tokens, ApplicationUser user, IReadOnlyList<string> roles) =>
+    public static AuthTokensDto Build(
+        TokenPair tokens,
+        ApplicationUser user,
+        IReadOnlyList<string> roles,
+        bool canActAsConsultant = false) =>
         new(
             tokens.AccessToken,
             tokens.RefreshToken,
@@ -31,5 +35,6 @@ internal static class AuthDtoFactory
                 // login/refresh paths don't, which is fine: those flows
                 // immediately call /api/auth/me to hydrate the full user).
                 user.Profile?.LastOnboardingRejectionReason,
-                user.Profile?.LastOnboardingRejectedAt));
+                user.Profile?.LastOnboardingRejectedAt,
+                canActAsConsultant));
 }

--- a/server/src/ScholarPath.Application/Auth/Commands/Login/LoginCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/Login/LoginCommandHandler.cs
@@ -14,6 +14,7 @@ public sealed class LoginCommandHandler(
     IPasswordHasher passwordHasher,
     ITokenService tokenService,
     IUserAdministration userAdministration,
+    IConsultantEligibilityService consultantEligibility,
     IDateTimeService clock)
     : IRequestHandler<LoginCommand, AuthTokensDto>
 {
@@ -86,8 +87,9 @@ public sealed class LoginCommandHandler(
         await db.SaveChangesAsync(ct);
 
         var roles = await userAdministration.GetRolesAsync(user.Id, ct);
+        var canActAsConsultant = await consultantEligibility.CanActAsConsultantAsync(user.Id, roles, ct);
         var tokens = tokenService.IssueTokens(user, roles, user.ActiveRole, request.RememberMe);
-        return AuthDtoFactory.Build(tokens, user, roles);
+        return AuthDtoFactory.Build(tokens, user, roles, canActAsConsultant);
     }
 
     private static LoginAttempt BuildAttempt(

--- a/server/src/ScholarPath.Application/Auth/Commands/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/RefreshToken/RefreshTokenCommandHandler.cs
@@ -11,7 +11,8 @@ namespace ScholarPath.Application.Auth.Commands.RefreshToken;
 public sealed class RefreshTokenCommandHandler(
     IApplicationDbContext db,
     ITokenService tokenService,
-    IUserAdministration userAdministration)
+    IUserAdministration userAdministration,
+    IConsultantEligibilityService consultantEligibility)
     : IRequestHandler<RefreshTokenCommand, AuthTokensDto>
 {
     public async Task<AuthTokensDto> Handle(RefreshTokenCommand request, CancellationToken ct)
@@ -30,6 +31,7 @@ public sealed class RefreshTokenCommandHandler(
             ?? throw new ConflictException("Invalid or expired refresh token.");
 
         var roles = await userAdministration.GetRolesAsync(user.Id, ct);
-        return AuthDtoFactory.Build(tokens, user, roles);
+        var canActAsConsultant = await consultantEligibility.CanActAsConsultantAsync(user.Id, roles, ct);
+        return AuthDtoFactory.Build(tokens, user, roles, canActAsConsultant);
     }
 }

--- a/server/src/ScholarPath.Application/Auth/Commands/SelectRole/SelectRoleCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/SelectRole/SelectRoleCommandHandler.cs
@@ -17,6 +17,7 @@ public sealed class SelectRoleCommandHandler(
     IApplicationDbContext db,
     ICurrentUserService currentUser,
     IUserAdministration userAdministration,
+    IConsultantEligibilityService consultantEligibility,
     ITokenService tokenService,
     INotificationDispatcher notifications,
     ILogger<SelectRoleCommandHandler> logger)
@@ -184,13 +185,14 @@ public sealed class SelectRoleCommandHandler(
         await tokenService.RevokeAllForUserAsync(userId, "Role selected", ct);
 
         var roles = await userAdministration.GetRolesAsync(userId, ct);
+        var canActAsConsultant = await consultantEligibility.CanActAsConsultantAsync(userId, roles, ct);
         var tokens = tokenService.IssueTokens(user, roles, user.ActiveRole, rememberMe: false);
 
         logger.LogInformation(
             "User {UserId} selected role {Role} -> account status {Status}.",
             userId, request.Role, user.AccountStatus);
 
-        return AuthDtoFactory.Build(tokens, user, roles);
+        return AuthDtoFactory.Build(tokens, user, roles, canActAsConsultant);
     }
 
     // FR-ONB — alert every admin so a new onboarding request never sits unseen.

--- a/server/src/ScholarPath.Application/Auth/Commands/SsoLogin/SsoLoginCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/SsoLogin/SsoLoginCommandHandler.cs
@@ -14,6 +14,7 @@ public sealed class SsoLoginCommandHandler(
     ISsoService ssoService,
     ITokenService tokenService,
     IUserAdministration userAdministration,
+    IConsultantEligibilityService consultantEligibility,
     IDateTimeService clock)
     : IRequestHandler<SsoLoginCommand, AuthTokensDto>
 {
@@ -65,7 +66,8 @@ public sealed class SsoLoginCommandHandler(
             roles = await userAdministration.GetRolesAsync(user.Id, ct);
         }
 
+        var canActAsConsultant = await consultantEligibility.CanActAsConsultantAsync(user.Id, roles, ct);
         var tokens = tokenService.IssueTokens(user, roles, user.ActiveRole, rememberMe: false);
-        return AuthDtoFactory.Build(tokens, user, roles);
+        return AuthDtoFactory.Build(tokens, user, roles, canActAsConsultant);
     }
 }

--- a/server/src/ScholarPath.Application/Auth/Commands/SwitchRole/SwitchRoleCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/SwitchRole/SwitchRoleCommandHandler.cs
@@ -12,9 +12,12 @@ public sealed class SwitchRoleCommandHandler(
     IApplicationDbContext db,
     ICurrentUserService currentUser,
     IUserAdministration userAdministration,
+    IConsultantEligibilityService consultantEligibility,
     ITokenService tokenService)
     : IRequestHandler<SwitchRoleCommand, AuthTokensDto>
 {
+    private const string ConsultantRole = "Consultant";
+
     public async Task<AuthTokensDto> Handle(SwitchRoleCommand request, CancellationToken ct)
     {
         var userId = currentUser.UserId
@@ -27,6 +30,21 @@ public sealed class SwitchRoleCommandHandler(
         if (!roles.Contains(request.TargetRole, StringComparer.OrdinalIgnoreCase))
             throw new ForbiddenAccessException($"You do not hold the '{request.TargetRole}' role.");
 
+        // Consultant is a privileged capability, not just a role row: holding the
+        // Consultant role is necessary but NOT sufficient. Block the switch unless
+        // the account is a verified/approved consultant — otherwise a stale or
+        // out-of-band Consultant role would let a plain student act as a
+        // consultant (create availability, appear in the marketplace).
+        var canActAsConsultant = await consultantEligibility
+            .CanActAsConsultantAsync(userId, roles, ct);
+        if (string.Equals(request.TargetRole, ConsultantRole, StringComparison.OrdinalIgnoreCase)
+            && !canActAsConsultant)
+        {
+            throw new ForbiddenAccessException(
+                "You can't switch to the Consultant role. A consultant upgrade request must be "
+                + "approved before consultant access is activated for your account.");
+        }
+
         user.ActiveRole = request.TargetRole;
         await db.SaveChangesAsync(ct);
 
@@ -36,6 +54,6 @@ public sealed class SwitchRoleCommandHandler(
 
         // Issue a fresh pair so the JWT carries the new active_role claim.
         var tokens = tokenService.IssueTokens(user, roles, request.TargetRole, rememberMe: false);
-        return AuthDtoFactory.Build(tokens, user, roles);
+        return AuthDtoFactory.Build(tokens, user, roles, canActAsConsultant);
     }
 }

--- a/server/src/ScholarPath.Application/Auth/DTOs/AuthDtos.cs
+++ b/server/src/ScholarPath.Application/Auth/DTOs/AuthDtos.cs
@@ -26,7 +26,13 @@ public sealed record CurrentUserDto(
     // before resubmitting. Null when the account has never been rejected
     // or when the most recent decision was an approval.
     string? LastOnboardingRejectionReason = null,
-    DateTimeOffset? LastOnboardingRejectedAt = null);
+    DateTimeOffset? LastOnboardingRejectedAt = null,
+    // Consultant eligibility gate — true only when the backend confirms the
+    // user may act as a Consultant (verified/approved), NOT merely that a
+    // Consultant role row exists. The role-switch UI uses this so a stale or
+    // unapproved Consultant role can never surface the "switch to Consultant"
+    // option; the backend still enforces the same rule server-side.
+    bool CanActAsConsultant = false);
 
 public sealed record RegisterRequestDto(string Email, string Password, string FirstName, string LastName);
 public sealed record LoginRequestDto(string Email, string Password, bool RememberMe);

--- a/server/src/ScholarPath.Application/Auth/Queries/GetCurrentUser/GetCurrentUserQueryHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Queries/GetCurrentUser/GetCurrentUserQueryHandler.cs
@@ -11,7 +11,8 @@ namespace ScholarPath.Application.Auth.Queries.GetCurrentUser;
 public sealed class GetCurrentUserQueryHandler(
     IApplicationDbContext db,
     ICurrentUserService currentUser,
-    IUserAdministration userAdministration)
+    IUserAdministration userAdministration,
+    IConsultantEligibilityService consultantEligibility)
     : IRequestHandler<GetCurrentUserQuery, CurrentUserDto>
 {
     public async Task<CurrentUserDto> Handle(GetCurrentUserQuery request, CancellationToken ct)
@@ -29,6 +30,8 @@ public sealed class GetCurrentUserQueryHandler(
             ?? throw new NotFoundException(nameof(ApplicationUser), userId);
 
         var roles = await userAdministration.GetRolesAsync(user.Id, ct);
+        var canActAsConsultant = await consultantEligibility
+            .CanActAsConsultantAsync(user.Id, roles, ct);
 
         return new CurrentUserDto(
             user.Id,
@@ -43,6 +46,7 @@ public sealed class GetCurrentUserQueryHandler(
             user.ActiveRole,
             user.PreferredLanguage,
             user.Profile?.LastOnboardingRejectionReason,
-            user.Profile?.LastOnboardingRejectedAt);
+            user.Profile?.LastOnboardingRejectedAt,
+            canActAsConsultant);
     }
 }

--- a/server/src/ScholarPath.Application/Common/Interfaces/IConsultantEligibilityService.cs
+++ b/server/src/ScholarPath.Application/Common/Interfaces/IConsultantEligibilityService.cs
@@ -1,0 +1,34 @@
+namespace ScholarPath.Application.Common.Interfaces;
+
+/// <summary>
+/// Single source of truth for "may this user act as a Consultant?".
+///
+/// Holding the <c>Consultant</c> Identity role is NOT sufficient on its own —
+/// a role row can be stale or granted out-of-band. A user may act as a
+/// consultant only when ALL of the following hold:
+/// <list type="number">
+///   <item>they hold the <c>Consultant</c> role,</item>
+///   <item>their account is <see cref="Domain.Enums.AccountStatus.Active"/>, and</item>
+///   <item>they carry an official approval signal — either
+///     <see cref="Domain.Entities.UserProfile.ConsultantVerifiedAt"/> is set,
+///     or they have an <see cref="Domain.Enums.UpgradeRequestStatus.Approved"/>
+///     Consultant upgrade request.</item>
+/// </list>
+/// Enforced everywhere consultant capability is exercised (role switch,
+/// availability management, the public marketplace) so a single business rule
+/// governs them all rather than each handler re-checking role membership.
+/// </summary>
+public interface IConsultantEligibilityService
+{
+    /// <summary>
+    /// Resolves the user's roles and evaluates full consultant eligibility.
+    /// </summary>
+    Task<bool> CanActAsConsultantAsync(Guid userId, CancellationToken ct);
+
+    /// <summary>
+    /// Overload for callers that have already loaded the user's roles, to avoid
+    /// a redundant role lookup on the hot auth paths.
+    /// </summary>
+    Task<bool> CanActAsConsultantAsync(
+        Guid userId, IReadOnlyList<string> roles, CancellationToken ct);
+}

--- a/server/src/ScholarPath.Application/Common/Services/ConsultantEligibilityService.cs
+++ b/server/src/ScholarPath.Application/Common/Services/ConsultantEligibilityService.cs
@@ -1,0 +1,72 @@
+using Microsoft.EntityFrameworkCore;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Enums;
+
+namespace ScholarPath.Application.Common.Services;
+
+/// <summary>
+/// Default <see cref="IConsultantEligibilityService"/> implementation. Reads the
+/// user's roles through <see cref="IUserAdministration"/> (the Identity
+/// join-tables are not exposed on <see cref="IApplicationDbContext"/>) and the
+/// approval signals through the application DbContext.
+/// </summary>
+public sealed class ConsultantEligibilityService(
+    IApplicationDbContext db,
+    IUserAdministration userAdministration) : IConsultantEligibilityService
+{
+    public const string ConsultantRole = "Consultant";
+
+    public async Task<bool> CanActAsConsultantAsync(Guid userId, CancellationToken ct)
+    {
+        var roles = await userAdministration.GetRolesAsync(userId, ct).ConfigureAwait(false);
+        return await CanActAsConsultantAsync(userId, roles, ct).ConfigureAwait(false);
+    }
+
+    public async Task<bool> CanActAsConsultantAsync(
+        Guid userId, IReadOnlyList<string> roles, CancellationToken ct)
+    {
+        // Rule 1 — must actually hold the Consultant role. Cheapest check first;
+        // it short-circuits every non-consultant without touching the database.
+        if (!roles.Contains(ConsultantRole, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Rule 2 + first half of Rule 3 — account must be Active and we grab the
+        // verification marker in the same round-trip.
+        var snapshot = await db.Users
+            .AsNoTracking()
+            .Where(u => u.Id == userId)
+            .Select(u => new
+            {
+                u.AccountStatus,
+                ConsultantVerifiedAt = u.Profile != null ? u.Profile.ConsultantVerifiedAt : null,
+            })
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (snapshot is null || snapshot.AccountStatus != AccountStatus.Active)
+        {
+            return false;
+        }
+
+        // Rule 3a — the official verification marker (set by the seeders and by
+        // both admin approval paths). This is the canonical signal.
+        if (snapshot.ConsultantVerifiedAt is not null)
+        {
+            return true;
+        }
+
+        // Rule 3b — fallback for accounts approved before the marker was written:
+        // an approved, non-deleted Consultant upgrade request is an equally valid
+        // approval signal, so historical data keeps working without a manual
+        // backfill.
+        return await db.UpgradeRequests
+            .AsNoTracking()
+            .AnyAsync(r => r.UserId == userId
+                        && r.Target == UpgradeTarget.Consultant
+                        && r.Status == UpgradeRequestStatus.Approved
+                        && !r.IsDeleted, ct)
+            .ConfigureAwait(false);
+    }
+}

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/RequestBooking/RequestBookingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/RequestBooking/RequestBookingCommandHandler.cs
@@ -16,17 +16,20 @@ public sealed class RequestBookingCommandHandler : IRequestHandler<RequestBookin
     private readonly ICurrentUserService _currentUser;
     private readonly IStripeService _stripeService;
     private readonly IPublisher _publisher;
+    private readonly IConsultantEligibilityService _consultantEligibility;
 
     public RequestBookingCommandHandler(
         IApplicationDbContext context,
         ICurrentUserService currentUser,
         IStripeService stripeService,
-        IPublisher publisher)
+        IPublisher publisher,
+        IConsultantEligibilityService consultantEligibility)
     {
         _context = context;
         _currentUser = currentUser;
         _stripeService = stripeService;
         _publisher = publisher;
+        _consultantEligibility = consultantEligibility;
     }
 
     public async Task<RequestBookingResult> Handle(RequestBookingCommand request, CancellationToken cancellationToken)
@@ -77,6 +80,15 @@ public sealed class RequestBookingCommandHandler : IRequestHandler<RequestBookin
         if (consultant is null)
         {
             throw new BookingDomainException("Consultant was not found.");
+        }
+
+        // A student may only book a genuinely eligible consultant (in-role,
+        // Active, verified/approved). This closes the direct-API path: the public
+        // marketplace already hides unverified consultants, but a crafted request
+        // could still target a stale/unapproved Consultant-role account by id.
+        if (!await _consultantEligibility.CanActAsConsultantAsync(request.ConsultantId, cancellationToken))
+        {
+            throw new BookingDomainException("This consultant is not available for booking.");
         }
 
         if (consultant.Profile is null)

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/UpdateAvailability/UpdateAvailabilityCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/UpdateAvailability/UpdateAvailabilityCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Exceptions;
@@ -11,11 +12,16 @@ public sealed class UpdateAvailabilityCommandHandler : IRequestHandler<UpdateAva
 {
     private readonly IApplicationDbContext _context;
     private readonly ICurrentUserService _currentUser;
+    private readonly IConsultantEligibilityService _consultantEligibility;
 
-    public UpdateAvailabilityCommandHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+    public UpdateAvailabilityCommandHandler(
+        IApplicationDbContext context,
+        ICurrentUserService currentUser,
+        IConsultantEligibilityService consultantEligibility)
     {
         _context = context;
         _currentUser = currentUser;
+        _consultantEligibility = consultantEligibility;
     }
 
     public async Task<Unit> Handle(UpdateAvailabilityCommand request, CancellationToken cancellationToken)
@@ -25,13 +31,18 @@ public sealed class UpdateAvailabilityCommandHandler : IRequestHandler<UpdateAva
             throw new UnauthorizedAccessException("User is not authenticated.");
         }
 
-        if (!_currentUser.IsInRole("Consultant"))
-        {
-            throw new UnauthorizedAccessException("Only consultants can update availability.");
-        }
-
         var consultantId = _currentUser.UserId
             ?? throw new UnauthorizedAccessException("Authenticated user id is missing.");
+
+        // Availability is a consultant-only capability, and holding the
+        // Consultant role is not enough — the account must be a verified/approved
+        // consultant. Without this, a stale Consultant role would let a student
+        // publish availability and surface themselves in the marketplace.
+        if (!await _consultantEligibility.CanActAsConsultantAsync(consultantId, cancellationToken))
+        {
+            throw new ForbiddenAccessException(
+                "Only verified consultants can manage availability. Your consultant access is not active.");
+        }
 
         var existingAvailabilities = await _context.Availabilities
             .Where(a => a.ConsultantId == consultantId && !a.IsDeleted && a.IsActive)

--- a/server/src/ScholarPath.Application/DependencyInjection.cs
+++ b/server/src/ScholarPath.Application/DependencyInjection.cs
@@ -3,6 +3,8 @@ using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using ScholarPath.Application.Common.Behaviors;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Common.Services;
 using ScholarPath.Application.ConsultantBookings.Services;
 
 namespace ScholarPath.Application;
@@ -31,6 +33,10 @@ public static class DependencyInjection
 
         // Consultant booking services
         services.AddScoped<RefundCalculatorService>();
+
+        // Central business rule: who may act as a Consultant (role switch,
+        // availability management, marketplace visibility all defer to this).
+        services.AddScoped<IConsultantEligibilityService, ConsultantEligibilityService>();
 
         return services;
     }

--- a/server/src/ScholarPath.Infrastructure/Services/ConsultantReadService.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/ConsultantReadService.cs
@@ -62,6 +62,21 @@ public sealed class ConsultantReadService(
             return Array.Empty<ConsultantSummaryDto>();
         }
 
+        // Being in the Consultant role + Active is not enough to be *listed*:
+        // the marketplace must only surface verified/approved consultants (same
+        // rule as IConsultantEligibilityService). Keep those with the official
+        // verification marker or an approved consultant upgrade request.
+        var upgradeApprovedIds = await LoadApprovedConsultantUpgradeIdsAsync(
+            consultants.Select(c => c.Id).ToList(), ct).ConfigureAwait(false);
+        consultants = consultants
+            .Where(c => c.Profile?.ConsultantVerifiedAt != null || upgradeApprovedIds.Contains(c.Id))
+            .ToList();
+
+        if (consultants.Count == 0)
+        {
+            return Array.Empty<ConsultantSummaryDto>();
+        }
+
         var ids = consultants.Select(c => c.Id).ToList();
         var ratings = await LoadRatingAggregatesAsync(ids, ct).ConfigureAwait(false);
         var completed = await LoadCompletedCountsAsync(ids, ct).ConfigureAwait(false);
@@ -124,6 +139,15 @@ public sealed class ConsultantReadService(
             return null;
         }
 
+        // Only verified/approved consultants are publicly viewable (same rule as
+        // IConsultantEligibilityService) — an unapproved Consultant-role account
+        // must 404 here just as it is absent from Browse.
+        if (consultant.Profile?.ConsultantVerifiedAt is null
+            && !await HasApprovedConsultantUpgradeAsync(consultantId, ct).ConfigureAwait(false))
+        {
+            return null;
+        }
+
         var ids = new List<Guid> { consultantId };
         var ratings = await LoadRatingAggregatesAsync(ids, ct).ConfigureAwait(false);
         var completed = await LoadCompletedCountsAsync(ids, ct).ConfigureAwait(false);
@@ -179,18 +203,30 @@ public sealed class ConsultantReadService(
     public async Task<IReadOnlyList<BookableSlotDto>?> GetConsultantOpenSlotsAsync(
         Guid consultantId, CancellationToken ct)
     {
-        var isConsultant = await (
+        var eligibility = await (
                 from u in db.Users.AsNoTracking()
                 join ur in db.UserRoles on u.Id equals ur.UserId
                 join r in db.Roles on ur.RoleId equals r.Id
                 where r.Name == ConsultantRole
                       && u.Id == consultantId
                       && u.AccountStatus == AccountStatus.Active
-                select u.Id)
-            .AnyAsync(ct)
+                select new
+                {
+                    HasVerificationMarker = u.Profile != null && u.Profile.ConsultantVerifiedAt != null,
+                })
+            .FirstOrDefaultAsync(ct)
             .ConfigureAwait(false);
 
-        if (!isConsultant)
+        // Not an active Consultant-role account at all → not a marketplace entity.
+        if (eligibility is null)
+        {
+            return null;
+        }
+
+        // In the role + active, but not yet verified/approved → no bookable slots
+        // are exposed publicly (same rule as IConsultantEligibilityService).
+        if (!eligibility.HasVerificationMarker
+            && !await HasApprovedConsultantUpgradeAsync(consultantId, ct).ConfigureAwait(false))
         {
             return null;
         }
@@ -401,6 +437,41 @@ public sealed class ConsultantReadService(
             yield return (slotStart, slotStart + session);
         }
     }
+
+    // ── Consultant eligibility (marketplace visibility) ─────────────────────────
+
+    /// <summary>
+    /// Of the supplied user ids, returns those with an approved, non-deleted
+    /// Consultant upgrade request — the fallback approval signal for accounts
+    /// that predate the <c>ConsultantVerifiedAt</c> marker. Mirrors
+    /// <see cref="Application.Common.Interfaces.IConsultantEligibilityService"/>.
+    /// </summary>
+    private async Task<HashSet<Guid>> LoadApprovedConsultantUpgradeIdsAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct)
+    {
+        var ids = await db.UpgradeRequests
+            .AsNoTracking()
+            .Where(r => userIds.Contains(r.UserId)
+                        && r.Target == UpgradeTarget.Consultant
+                        && r.Status == UpgradeRequestStatus.Approved
+                        && !r.IsDeleted)
+            .Select(r => r.UserId)
+            .Distinct()
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return ids.ToHashSet();
+    }
+
+    /// <summary>Single-user variant of the approved-upgrade eligibility check.</summary>
+    private async Task<bool> HasApprovedConsultantUpgradeAsync(Guid userId, CancellationToken ct) =>
+        await db.UpgradeRequests
+            .AsNoTracking()
+            .AnyAsync(r => r.UserId == userId
+                        && r.Target == UpgradeTarget.Consultant
+                        && r.Status == UpgradeRequestStatus.Approved
+                        && !r.IsDeleted, ct)
+            .ConfigureAwait(false);
 
     // ── Aggregate loaders (batched, no N+1) ─────────────────────────────────────
 

--- a/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/AcceptBookingEndpointTests.cs
+++ b/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/AcceptBookingEndpointTests.cs
@@ -81,6 +81,10 @@ public sealed class AcceptBookingEndpointTests : IntegrationTestBase
             }
 
             await db.SaveChangesAsync();
+
+            // RequestBooking now requires the target to be a verified/approved
+            // consultant — make the seeded consultant genuinely eligible.
+            await EnsureEligibleConsultantAsync(sp, consultantId);
         });
 
         var requestBooking = new RequestBookingCommand(

--- a/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/CancelBookingEndpointTests.cs
+++ b/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/CancelBookingEndpointTests.cs
@@ -81,6 +81,10 @@ public sealed class CancelBookingEndpointTests : IntegrationTestBase
             }
 
             await db.SaveChangesAsync();
+
+            // RequestBooking now requires the target to be a verified/approved
+            // consultant — make the seeded consultant genuinely eligible.
+            await EnsureEligibleConsultantAsync(sp, consultantId);
         });
 
         var requestBooking = new RequestBookingCommand(

--- a/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/RejectBookingEndpointTests.cs
+++ b/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/RejectBookingEndpointTests.cs
@@ -81,6 +81,10 @@ public sealed class RejectBookingEndpointTests : IntegrationTestBase
             }
 
             await db.SaveChangesAsync();
+
+            // RequestBooking now requires the target to be a verified/approved
+            // consultant — make the seeded consultant genuinely eligible.
+            await EnsureEligibleConsultantAsync(sp, consultantId);
         });
 
         var requestBooking = new RequestBookingCommand(

--- a/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/RequestBookingEndpointTests.cs
+++ b/server/tests/ScholarPath.IntegrationTests/ConsultantBookings/RequestBookingEndpointTests.cs
@@ -81,6 +81,10 @@ public sealed class RequestBookingEndpointTests : IntegrationTestBase
             }
 
             await db.SaveChangesAsync();
+
+            // RequestBooking now requires the target to be a verified/approved
+            // consultant — make the seeded consultant genuinely eligible.
+            await EnsureEligibleConsultantAsync(sp, consultantId);
         });
 
         var command = new RequestBookingCommand(

--- a/server/tests/ScholarPath.IntegrationTests/IntegrationTestBase.cs
+++ b/server/tests/ScholarPath.IntegrationTests/IntegrationTestBase.cs
@@ -1,5 +1,9 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Infrastructure.Persistence;
 
 namespace ScholarPath.IntegrationTests;
 
@@ -39,4 +43,45 @@ public abstract class IntegrationTestBase
 
     protected static TestCurrentUserService GetCurrentUser(IServiceProvider sp) =>
         sp.GetRequiredService<TestCurrentUserService>();
+
+    /// <summary>
+    /// Makes a seeded consultant a genuinely eligible consultant: ensures the
+    /// <c>Consultant</c> Identity role exists, adds the user to it, and stamps
+    /// <see cref="UserProfile.ConsultantVerifiedAt"/>. Required now that
+    /// <c>RequestBooking</c> (and the marketplace / availability paths) reject
+    /// consultants who are not verified/approved. Idempotent.
+    /// </summary>
+    protected static async Task EnsureEligibleConsultantAsync(IServiceProvider sp, Guid consultantId)
+    {
+        var db = sp.GetRequiredService<ApplicationDbContext>();
+
+        var role = await db.Roles.FirstOrDefaultAsync(r => r.NormalizedName == "CONSULTANT");
+        if (role is null)
+        {
+            role = new ApplicationRole
+            {
+                Id = Guid.NewGuid(),
+                Name = "Consultant",
+                NormalizedName = "CONSULTANT",
+                ConcurrencyStamp = Guid.NewGuid().ToString(),
+            };
+            db.Roles.Add(role);
+            await db.SaveChangesAsync();
+        }
+
+        var alreadyInRole = await db.UserRoles
+            .AnyAsync(ur => ur.UserId == consultantId && ur.RoleId == role.Id);
+        if (!alreadyInRole)
+        {
+            db.UserRoles.Add(new IdentityUserRole<Guid> { UserId = consultantId, RoleId = role.Id });
+        }
+
+        var profile = await db.UserProfiles.FirstOrDefaultAsync(p => p.UserId == consultantId);
+        if (profile is not null)
+        {
+            profile.ConsultantVerifiedAt ??= DateTimeOffset.UtcNow;
+        }
+
+        await db.SaveChangesAsync();
+    }
 }

--- a/server/tests/ScholarPath.UnitTests/Admin/ReviewOnboardingRoleGrantTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Admin/ReviewOnboardingRoleGrantTests.cs
@@ -59,6 +59,47 @@ public class ReviewOnboardingRoleGrantTests
     }
 
     [Fact]
+    public async Task Approving_direct_consultant_onboarding_sets_verification_marker()
+    {
+        using var db = CreateDb();
+        var userId = SeedPendingUser(db, "Consultant");
+        db.UserProfiles.Add(new UserProfile { UserId = userId });
+        await db.SaveChangesAsync();
+
+        var admin = Substitute.For<IUserAdministration>();
+        admin.SetAccountStatusAsync(userId, AccountStatus.Active,
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await Sut(db, admin).Handle(
+            new ReviewOnboardingCommand(userId, OnboardingDecision.Approve, null), default);
+
+        await admin.Received().AddRoleAsync(userId, "Consultant", Arg.Any<CancellationToken>());
+        var profile = await db.UserProfiles.FirstAsync(p => p.UserId == userId);
+        profile.ConsultantVerifiedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Approving_company_onboarding_does_not_set_consultant_marker()
+    {
+        using var db = CreateDb();
+        var userId = SeedPendingUser(db, "Company");
+        db.UserProfiles.Add(new UserProfile { UserId = userId });
+        await db.SaveChangesAsync();
+
+        var admin = Substitute.For<IUserAdministration>();
+        admin.SetAccountStatusAsync(userId, AccountStatus.Active,
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await Sut(db, admin).Handle(
+            new ReviewOnboardingCommand(userId, OnboardingDecision.Approve, null), default);
+
+        var profile = await db.UserProfiles.FirstAsync(p => p.UserId == userId);
+        profile.ConsultantVerifiedAt.Should().BeNull();
+    }
+
+    [Fact]
     public async Task Rejection_does_not_grant_a_role()
     {
         using var db = CreateDb();

--- a/server/tests/ScholarPath.UnitTests/Admin/ReviewUpgradeRequestConsultantMarkerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Admin/ReviewUpgradeRequestConsultantMarkerTests.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Admin.Commands.ReviewUpgradeRequest;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.Admin;
+
+/// <summary>
+/// Approving a Consultant upgrade must grant the role AND stamp the official
+/// verification marker (<see cref="UserProfile.ConsultantVerifiedAt"/>) so the
+/// user passes consultant eligibility. Company upgrades leave it untouched.
+/// </summary>
+public sealed class ReviewUpgradeRequestConsultantMarkerTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly DateTimeOffset _now = new(2026, 7, 1, 10, 0, 0, TimeSpan.Zero);
+
+    public ReviewUpgradeRequestConsultantMarkerTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+    }
+
+    private ReviewUpgradeRequestCommandHandler Sut(IUserAdministration admin)
+    {
+        var clock = Substitute.For<IDateTimeService>();
+        clock.UtcNow.Returns(_now);
+        var currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserId.Returns(Guid.NewGuid());
+        return new ReviewUpgradeRequestCommandHandler(
+            _db, admin, currentUser, clock,
+            Substitute.For<INotificationDispatcher>(),
+            NullLogger<ReviewUpgradeRequestCommandHandler>.Instance);
+    }
+
+    private Guid SeedUserWithProfile()
+    {
+        var id = Guid.NewGuid();
+        _db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Omar",
+            LastName = "Khalil",
+            Email = $"{id:N}@test.local",
+            UserName = $"{id:N}@test.local",
+            AccountStatus = AccountStatus.Active,
+            Profile = new UserProfile { UserId = id },
+        });
+        _db.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedPendingRequest(Guid userId, UpgradeTarget target)
+    {
+        var reqId = Guid.NewGuid();
+        _db.UpgradeRequests.Add(new UpgradeRequest
+        {
+            Id = reqId,
+            UserId = userId,
+            Target = target,
+            Status = UpgradeRequestStatus.Pending,
+            CreatedAt = _now.AddDays(-1),
+        });
+        _db.SaveChanges();
+        return reqId;
+    }
+
+    [Fact]
+    public async Task Approving_consultant_upgrade_sets_verification_marker()
+    {
+        var userId = SeedUserWithProfile();
+        var reqId = SeedPendingRequest(userId, UpgradeTarget.Consultant);
+        var admin = Substitute.For<IUserAdministration>();
+
+        await Sut(admin).Handle(
+            new ReviewUpgradeRequestCommand(reqId, UpgradeDecision.Approve, null), default);
+
+        await admin.Received().AddRoleAsync(userId, "Consultant", Arg.Any<CancellationToken>());
+        var profile = await _db.UserProfiles.FirstAsync(p => p.UserId == userId);
+        profile.ConsultantVerifiedAt.Should().Be(_now);
+    }
+
+    [Fact]
+    public async Task Approving_consultant_upgrade_creates_profile_if_missing()
+    {
+        var id = Guid.NewGuid();
+        _db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "No",
+            LastName = "Profile",
+            Email = $"{id:N}@test.local",
+            UserName = $"{id:N}@test.local",
+            AccountStatus = AccountStatus.Active,
+        });
+        _db.SaveChanges();
+        var reqId = SeedPendingRequest(id, UpgradeTarget.Consultant);
+
+        await Sut(Substitute.For<IUserAdministration>()).Handle(
+            new ReviewUpgradeRequestCommand(reqId, UpgradeDecision.Approve, null), default);
+
+        var profile = await _db.UserProfiles.FirstOrDefaultAsync(p => p.UserId == id);
+        profile.Should().NotBeNull();
+        profile!.ConsultantVerifiedAt.Should().Be(_now);
+    }
+
+    [Fact]
+    public async Task Approving_company_upgrade_does_not_set_consultant_marker()
+    {
+        var userId = SeedUserWithProfile();
+        var reqId = SeedPendingRequest(userId, UpgradeTarget.Company);
+
+        await Sut(Substitute.For<IUserAdministration>()).Handle(
+            new ReviewUpgradeRequestCommand(reqId, UpgradeDecision.Approve, null), default);
+
+        var profile = await _db.UserProfiles.FirstAsync(p => p.UserId == userId);
+        profile.ConsultantVerifiedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Rejecting_consultant_upgrade_does_not_set_marker()
+    {
+        var userId = SeedUserWithProfile();
+        var reqId = SeedPendingRequest(userId, UpgradeTarget.Consultant);
+
+        await Sut(Substitute.For<IUserAdministration>()).Handle(
+            new ReviewUpgradeRequestCommand(reqId, UpgradeDecision.Reject, "Insufficient evidence"), default);
+
+        var profile = await _db.UserProfiles.FirstAsync(p => p.UserId == userId);
+        profile.ConsultantVerifiedAt.Should().BeNull();
+    }
+
+    public void Dispose() => _db.Dispose();
+}

--- a/server/tests/ScholarPath.UnitTests/Auth/LoginCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Auth/LoginCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using ScholarPath.Application.Auth.Commands.Login;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Common.Services;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Interfaces;
@@ -38,7 +39,9 @@ public sealed class LoginCommandHandlerTests : IDisposable
         _userAdmin.GetRolesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<string>());
 
-        _handler = new LoginCommandHandler(_db, _hasher, _tokens, _userAdmin, _clock);
+        _handler = new LoginCommandHandler(
+            _db, _hasher, _tokens, _userAdmin,
+            new ConsultantEligibilityService(_db, _userAdmin), _clock);
     }
 
     private async Task<ApplicationUser> SeedUserAsync()

--- a/server/tests/ScholarPath.UnitTests/Auth/SelectRoleCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Auth/SelectRoleCommandHandlerTests.cs
@@ -41,7 +41,9 @@ public class SelectRoleCommandHandlerTests
     private static SelectRoleCommandHandler Sut(
         ApplicationDbContext db, Guid userId, IUserAdministration admin,
         INotificationDispatcher? notifications = null) =>
-        new(db, CurrentUser(userId), admin, TokenService(),
+        new(db, CurrentUser(userId), admin,
+            Substitute.For<IConsultantEligibilityService>(),
+            TokenService(),
             notifications ?? Substitute.For<INotificationDispatcher>(),
             NullLogger<SelectRoleCommandHandler>.Instance);
 

--- a/server/tests/ScholarPath.UnitTests/Auth/SwitchRoleCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Auth/SwitchRoleCommandHandlerTests.cs
@@ -1,0 +1,163 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using ScholarPath.Application.Auth.Commands.SwitchRole;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Common.Services;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.Auth;
+
+/// <summary>
+/// Covers <see cref="SwitchRoleCommandHandler"/> — in particular the consultant
+/// eligibility gate: switching to the Consultant role requires verified/approved
+/// consultant status, not merely a Consultant role row.
+/// </summary>
+public sealed class SwitchRoleCommandHandlerTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+
+    public SwitchRoleCommandHandlerTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+    }
+
+    private static ICurrentUserService CurrentUser(Guid? id)
+    {
+        var u = Substitute.For<ICurrentUserService>();
+        u.UserId.Returns(id);
+        return u;
+    }
+
+    private static IUserAdministration Admin(params string[] roles)
+    {
+        var a = Substitute.For<IUserAdministration>();
+        a.GetRolesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(roles);
+        return a;
+    }
+
+    private static ITokenService Tokens()
+    {
+        var t = Substitute.For<ITokenService>();
+        t.IssueTokens(Arg.Any<ApplicationUser>(), Arg.Any<IEnumerable<string>>(),
+                Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(new TokenPair("access", "refresh",
+                DateTimeOffset.UtcNow.AddHours(1), DateTimeOffset.UtcNow.AddDays(7)));
+        return t;
+    }
+
+    private SwitchRoleCommandHandler Sut(Guid? userId, IUserAdministration admin, ITokenService tokens) =>
+        new(_db, CurrentUser(userId), admin, new ConsultantEligibilityService(_db, admin), tokens);
+
+    private Guid SeedUser(
+        string activeRole = "Student",
+        AccountStatus status = AccountStatus.Active,
+        DateTimeOffset? consultantVerifiedAt = null)
+    {
+        var id = Guid.NewGuid();
+        _db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Alaa",
+            LastName = "Mostafa",
+            Email = $"{id:N}@test.local",
+            UserName = $"{id:N}@test.local",
+            AccountStatus = status,
+            ActiveRole = activeRole,
+            Profile = new UserProfile { UserId = id, ConsultantVerifiedAt = consultantVerifiedAt },
+        });
+        _db.SaveChanges();
+        return id;
+    }
+
+    private void SeedApprovedConsultantUpgrade(Guid userId)
+    {
+        _db.UpgradeRequests.Add(new UpgradeRequest
+        {
+            UserId = userId,
+            Target = UpgradeTarget.Consultant,
+            Status = UpgradeRequestStatus.Approved,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-2),
+        });
+        _db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task Student_without_consultant_role_cannot_switch_to_consultant()
+    {
+        var id = SeedUser();
+
+        var act = () => Sut(id, Admin("Student"), Tokens())
+            .Handle(new SwitchRoleCommand("Consultant"), default);
+
+        await act.Should().ThrowAsync<ForbiddenAccessException>()
+            .WithMessage("*do not hold*");
+    }
+
+    [Fact]
+    public async Task Consultant_role_without_verification_cannot_switch_to_consultant()
+    {
+        // The reported bug: a student holds a Consultant role row but never had an
+        // approved upgrade and carries no verification marker.
+        var id = SeedUser(consultantVerifiedAt: null);
+
+        var act = () => Sut(id, Admin("Student", "Consultant"), Tokens())
+            .Handle(new SwitchRoleCommand("Consultant"), default);
+
+        await act.Should().ThrowAsync<ForbiddenAccessException>()
+            .WithMessage("*approved*");
+
+        (await _db.Users.FirstAsync(u => u.Id == id)).ActiveRole.Should().Be("Student");
+    }
+
+    [Fact]
+    public async Task Verified_consultant_can_switch_to_consultant()
+    {
+        var id = SeedUser(consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-20));
+        var tokens = Tokens();
+
+        var result = await Sut(id, Admin("Student", "Consultant"), tokens)
+            .Handle(new SwitchRoleCommand("Consultant"), default);
+
+        result.User.ActiveRole.Should().Be("Consultant");
+        result.User.CanActAsConsultant.Should().BeTrue();
+        (await _db.Users.FirstAsync(u => u.Id == id)).ActiveRole.Should().Be("Consultant");
+        await tokens.Received().RevokeAllForUserAsync(id, Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Consultant_approved_via_upgrade_can_switch_to_consultant()
+    {
+        var id = SeedUser(consultantVerifiedAt: null);
+        SeedApprovedConsultantUpgrade(id);
+
+        var result = await Sut(id, Admin("Student", "Consultant"), Tokens())
+            .Handle(new SwitchRoleCommand("Consultant"), default);
+
+        result.User.ActiveRole.Should().Be("Consultant");
+        result.User.CanActAsConsultant.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Switching_to_a_non_consultant_role_is_not_gated()
+    {
+        // A verified consultant switching back to Student must always work.
+        var id = SeedUser(activeRole: "Consultant",
+            consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-20));
+
+        var result = await Sut(id, Admin("Student", "Consultant"), Tokens())
+            .Handle(new SwitchRoleCommand("Student"), default);
+
+        result.User.ActiveRole.Should().Be("Student");
+    }
+
+    public void Dispose() => _db.Dispose();
+}

--- a/server/tests/ScholarPath.UnitTests/Common/ConsultantEligibilityServiceTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Common/ConsultantEligibilityServiceTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Common.Services;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.Common;
+
+/// <summary>
+/// Covers <see cref="ConsultantEligibilityService"/> — the single business rule
+/// that decides whether a user may act as a Consultant. Holding the Consultant
+/// role is necessary but never sufficient: the account must also be Active and
+/// carry an approval signal (verification marker OR approved upgrade request).
+/// </summary>
+public sealed class ConsultantEligibilityServiceTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+
+    public ConsultantEligibilityServiceTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+    }
+
+    private static IUserAdministration Admin(params string[] roles)
+    {
+        var a = Substitute.For<IUserAdministration>();
+        a.GetRolesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(roles);
+        return a;
+    }
+
+    private ConsultantEligibilityService Sut(IUserAdministration admin) => new(_db, admin);
+
+    private Guid SeedUser(
+        AccountStatus status = AccountStatus.Active,
+        DateTimeOffset? consultantVerifiedAt = null)
+    {
+        var id = Guid.NewGuid();
+        _db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Test",
+            LastName = "User",
+            Email = $"{id:N}@test.local",
+            UserName = $"{id:N}@test.local",
+            AccountStatus = status,
+            Profile = new UserProfile
+            {
+                UserId = id,
+                ConsultantVerifiedAt = consultantVerifiedAt,
+            },
+        });
+        _db.SaveChanges();
+        return id;
+    }
+
+    private void SeedApprovedConsultantUpgrade(Guid userId, bool deleted = false)
+    {
+        _db.UpgradeRequests.Add(new UpgradeRequest
+        {
+            UserId = userId,
+            Target = UpgradeTarget.Consultant,
+            Status = UpgradeRequestStatus.Approved,
+            IsDeleted = deleted,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-3),
+        });
+        _db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task Student_only_account_cannot_act_as_consultant()
+    {
+        var id = SeedUser();
+
+        var result = await Sut(Admin("Student")).CanActAsConsultantAsync(id, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Consultant_role_without_marker_or_approval_cannot_act()
+    {
+        // The exact bug: a Consultant role row but no verification and no
+        // approved upgrade request.
+        var id = SeedUser(consultantVerifiedAt: null);
+
+        var result = await Sut(Admin("Student", "Consultant"))
+            .CanActAsConsultantAsync(id, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Consultant_with_verification_marker_can_act()
+    {
+        var id = SeedUser(consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-10));
+
+        var result = await Sut(Admin("Consultant"))
+            .CanActAsConsultantAsync(id, CancellationToken.None);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Consultant_with_approved_upgrade_but_no_marker_can_act()
+    {
+        var id = SeedUser(consultantVerifiedAt: null);
+        SeedApprovedConsultantUpgrade(id);
+
+        var result = await Sut(Admin("Student", "Consultant"))
+            .CanActAsConsultantAsync(id, CancellationToken.None);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Soft_deleted_approved_upgrade_does_not_count()
+    {
+        var id = SeedUser(consultantVerifiedAt: null);
+        SeedApprovedConsultantUpgrade(id, deleted: true);
+
+        var result = await Sut(Admin("Consultant"))
+            .CanActAsConsultantAsync(id, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(AccountStatus.Suspended)]
+    [InlineData(AccountStatus.Deactivated)]
+    [InlineData(AccountStatus.PendingApproval)]
+    public async Task Non_active_verified_consultant_cannot_act(AccountStatus status)
+    {
+        var id = SeedUser(status: status, consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-10));
+
+        var result = await Sut(Admin("Consultant"))
+            .CanActAsConsultantAsync(id, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Overload_with_prefetched_roles_skips_role_lookup()
+    {
+        var id = SeedUser(consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-10));
+        var admin = Admin("Consultant");
+
+        var result = await Sut(admin).CanActAsConsultantAsync(
+            id, new[] { "Consultant" }, CancellationToken.None);
+
+        result.Should().BeTrue();
+        await admin.DidNotReceive().GetRolesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    public void Dispose() => _db.Dispose();
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingQueryHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingQueryHandlerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Application.ConsultantBookings.Commands.UpdateAvailability;
 using ScholarPath.Application.ConsultantBookings.Queries.GetBookingById;
 using ScholarPath.Application.ConsultantBookings.Queries.GetConsultantBookings;
@@ -367,7 +368,13 @@ public sealed class BookingQueryHandlerTests : IDisposable
         _currentUser.IsInRole("Consultant").Returns(true);
         _currentUser.UserId.Returns(_consultantId);
 
-        var update = new UpdateAvailabilityCommandHandler(_db, _currentUser);
+        // Eligibility is covered by UpdateAvailabilityCommandHandlerTests; this
+        // test only exercises the multi-slot round-trip, so treat the consultant
+        // as eligible.
+        var eligibility = Substitute.For<IConsultantEligibilityService>();
+        eligibility.CanActAsConsultantAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        var update = new UpdateAvailabilityCommandHandler(_db, _currentUser, eligibility);
         await update.Handle(
             new UpdateAvailabilityCommand(
                 ReplaceExisting: true,

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantReadServiceTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantReadServiceTests.cs
@@ -61,7 +61,8 @@ public sealed class ConsultantReadServiceTests : IDisposable
         int? durationMinutes = 45,
         string? expertiseJson = null,
         string? languagesJson = null,
-        string? bio = "Helps students with scholarships.")
+        string? bio = "Helps students with scholarships.",
+        bool verified = true)
     {
         var id = Guid.NewGuid();
         var email = $"c-{id:N}@test.com";
@@ -81,6 +82,10 @@ public sealed class ConsultantReadServiceTests : IDisposable
                 SessionDurationMinutes = durationMinutes,
                 ExpertiseTagsJson = expertiseJson,
                 LanguagesJson = languagesJson,
+                // Marketplace visibility requires the official verification
+                // marker (PB-006 / consultant-eligibility). Seed it by default so
+                // the pre-existing projection tests still surface the consultant.
+                ConsultantVerifiedAt = verified ? Now.AddDays(-30) : null,
             },
         });
 
@@ -112,6 +117,18 @@ public sealed class ConsultantReadServiceTests : IDisposable
         });
         _db.SaveChanges();
         return id;
+    }
+
+    private void SeedApprovedConsultantUpgrade(Guid userId)
+    {
+        _db.UpgradeRequests.Add(new UpgradeRequest
+        {
+            UserId = userId,
+            Target = UpgradeTarget.Consultant,
+            Status = UpgradeRequestStatus.Approved,
+            CreatedAt = Now.AddDays(-5),
+        });
+        _db.SaveChanges();
     }
 
     private void SeedReview(Guid consultantId, Guid studentId, int rating, bool hidden = false)
@@ -282,6 +299,32 @@ public sealed class ConsultantReadServiceTests : IDisposable
         result.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task Browse_ExcludesActiveConsultantWithoutVerificationMarker()
+    {
+        // An active user in the Consultant role but with no verification marker
+        // and no approved upgrade must NOT appear in the public marketplace.
+        SeedConsultant(first: "Unverified", verified: false);
+
+        var result = await _service.BrowseConsultantsAsync(CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Browse_IncludesConsultantVerifiedByApprovedUpgrade()
+    {
+        // No ConsultantVerifiedAt marker, but an approved consultant upgrade
+        // request is an equally valid approval signal (historical accounts).
+        var consultant = SeedConsultant(first: "ByUpgrade", verified: false);
+        SeedApprovedConsultantUpgrade(consultant);
+
+        var result = await _service.BrowseConsultantsAsync(CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be(consultant);
+    }
+
     // ── GetConsultantDetailAsync ────────────────────────────────────────────────
 
     [Fact]
@@ -300,6 +343,16 @@ public sealed class ConsultantReadServiceTests : IDisposable
         var suspended = SeedConsultant(status: AccountStatus.Suspended);
 
         var result = await _service.GetConsultantDetailAsync(suspended, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Detail_ReturnsNull_WhenConsultantIsNotVerified()
+    {
+        var unverified = SeedConsultant(verified: false);
+
+        var result = await _service.GetConsultantDetailAsync(unverified, CancellationToken.None);
 
         result.Should().BeNull();
     }
@@ -364,6 +417,20 @@ public sealed class ConsultantReadServiceTests : IDisposable
 
         result.Should().NotBeNull();
         result!.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OpenSlots_ReturnsNull_WhenConsultantIsNotVerified()
+    {
+        // Even with saved availability, an unverified consultant exposes no
+        // bookable slots to the public.
+        var unverified = SeedConsultant(verified: false);
+        SeedRecurringAvailability(unverified, DayOfWeek.Tuesday,
+            new TimeOnly(16, 0), new TimeOnly(17, 0));
+
+        var result = await _service.GetConsultantOpenSlotsAsync(unverified, CancellationToken.None);
+
+        result.Should().BeNull();
     }
 
     [Fact]

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/RequestBookingEligibilityTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/RequestBookingEligibilityTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Common.Services;
+using ScholarPath.Application.ConsultantBookings.Commands.RequestBooking;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Exceptions;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.ConsultantBookings;
+
+/// <summary>
+/// A student may only book a consultant who is truly eligible (in-role, Active,
+/// verified/approved) — this guards the direct-API booking path against a
+/// stale/unapproved Consultant-role account that the marketplace already hides.
+/// </summary>
+public sealed class RequestBookingEligibilityTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IStripeService _stripe = Substitute.For<IStripeService>();
+    private readonly IPublisher _publisher = Substitute.For<IPublisher>();
+    private readonly Guid _studentId = Guid.NewGuid();
+    private readonly Guid _consultantId = Guid.NewGuid();
+
+    public RequestBookingEligibilityTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        _currentUser.IsAuthenticated.Returns(true);
+        _currentUser.IsInRole("Student").Returns(true);
+        _currentUser.UserId.Returns(_studentId);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static IUserAdministration Admin(params string[] roles)
+    {
+        var a = Substitute.For<IUserAdministration>();
+        a.GetRolesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(roles);
+        return a;
+    }
+
+    private void SeedConsultant(DateTimeOffset? consultantVerifiedAt)
+    {
+        _db.Users.Add(new ApplicationUser
+        {
+            Id = _consultantId,
+            FirstName = "Sarah",
+            LastName = "Adel",
+            Email = "c@test.local",
+            UserName = "c@test.local",
+            AccountStatus = AccountStatus.Active,
+            Profile = new UserProfile
+            {
+                UserId = _consultantId,
+                SessionFeeUsd = 0m,            // free path → no Stripe dependency
+                SessionDurationMinutes = null,
+                ConsultantVerifiedAt = consultantVerifiedAt,
+            },
+        });
+        _db.SaveChanges();
+    }
+
+    private RequestBookingCommand FutureBooking()
+    {
+        var start = DateTimeOffset.UtcNow.AddDays(2);
+        return new RequestBookingCommand(_consultantId, null, start, start.AddMinutes(45), "UTC", null);
+    }
+
+    private RequestBookingCommandHandler Sut(IUserAdministration admin) =>
+        new(_db, _currentUser, _stripe, _publisher, new ConsultantEligibilityService(_db, admin));
+
+    [Fact]
+    public async Task Booking_an_unverified_consultant_is_rejected()
+    {
+        // In the Consultant role but no verification marker / approved upgrade.
+        SeedConsultant(consultantVerifiedAt: null);
+
+        var act = () => Sut(Admin("Consultant")).Handle(FutureBooking(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<BookingDomainException>().WithMessage("*not available*");
+        _db.Bookings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Booking_a_consultant_without_the_role_is_rejected()
+    {
+        // Even with a verification marker, a user not actually in the Consultant
+        // role is not bookable.
+        SeedConsultant(consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-10));
+
+        var act = () => Sut(Admin("Student")).Handle(FutureBooking(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<BookingDomainException>().WithMessage("*not available*");
+        _db.Bookings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Booking_a_verified_consultant_succeeds()
+    {
+        SeedConsultant(consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-30));
+
+        var result = await Sut(Admin("Consultant")).Handle(FutureBooking(), CancellationToken.None);
+
+        result.BookingId.Should().NotBeEmpty();
+        _db.Bookings.Should().ContainSingle();
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/RequestBookingMasterSwitchTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/RequestBookingMasterSwitchTests.cs
@@ -26,6 +26,8 @@ public sealed class RequestBookingMasterSwitchTests : IDisposable
     private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
     private readonly IStripeService _stripe = Substitute.For<IStripeService>();
     private readonly IPublisher _publisher = Substitute.For<IPublisher>();
+    private readonly IConsultantEligibilityService _eligibility =
+        Substitute.For<IConsultantEligibilityService>();
     private readonly Guid _studentId = Guid.NewGuid();
     private readonly Guid _consultantId = Guid.NewGuid();
 
@@ -39,6 +41,11 @@ public sealed class RequestBookingMasterSwitchTests : IDisposable
         _currentUser.IsAuthenticated.Returns(true);
         _currentUser.IsInRole("Student").Returns(true);
         _currentUser.UserId.Returns(_studentId);
+
+        // Eligibility is covered by RequestBookingEligibilityTests; these tests
+        // focus on the payments master switch, so treat the consultant as eligible.
+        _eligibility.CanActAsConsultantAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(true);
     }
 
     public void Dispose() => _db.Dispose();
@@ -86,7 +93,7 @@ public sealed class RequestBookingMasterSwitchTests : IDisposable
     }
 
     private RequestBookingCommandHandler Sut() =>
-        new(_db, _currentUser, _stripe, _publisher);
+        new(_db, _currentUser, _stripe, _publisher, _eligibility);
 
     [Fact]
     public async Task Master_switch_off_makes_the_booking_free_and_never_calls_Stripe()

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/UpdateAvailabilityCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/UpdateAvailabilityCommandHandlerTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Common.Services;
+using ScholarPath.Application.ConsultantBookings.Commands.UpdateAvailability;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.ConsultantBookings;
+
+/// <summary>
+/// Covers the consultant-eligibility gate on <see cref="UpdateAvailabilityCommandHandler"/>:
+/// a Consultant role row is not enough — the account must be a verified/approved
+/// consultant to publish or edit availability.
+/// </summary>
+public sealed class UpdateAvailabilityCommandHandlerTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+
+    public UpdateAvailabilityCommandHandlerTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+    }
+
+    private static ICurrentUserService CurrentUser(Guid id)
+    {
+        var u = Substitute.For<ICurrentUserService>();
+        u.IsAuthenticated.Returns(true);
+        u.UserId.Returns(id);
+        u.IsInRole("Consultant").Returns(true);
+        return u;
+    }
+
+    private static IUserAdministration Admin(params string[] roles)
+    {
+        var a = Substitute.For<IUserAdministration>();
+        a.GetRolesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(roles);
+        return a;
+    }
+
+    private UpdateAvailabilityCommandHandler Sut(Guid userId, IUserAdministration admin) =>
+        new(_db, CurrentUser(userId), new ConsultantEligibilityService(_db, admin));
+
+    private Guid SeedConsultant(DateTimeOffset? consultantVerifiedAt)
+    {
+        var id = Guid.NewGuid();
+        _db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Hana",
+            LastName = "Farouk",
+            Email = $"{id:N}@test.local",
+            UserName = $"{id:N}@test.local",
+            AccountStatus = AccountStatus.Active,
+            Profile = new UserProfile { UserId = id, ConsultantVerifiedAt = consultantVerifiedAt },
+        });
+        _db.SaveChanges();
+        return id;
+    }
+
+    private static UpdateAvailabilityCommand OneRecurringSlot() => new(
+        ReplaceExisting: true,
+        Slots: new List<AvailabilityInputModel>
+        {
+            new(
+                IsRecurring: true,
+                DayOfWeek: DayOfWeek.Tuesday,
+                StartTime: new TimeOnly(16, 0),
+                EndTime: new TimeOnly(18, 0),
+                SpecificStartAt: null,
+                SpecificEndAt: null,
+                Timezone: "Africa/Cairo",
+                IsActive: true),
+        });
+
+    [Fact]
+    public async Task Unverified_consultant_role_cannot_update_availability()
+    {
+        var id = SeedConsultant(consultantVerifiedAt: null);
+
+        var act = () => Sut(id, Admin("Student", "Consultant"))
+            .Handle(OneRecurringSlot(), default);
+
+        await act.Should().ThrowAsync<ForbiddenAccessException>()
+            .WithMessage("*verified consultants*");
+
+        (await _db.Availabilities.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Verified_consultant_can_update_availability()
+    {
+        var id = SeedConsultant(consultantVerifiedAt: DateTimeOffset.UtcNow.AddDays(-20));
+
+        var result = await Sut(id, Admin("Consultant")).Handle(OneRecurringSlot(), default);
+
+        result.Should().Be(Unit.Value);
+        var saved = await _db.Availabilities.SingleAsync();
+        saved.ConsultantId.Should().Be(id);
+        saved.IsRecurring.Should().BeTrue();
+        saved.DayOfWeek.Should().Be(DayOfWeek.Tuesday);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_user_is_rejected()
+    {
+        var currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.IsAuthenticated.Returns(false);
+        var handler = new UpdateAvailabilityCommandHandler(
+            _db, currentUser, new ConsultantEligibilityService(_db, Admin()));
+
+        var act = () => handler.Handle(OneRecurringSlot(), default);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    public void Dispose() => _db.Dispose();
+}

--- a/sql/audit-consultant-eligibility.sql
+++ b/sql/audit-consultant-eligibility.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- Consultant eligibility audit + optional remediation
+-- ----------------------------------------------------------------------------
+-- Business rule (enforced in code by IConsultantEligibilityService):
+--   A user may act as a Consultant ONLY when ALL of the following hold:
+--     1. they hold the "Consultant" role,
+--     2. their account is Active, AND
+--     3. they carry an approval signal — either UserProfile.ConsultantVerifiedAt
+--        is set, OR they have an Approved (non-deleted) Consultant UpgradeRequest.
+--
+-- The application code now BLOCKS ineligible consultants at every entry point
+-- (role switch, availability management, public marketplace), so this script is
+-- NOT required for the fix to work — it is a diagnostic aid for ops.
+--
+-- STEP 1 is read-only: it lists Consultant-role accounts that are NOT eligible
+-- (the "stale / unapproved Consultant role" data the bug produced). Review the
+-- output before running any change.
+-- ============================================================================
+
+-- STEP 1 — DIAGNOSTIC (read-only): stale/unapproved Consultant-role accounts.
+SELECT  u.Id,
+        u.Email,
+        u.AccountStatus,
+        p.ConsultantVerifiedAt,
+        CASE WHEN EXISTS (
+                SELECT 1 FROM UpgradeRequests ur
+                WHERE ur.UserId = u.Id
+                  AND ur.Target = 1              -- UpgradeTarget.Consultant
+                  AND ur.Status = 1              -- UpgradeRequestStatus.Approved
+                  AND ur.IsDeleted = 0)
+             THEN 1 ELSE 0 END AS HasApprovedConsultantUpgrade
+FROM    AspNetUsers u
+        INNER JOIN AspNetUserRoles usr ON usr.UserId = u.Id
+        INNER JOIN AspNetRoles r       ON r.Id = usr.RoleId
+        LEFT  JOIN UserProfiles p      ON p.UserId = u.Id
+WHERE   r.Name = N'Consultant'
+        AND p.ConsultantVerifiedAt IS NULL
+        AND NOT EXISTS (
+                SELECT 1 FROM UpgradeRequests ur
+                WHERE ur.UserId = u.Id
+                  AND ur.Target = 1
+                  AND ur.Status = 1
+                  AND ur.IsDeleted = 0);
+
+-- ----------------------------------------------------------------------------
+-- STEP 2 — OPTIONAL remediation. Pick exactly ONE, only after reviewing STEP 1.
+--
+-- Option A (recommended, fail-closed): leave the rows as-is. The application
+--   already refuses to let these accounts act as consultants, and they will be
+--   verified the moment an admin approves them through the normal flow. No SQL
+--   change needed.
+--
+-- Option B (backfill markers for accounts you have confirmed ARE legitimate
+--   consultants, e.g. accounts that were verified out-of-band): stamp the
+--   marker so they immediately regain consultant capability. DO NOT run this
+--   blindly — it grants consultant capability to every listed row.
+--
+--   BEGIN TRAN;
+--       UPDATE p
+--          SET p.ConsultantVerifiedAt = SYSDATETIMEOFFSET()
+--       FROM  UserProfiles p
+--             INNER JOIN AspNetUserRoles usr ON usr.UserId = p.UserId
+--             INNER JOIN AspNetRoles r       ON r.Id = usr.RoleId
+--       WHERE r.Name = N'Consultant'
+--         AND p.ConsultantVerifiedAt IS NULL
+--         AND p.UserId IN ( /* explicit, reviewed user ids only */ );
+--   COMMIT;   -- verify @@ROWCOUNT first, ROLLBACK if unexpected.
+--
+-- Option C (revoke the stray role for accounts that should never have had it):
+--   remove the Consultant role membership entirely.
+--
+--   DELETE usr
+--   FROM   AspNetUserRoles usr
+--          INNER JOIN AspNetRoles r ON r.Id = usr.RoleId
+--   WHERE  r.Name = N'Consultant'
+--     AND  usr.UserId IN ( /* explicit, reviewed user ids only */ );
+-- ============================================================================


### PR DESCRIPTION
## What / Why

A Student holding a stale/unapproved `Consultant` role could switch to Consultant, publish availability, appear in the public consultant marketplace, and receive bookings — consultant capability was gated only on `AspNetUserRoles` membership, never on business approval. This PR introduces a single reusable eligibility rule and enforces it at every consultant entry point so a role row alone is no longer enough.

**Rule (`IConsultantEligibilityService.CanActAsConsultant`):** a user may act as a Consultant only when they (1) hold the `Consultant` role, (2) have an `Active` account, and (3) carry an approval signal — `UserProfile.ConsultantVerifiedAt` is set **or** they have an approved, non-deleted Consultant upgrade request.

Enforced in:
- **SwitchRole** — reject switching to Consultant unless eligible.
- **UpdateAvailability** — reject publishing/editing availability unless eligible.
- **ConsultantReadService** (browse / detail / open-slots) — only surface verified/approved consultants.
- **RequestBooking** — students can only book an eligible consultant (closes the direct-API path the marketplace filter alone doesn't cover).
- **Admin approval** (upgrade request + direct onboarding) — stamp `ConsultantVerifiedAt` so approval is a single atomic act.
- **Frontend** — the "switch to Consultant" option is gated on a backend-provided `canActAsConsultant` flag instead of the raw roles list.

## SRS traceability

- Epic: PB-006 (Consultant booking & marketplace)
- FRs: consultant onboarding/upgrade approval (FR-ONB-04 / FR-ONB-07), consultant booking intake (FR-094)
- User stories: Student → Consultant upgrade must be admin-approved before consultant capability is activated

## Checklist

- [x] Tests added/updated for new logic
- [ ] Module coverage stays ≥70% <!-- not measured in this environment -->
- [ ] EN + AR translations added for any user-facing strings <!-- N/A: no new UI string keys; role-switch UI reuses existing i18n keys -->
- [ ] `dotnet build` (server) — 0 warnings, 0 errors <!-- could not run: no .NET SDK available in the working environment; please verify locally -->
- [x] `npm run typecheck` + `npm run lint` + `npm run test` (client) — all green
- [ ] Manual smoke test via `/scalar/v1` (API) or dev UI
- [ ] Docs updated (`docs/*.md`) if public contract changed <!-- added sql/audit-consultant-eligibility.sql instead -->
- [x] No secrets / tokens / PII in code or logs

## Screenshots / demo (UI changes only)

No visual change — the only UI difference is that the "switch to Consultant" menu item is hidden unless the backend reports the account as an eligible consultant.

## Deployment notes

- **No migration required** — `UserProfile.ConsultantVerifiedAt` already exists in the schema; both admin approval paths now populate it.
- **Behavior change:** a booking request targeting a non-eligible consultant now returns `422` (`"This consultant is not available for booking."`).
- **Stale data (optional, no manual step required for correctness):** the new rule fails closed for any pre-existing Consultant-role account without approval. `sql/audit-consultant-eligibility.sql` provides a read-only diagnostic to list such accounts, plus optional remediation snippets to review before running.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HU6JDDyN5ijX3jXCEzmrtt)_