### PR TITLE
feat(resources): surface resource progress to students

### DIFF
--- a/client/src/components/layout/AuthenticatedLayout.tsx
+++ b/client/src/components/layout/AuthenticatedLayout.tsx
@@ -224,6 +224,7 @@ const NAV_BY_ROLE: Record<string, NavItem[]> = {
     { to: "/student/bookings", key: "student.bookings", icon: Calendar },
     { to: "/student/community", key: "student.community", icon: MessageSquare },
     { to: "/student/resources", key: "student.resources", icon: BookOpen },
+    { to: "/student/resource-progress", key: "student.resourceProgress", icon: TrendingUp },
     { to: "/student/documents", key: "student.documents", icon: FolderOpen },
     { to: "/student/ai", key: "student.ai", icon: Sparkles },
     { to: "/student/messages", key: "student.messages", icon: MessageSquare },

--- a/client/src/locales/ar/nav.json
+++ b/client/src/locales/ar/nav.json
@@ -15,6 +15,7 @@
     "bookings": "الحجوزات",
     "community": "المجتمع",
     "resources": "الموارد",
+    "resourceProgress": "تقدّمي",
     "documents": "المستندات",
     "ai": "الذكاء الاصطناعي",
     "messages": "الرسائل",

--- a/client/src/locales/ar/resources.json
+++ b/client/src/locales/ar/resources.json
@@ -36,8 +36,27 @@
     "bookmark": "حفظ",
     "bookmarkToggle": "تبديل الحفظ",
     "markComplete": "تم",
+    "completed": "مكتمل",
+    "progressLabel": "{{done}} من {{total}} فصلاً مكتملة",
+    "progressPercent": "{{percent}}٪",
     "chapterMarked": "تم تمييز الفصل كمكتمل.",
     "resourceComplete": "اكتمل المورد! أحسنت."
+  },
+  "progress": {
+    "title": "تقدّمي في الموارد",
+    "subtitle": "الموارد التي بدأتها ومدى تقدّمك فيها.",
+    "loadError": "تعذّر تحميل تقدّمك.",
+    "retry": "إعادة المحاولة",
+    "empty": "لم تبدأ أي مورد بعد.",
+    "emptyBody": "افتح دليلاً أو قائمة تحقّق وميّز الفصول كمكتملة لتتبّع تقدّمك هنا.",
+    "browse": "تصفّح الموارد",
+    "inProgress": "قيد التقدّم",
+    "completed": "مكتمل",
+    "chaptersDone": "{{done}} من {{total}} فصلاً",
+    "percentComplete": "{{percent}}٪ مكتمل",
+    "continue": "متابعة",
+    "review": "مراجعة",
+    "lastAccessed": "آخر فتح {{date}}"
   },
   "author": {
     "title": "مواردي",

--- a/client/src/locales/en/nav.json
+++ b/client/src/locales/en/nav.json
@@ -15,6 +15,7 @@
     "bookings": "Bookings",
     "community": "Community",
     "resources": "Resources",
+    "resourceProgress": "My Progress",
     "documents": "Documents",
     "ai": "AI",
     "messages": "Messages",

--- a/client/src/locales/en/resources.json
+++ b/client/src/locales/en/resources.json
@@ -36,8 +36,27 @@
     "bookmark": "Save",
     "bookmarkToggle": "Toggle bookmark",
     "markComplete": "Done",
+    "completed": "Completed",
+    "progressLabel": "{{done}} of {{total}} chapters completed",
+    "progressPercent": "{{percent}}%",
     "chapterMarked": "Chapter marked as complete.",
     "resourceComplete": "Resource complete! Well done."
+  },
+  "progress": {
+    "title": "My Resource Progress",
+    "subtitle": "Resources you've started and how far you've gotten.",
+    "loadError": "Could not load your progress.",
+    "retry": "Retry",
+    "empty": "You haven't started any resources yet.",
+    "emptyBody": "Open a guide or checklist and mark chapters complete to track your progress here.",
+    "browse": "Browse resources",
+    "inProgress": "In progress",
+    "completed": "Completed",
+    "chaptersDone": "{{done}} of {{total}} chapters",
+    "percentComplete": "{{percent}}% complete",
+    "continue": "Continue",
+    "review": "Review",
+    "lastAccessed": "Last opened {{date}}"
   },
   "author": {
     "title": "My Resources",

--- a/client/src/pages/student/ResourceDetail.tsx
+++ b/client/src/pages/student/ResourceDetail.tsx
@@ -23,6 +23,7 @@ import {
 import {
   resourcesApi,
   type ResourceDetail as ResourceDetailDto,
+  type ResourceProgressDetail,
   type ChapterProgressResult,
   type ResourceType,
 } from "@/services/api/resources";
@@ -182,6 +183,16 @@ export function ResourceDetail() {
     enabled: !!idOrSlug,
   });
 
+  // ── Per-resource progress (which chapters the student has completed) ───────
+  const resourceId = data?.id;
+  const hasChapters = (data?.chapters.length ?? 0) > 0;
+  const { data: progress } = useQuery<ResourceProgressDetail>({
+    queryKey: ["resources", "progress", "detail", resourceId],
+    queryFn: () => resourcesApi.getResourceProgress(resourceId!),
+    enabled: !!user && !!resourceId && hasChapters,
+  });
+  const completedChapters = new Set(progress?.completedChapterIds ?? []);
+
   // ── Bookmark toggle ──────────────────────────────────────────────────────
   const bookmarkMut = useMutation({
     mutationFn: (id: string) => resourcesApi.toggleBookmark(id),
@@ -196,11 +207,14 @@ export function ResourceDetail() {
     mutationFn: ({ resourceId, chapterId }) =>
       resourcesApi.completeChapter(resourceId, chapterId),
     onSuccess: (res) => {
-      if (res.isResourceComplete) {
+      const isResourceComplete =
+        res.totalChapters > 0 && res.chaptersCompletedCount >= res.totalChapters;
+      if (isResourceComplete) {
         toast.success(t("resources:detail.resourceComplete"));
       } else {
         toast.success(t("resources:detail.chapterMarked"));
       }
+      // Refreshes both this page's completion state and the "My Progress" list.
       void qc.invalidateQueries({ queryKey: ["resources", "progress"] });
     },
     onError: (err) => toast.error(apiErrorMessage(err, t("common:status.error"))),
@@ -377,11 +391,45 @@ export function ResourceDetail() {
               <h2 id="chapters" className="text-xl font-bold text-text-primary tracking-tight scroll-mt-24">
                 {t("resources:detail.chapters")}
               </h2>
+
+              {/* Completion bar (signed-in students only) */}
+              {user && (() => {
+                const done = completedChapters.size;
+                const total = chapters.length;
+                const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+                return (
+                  <div className="card-premium p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-text-primary">
+                        <CheckCircle aria-hidden className="size-4 text-success-500" />
+                        {t("resources:detail.progressLabel", { done, total })}
+                      </span>
+                      <span className="text-sm font-bold text-brand-600">
+                        {t("resources:detail.progressPercent", { percent: pct })}
+                      </span>
+                    </div>
+                    <div
+                      className="mt-2.5 h-2 w-full overflow-hidden rounded-full bg-bg-subtle"
+                      role="progressbar"
+                      aria-valuenow={pct}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    >
+                      <div
+                        className="h-full rounded-full bg-gradient-to-r from-success-500 to-success-600 transition-[width] duration-500"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })()}
+
               {chapters.map((ch, idx) => {
                 const chTitle = isAr ? ch.titleAr || ch.titleEn : ch.titleEn || ch.titleAr;
                 const chContent = isAr
                   ? ch.contentMarkdownAr ?? ch.contentMarkdownEn
                   : ch.contentMarkdownEn ?? ch.contentMarkdownAr;
+                const isChapterDone = completedChapters.has(ch.id);
                 return (
                   <div
                     key={ch.id}
@@ -390,8 +438,14 @@ export function ResourceDetail() {
                   >
                     <div className="flex items-start justify-between gap-3 flex-wrap">
                       <h3 className="flex items-center gap-3 font-bold text-text-primary tracking-tight text-lg leading-snug">
-                        <span className="flex size-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-brand-500 to-brand-700 text-xs font-bold text-white shadow-brand-sm">
-                          {idx + 1}
+                        <span
+                          className={`flex size-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br text-xs font-bold text-white shadow-brand-sm ${
+                            isChapterDone
+                              ? "from-success-500 to-success-600"
+                              : "from-brand-500 to-brand-700"
+                          }`}
+                        >
+                          {isChapterDone ? <CheckCircle aria-hidden className="size-4" /> : idx + 1}
                         </span>
                         {chTitle}
                       </h3>
@@ -404,20 +458,26 @@ export function ResourceDetail() {
                             })}
                           </span>
                         )}
-                        {user && (
-                          <button
-                            type="button"
-                            disabled={chapterMut.isPending}
-                            onClick={() =>
-                              chapterMut.mutate({ resourceId: data.id, chapterId: ch.id })
-                            }
-                            className="inline-flex items-center gap-1 rounded-full border border-success-200 bg-success-50 px-2.5 py-1 text-xs font-semibold text-success-700 transition hover:bg-success-100 disabled:opacity-60"
-                            aria-label={t("resources:detail.markComplete")}
-                          >
-                            <CheckCircle aria-hidden className="size-3.5" />
-                            {t("resources:detail.markComplete")}
-                          </button>
-                        )}
+                        {user &&
+                          (isChapterDone ? (
+                            <span className="inline-flex items-center gap-1 rounded-full border border-success-200 bg-success-100 px-2.5 py-1 text-xs font-semibold text-success-700">
+                              <CheckCircle aria-hidden className="size-3.5" />
+                              {t("resources:detail.completed")}
+                            </span>
+                          ) : (
+                            <button
+                              type="button"
+                              disabled={chapterMut.isPending}
+                              onClick={() =>
+                                chapterMut.mutate({ resourceId: data.id, chapterId: ch.id })
+                              }
+                              className="inline-flex items-center gap-1 rounded-full border border-success-200 bg-success-50 px-2.5 py-1 text-xs font-semibold text-success-700 transition hover:bg-success-100 disabled:opacity-60"
+                              aria-label={t("resources:detail.markComplete")}
+                            >
+                              <CheckCircle aria-hidden className="size-3.5" />
+                              {t("resources:detail.markComplete")}
+                            </button>
+                          ))}
                       </div>
                     </div>
                     {chContent && chContent.trim() && (

--- a/client/src/pages/student/ResourceProgressPage.tsx
+++ b/client/src/pages/student/ResourceProgressPage.tsx
@@ -1,0 +1,167 @@
+import { Link } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { format } from "date-fns";
+import { ar } from "date-fns/locale";
+import {
+  TrendingUp,
+  ArrowRight,
+  ArrowLeft,
+  CheckCircle,
+  BookOpen,
+  Clock,
+} from "lucide-react";
+import { motion } from "motion/react";
+import { resourcesApi, type ResourceProgressItem } from "@/services/api/resources";
+
+export function ResourceProgressPage() {
+  const { t, i18n } = useTranslation(["resources", "common"]);
+  const isAr = i18n.language.startsWith("ar");
+  const isRtl = i18n.dir() === "rtl";
+  const dateLocale = isAr ? ar : undefined;
+  const ContinueIcon = isRtl ? ArrowLeft : ArrowRight;
+
+  const { data, isLoading, isError, refetch } = useQuery<ResourceProgressItem[]>({
+    queryKey: ["resources", "progress", "mine"],
+    queryFn: () => resourcesApi.getMyProgress(),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight text-text-primary">
+          {t("resources:progress.title")}
+        </h1>
+        <p className="mt-2 max-w-xl text-text-secondary">
+          {t("resources:progress.subtitle")}
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="skeleton h-36 rounded-2xl" />
+          ))}
+        </div>
+      )}
+
+      {isError && !isLoading && (
+        <p className="py-12 text-center text-sm text-text-tertiary">
+          {t("resources:progress.loadError")}{" "}
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="text-brand-500 underline font-medium"
+          >
+            {t("resources:progress.retry")}
+          </button>
+        </p>
+      )}
+
+      {!isLoading && !isError && data?.length === 0 && (
+        <div className="flex min-h-[50vh] flex-col items-center justify-center rounded-2xl border border-border-subtle bg-bg-elevated p-12 text-center">
+          <div className="mb-5 flex size-16 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-100 to-brand-50 text-brand-600">
+            <TrendingUp aria-hidden className="size-7" />
+          </div>
+          <h3 className="text-lg font-semibold text-text-primary">
+            {t("resources:progress.empty")}
+          </h3>
+          <p className="mt-2 max-w-md text-sm text-text-secondary">
+            {t("resources:progress.emptyBody")}
+          </p>
+          <Link to="/student/resources" className="btn btn-primary btn-sm mt-6">
+            <BookOpen aria-hidden className="size-4" />
+            {t("resources:progress.browse")}
+          </Link>
+        </div>
+      )}
+
+      {!isLoading && !isError && (data?.length ?? 0) > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {data?.map((item, i) => {
+            const title = isAr
+              ? item.titleAr || item.titleEn
+              : item.titleEn || item.titleAr;
+            const total = item.totalChapters;
+            const done = item.chaptersCompletedCount;
+            const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+            const isComplete = total > 0 && done >= total;
+
+            return (
+              <motion.div
+                key={item.resourceId}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.25, delay: Math.min(i, 8) * 0.04 }}
+              >
+                <Link
+                  to={`/student/resources/${item.slug}`}
+                  className="group flex h-full flex-col rounded-2xl border border-border-subtle bg-bg-elevated p-5 transition-all hover:-translate-y-1 hover:border-brand-200 hover:shadow-lg"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    {isComplete ? (
+                      <span className="badge badge-success">
+                        <CheckCircle aria-hidden className="size-3" />
+                        {t("resources:progress.completed")}
+                      </span>
+                    ) : (
+                      <span className="badge badge-brand">
+                        <TrendingUp aria-hidden className="size-3" />
+                        {t("resources:progress.inProgress")}
+                      </span>
+                    )}
+                    <span className="text-sm font-bold text-brand-600">
+                      {t("resources:progress.percentComplete", { percent: pct })}
+                    </span>
+                  </div>
+
+                  <h2 className="mt-3 line-clamp-2 text-base font-semibold leading-snug text-text-primary transition-colors group-hover:text-brand-600">
+                    {title}
+                  </h2>
+
+                  <div
+                    className="mt-4 h-2 w-full overflow-hidden rounded-full bg-bg-subtle"
+                    role="progressbar"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  >
+                    <div
+                      className={`h-full rounded-full transition-[width] duration-500 ${
+                        isComplete
+                          ? "bg-gradient-to-r from-success-500 to-success-600"
+                          : "bg-gradient-to-r from-brand-500 to-brand-600"
+                      }`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+
+                  <p className="mt-2 text-xs font-medium text-text-secondary">
+                    {t("resources:progress.chaptersDone", { done, total })}
+                  </p>
+
+                  <div className="mt-auto flex items-center justify-between pt-4 text-xs text-text-tertiary">
+                    <span className="inline-flex items-center gap-1">
+                      <Clock aria-hidden className="size-3" />
+                      {t("resources:progress.lastAccessed", {
+                        date: format(new Date(item.lastAccessedAt), "dd MMM yyyy", {
+                          locale: dateLocale,
+                        }),
+                      })}
+                    </span>
+                    <span className="inline-flex items-center gap-1 font-semibold text-brand-600">
+                      {isComplete
+                        ? t("resources:progress.review")
+                        : t("resources:progress.continue")}
+                      <ContinueIcon aria-hidden className="size-3.5" />
+                    </span>
+                  </div>
+                </Link>
+              </motion.div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/routes/router.tsx
+++ b/client/src/routes/router.tsx
@@ -97,6 +97,11 @@ const StudentResourceDetail = lazy(() =>
     default: m.ResourceDetail,
   })),
 );
+const StudentResourceProgress = lazy(() =>
+  import("@/pages/student/ResourceProgressPage").then((m) => ({
+    default: m.ResourceProgressPage,
+  })),
+);
 const StudentDocuments = lazy(() =>
   import("@/pages/student/Documents").then((m) => ({ default: m.Documents })),
 );
@@ -504,6 +509,7 @@ export function AppRouter() {
 
           {/* Others */}
           <Route path="/student/resources"         element={<AnimatedRoute><StudentResources /></AnimatedRoute>} />
+          <Route path="/student/resource-progress" element={<AnimatedRoute><StudentResourceProgress /></AnimatedRoute>} />
           <Route path="/student/resources/:idOrSlug" element={<AnimatedRoute><StudentResourceDetail /></AnimatedRoute>} />
           <Route path="/student/documents"         element={<AnimatedRoute><StudentDocuments /></AnimatedRoute>} />
           <Route path="/student/ai"                element={<AnimatedRoute><StudentAi /></AnimatedRoute>} />

--- a/client/src/services/api/resources.ts
+++ b/client/src/services/api/resources.ts
@@ -124,12 +124,19 @@ export interface ResourceProgressItem {
   lastAccessedAt: string;
 }
 
+/** Server ChapterProgressResult — returned when a chapter is marked complete. */
 export interface ChapterProgressResult {
   resourceId: string;
-  chapterId: string;
+  chaptersCompletedCount: number;
   totalChapters: number;
-  chaptersCompleted: number;
-  isResourceComplete: boolean;
+}
+
+/** The caller's progress for one resource, incl. which chapters are done. */
+export interface ResourceProgressDetail {
+  resourceId: string;
+  chaptersCompletedCount: number;
+  totalChapters: number;
+  completedChapterIds: string[];
 }
 
 // ─── API ─────────────────────────────────────────────────────────────────────
@@ -218,6 +225,14 @@ export const resourcesApi = {
   /** The caller's reading progress across all resources. */
   async getMyProgress(): Promise<ResourceProgressItem[]> {
     const { data } = await apiClient.get<ResourceProgressItem[]>("/api/resources/progress/me");
+    return data;
+  },
+
+  /** The caller's progress for a single resource, incl. which chapters are done. */
+  async getResourceProgress(resourceId: string): Promise<ResourceProgressDetail> {
+    const { data } = await apiClient.get<ResourceProgressDetail>(
+      `/api/resources/${resourceId}/progress/me`,
+    );
     return data;
   },
 

--- a/server/src/ScholarPath.API/Controllers/ResourcesController.cs
+++ b/server/src/ScholarPath.API/Controllers/ResourcesController.cs
@@ -18,6 +18,7 @@ using ScholarPath.Application.Resources.Queries.GetMyResourceProgress;
 using ScholarPath.Application.Resources.Queries.GetMyResources;
 using ScholarPath.Application.Resources.Queries.GetPendingReviewResources;
 using ScholarPath.Application.Resources.Queries.GetResourceDetail;
+using ScholarPath.Application.Resources.Queries.GetResourceProgressDetail;
 using ScholarPath.Application.Resources.Queries.SearchResources;
 using ScholarPath.Domain.Enums;
 
@@ -133,6 +134,13 @@ public sealed class ResourcesController(IMediator mediator) : ControllerBase
     [ProducesResponseType(typeof(IReadOnlyList<ResourceProgressDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> MyProgress(CancellationToken ct)
         => Ok(await mediator.Send(new GetMyResourceProgressQuery(), ct));
+
+    /// <summary>The caller's progress for a single resource, incl. which chapters are done.</summary>
+    [HttpGet("{id:guid}/progress/me")]
+    [Authorize]
+    [ProducesResponseType(typeof(ResourceProgressDetailDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> MyResourceProgress(Guid id, CancellationToken ct)
+        => Ok(await mediator.Send(new GetResourceProgressDetailQuery(id), ct));
 
     // ── Admin moderation ──────────────────────────────────────────────────────
 

--- a/server/src/ScholarPath.Application/Resources/Queries/GetResourceProgressDetail/GetResourceProgressDetailQuery.cs
+++ b/server/src/ScholarPath.Application/Resources/Queries/GetResourceProgressDetail/GetResourceProgressDetailQuery.cs
@@ -1,0 +1,50 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Interfaces;
+
+namespace ScholarPath.Application.Resources.Queries.GetResourceProgressDetail;
+
+/// <summary>
+/// The authenticated student's progress for a single resource, including the ids of the
+/// chapters they have already completed so the detail page can render per-chapter state
+/// and a completion bar (PB-009 AC#6).
+/// </summary>
+public sealed record GetResourceProgressDetailQuery(Guid ResourceId)
+    : IRequest<ResourceProgressDetailDto>;
+
+public sealed class GetResourceProgressDetailQueryHandler(
+    IApplicationDbContext db,
+    ICurrentUserService currentUser)
+    : IRequestHandler<GetResourceProgressDetailQuery, ResourceProgressDetailDto>
+{
+    public async Task<ResourceProgressDetailDto> Handle(
+        GetResourceProgressDetailQuery request, CancellationToken ct)
+    {
+        var userId = currentUser.UserId
+            ?? throw new ForbiddenAccessException("Not authenticated.");
+
+        var totalChapters = await db.ResourceChapters
+            .CountAsync(c => c.ResourceId == request.ResourceId, ct);
+
+        var progress = await db.ResourceProgress
+            .AsNoTracking()
+            .Include(p => p.ChapterProgress)
+            .FirstOrDefaultAsync(
+                p => p.UserId == userId && p.ResourceId == request.ResourceId, ct);
+
+        var completedChapterIds = progress is null
+            ? new List<Guid>()
+            : progress.ChapterProgress
+                .Where(cp => cp.IsCompleted)
+                .Select(cp => cp.ResourceChildId)
+                .ToList();
+
+        return new ResourceProgressDetailDto(
+            request.ResourceId,
+            completedChapterIds.Count,
+            totalChapters,
+            completedChapterIds);
+    }
+}

--- a/server/src/ScholarPath.Application/Resources/ResourceDtos.cs
+++ b/server/src/ScholarPath.Application/Resources/ResourceDtos.cs
@@ -69,6 +69,13 @@ public sealed record ResourceProgressDto(
     int TotalChapters,
     DateTimeOffset LastAccessedAt);
 
+/// <summary>The caller's progress for a single resource, including which chapters are done.</summary>
+public sealed record ResourceProgressDetailDto(
+    Guid ResourceId,
+    int ChaptersCompletedCount,
+    int TotalChapters,
+    IReadOnlyList<Guid> CompletedChapterIds);
+
 /// <summary>Chapter payload accepted by Create/Update resource commands.</summary>
 public sealed record ResourceChapterInput(
     string TitleEn,

--- a/server/tests/ScholarPath.UnitTests/Resources/ResourceStudentActionsTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Resources/ResourceStudentActionsTests.cs
@@ -5,6 +5,7 @@ using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Application.Resources.Commands.CompleteResourceChapter;
 using ScholarPath.Application.Resources.Commands.ToggleResourceBookmark;
+using ScholarPath.Application.Resources.Queries.GetResourceProgressDetail;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Interfaces;
@@ -106,5 +107,86 @@ public class ResourceStudentActionsTests
             new CompleteResourceChapterCommand(resource.Id, Guid.NewGuid()), default);
 
         await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Complete_chapter_twice_is_idempotent()
+    {
+        using var db = CreateDb();
+        var resource = PublishedResource();
+        var chapter = new ResourceChild
+        {
+            Id = Guid.NewGuid(),
+            ResourceId = resource.Id,
+            TitleEn = "Ch", TitleAr = "فصل",
+            SortOrder = 0,
+        };
+        db.Resources.Add(resource);
+        db.ResourceChapters.Add(chapter);
+        await db.SaveChangesAsync();
+
+        var studentId = Guid.NewGuid();
+        var sut = new CompleteResourceChapterCommandHandler(db, User(studentId));
+        var cmd = new CompleteResourceChapterCommand(resource.Id, chapter.Id);
+
+        await sut.Handle(cmd, default);
+        var second = await sut.Handle(cmd, default);
+
+        second.ChaptersCompletedCount.Should().Be(1);
+        (await db.ResourceProgress.CountAsync()).Should().Be(1);
+        (await db.ResourceProgressChildren.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Progress_detail_returns_completed_chapter_ids()
+    {
+        using var db = CreateDb();
+        var resource = PublishedResource();
+        var chapterOne = new ResourceChild
+        {
+            Id = Guid.NewGuid(), ResourceId = resource.Id,
+            TitleEn = "One", TitleAr = "١", SortOrder = 0,
+        };
+        var chapterTwo = new ResourceChild
+        {
+            Id = Guid.NewGuid(), ResourceId = resource.Id,
+            TitleEn = "Two", TitleAr = "٢", SortOrder = 1,
+        };
+        db.Resources.Add(resource);
+        db.ResourceChapters.AddRange(chapterOne, chapterTwo);
+        await db.SaveChangesAsync();
+
+        var studentId = Guid.NewGuid();
+        await new CompleteResourceChapterCommandHandler(db, User(studentId))
+            .Handle(new CompleteResourceChapterCommand(resource.Id, chapterOne.Id), default);
+
+        var progress = await new GetResourceProgressDetailQueryHandler(db, User(studentId))
+            .Handle(new GetResourceProgressDetailQuery(resource.Id), default);
+
+        progress.TotalChapters.Should().Be(2);
+        progress.ChaptersCompletedCount.Should().Be(1);
+        progress.CompletedChapterIds.Should().ContainSingle().Which.Should().Be(chapterOne.Id);
+    }
+
+    [Fact]
+    public async Task Progress_detail_is_empty_when_nothing_completed()
+    {
+        using var db = CreateDb();
+        var resource = PublishedResource();
+        var chapter = new ResourceChild
+        {
+            Id = Guid.NewGuid(), ResourceId = resource.Id,
+            TitleEn = "Ch", TitleAr = "فصل", SortOrder = 0,
+        };
+        db.Resources.Add(resource);
+        db.ResourceChapters.Add(chapter);
+        await db.SaveChangesAsync();
+
+        var progress = await new GetResourceProgressDetailQueryHandler(db, User(Guid.NewGuid()))
+            .Handle(new GetResourceProgressDetailQuery(resource.Id), default);
+
+        progress.TotalChapters.Should().Be(1);
+        progress.ChaptersCompletedCount.Should().Be(0);
+        progress.CompletedChapterIds.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
Resource progress was write-only: students could mark a chapter complete but could never see it. Make it visible and fix the client/API contract.

- Detail page: completion bar and per-chapter completed state
- New 'My Progress' page listing started resources with percentage and continue links (route + sidebar entry)
- Add GET /api/resources/{id}/progress/me returning completed chapter ids
- Fix ChapterProgressResult client type to match the API response so the 'resource complete' toast fires correctly
- Add idempotency and progress-detail unit tests; EN/AR translations

## What / Why

<!-- 1–2 sentences. What does this PR do, and why? -->

## SRS traceability

- FRs: FR-xxx, FR-yyy
- User stories: US-xxx
- Epic: PB-xxx

## Checklist

- [ ] Tests added/updated for new logic
- [ ] Module coverage stays ≥70%
- [ ] EN + AR translations added for any user-facing strings
- [ ] `dotnet build` (server) — 0 warnings, 0 errors
- [ ] `npm run typecheck` + `npm run lint` + `npm run test` (client) — all green
- [ ] Manual smoke test via `/scalar/v1` (API) or dev UI
- [ ] Docs updated (`docs/*.md`) if public contract changed
- [ ] No secrets / tokens / PII in code or logs

## Screenshots / demo (UI changes only)

<!-- Drag in before/after screenshots. For interactions, record a <10s clip. -->

## Deployment notes

<!-- Migrations? Feature flags? Environment variables? Config changes? -->
