### PR TITLE
Auth/Onboarding gap fixes: upgrade docs (GAP-1), lockdown (FR-AUTH-02), logout revoke (SEC-11), register race (RACE-03)

### DIFF
--- a/client/src/components/layout/AuthenticatedLayout.tsx
+++ b/client/src/components/layout/AuthenticatedLayout.tsx
@@ -76,6 +76,9 @@ function ProfileMenu() {
   );
 
   const onSignOut = () => {
+    // SEC-11 — revoke the refresh token server-side before clearing locally.
+    const refreshToken = useAuthStore.getState().tokens?.refreshToken;
+    if (refreshToken) void authApi.logout(refreshToken).catch(() => {});
     clear();
     navigate("/");
   };
@@ -271,6 +274,9 @@ function SidebarContent({
   const navigate = useNavigate();
 
   const onSignOut = () => {
+    // SEC-11 — revoke the refresh token server-side before clearing locally.
+    const refreshToken = useAuthStore.getState().tokens?.refreshToken;
+    if (refreshToken) void authApi.logout(refreshToken).catch(() => {});
     clear();
     navigate("/");
     onNavigate?.();

--- a/client/src/components/layout/PublicLayout.tsx
+++ b/client/src/components/layout/PublicLayout.tsx
@@ -7,7 +7,7 @@ import { motion, AnimatePresence } from "motion/react";
 import { LanguageSwitcher } from "@/components/common/LanguageSwitcher";
 import { ThemeToggle } from "@/components/common/ThemeToggle";
 import { useAuthStore } from "@/stores/authStore";
-import { postAuthPath } from "@/services/api/auth";
+import { authApi, postAuthPath } from "@/services/api/auth";
 import { usePaymentsEnabled } from "@/hooks/usePlatformStatus";
 
 /** Email address used for placeholder footer links until proper static pages ship. */
@@ -40,6 +40,11 @@ export function PublicLayout({ children }: { children: ReactNode }) {
   const homePath = user ? postAuthPath(user) : "/";
 
   const onSignOut = () => {
+    // SEC-11 — revoke the refresh token server-side so a leaked token can't be
+    // reused after logout. Fire-and-forget: a network failure must not block the
+    // local sign-out, which clears the session regardless.
+    const refreshToken = useAuthStore.getState().tokens?.refreshToken;
+    if (refreshToken) void authApi.logout(refreshToken).catch(() => {});
     clearAuth();
     setMobileOpen(false);
     navigate("/");

--- a/server/src/ScholarPath.API/Controllers/CommunityController.cs
+++ b/server/src/ScholarPath.API/Controllers/CommunityController.cs
@@ -25,14 +25,14 @@ public class CommunityController(IMediator mediator) : ControllerBase
     // ── Public reads ───────────────────────────────────────────────────────────
 
     [HttpGet("categories")]
-    [AllowAnonymous]
+    [Authorize]
     public async Task<IActionResult> GetCategories(CancellationToken ct)
     {
         return Ok(await mediator.Send(new GetCategoriesQuery(), ct));
     }
 
     [HttpGet("posts")]
-    [AllowAnonymous]
+    [Authorize]
     public async Task<IActionResult> GetPosts(
         [FromQuery] Guid? categoryId,
         [FromQuery] string? query,
@@ -46,7 +46,7 @@ public class CommunityController(IMediator mediator) : ControllerBase
     }
 
     [HttpGet("posts/{id:guid}")]
-    [AllowAnonymous]
+    [Authorize]
     public async Task<IActionResult> GetPostDetails(Guid id, CancellationToken ct)
     {
         return Ok(await mediator.Send(new GetPostDetailsQuery(id), ct));

--- a/server/src/ScholarPath.API/Controllers/ConsultantsController.cs
+++ b/server/src/ScholarPath.API/Controllers/ConsultantsController.cs
@@ -15,7 +15,7 @@ namespace ScholarPath.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/consultants")]
-[AllowAnonymous]
+[Authorize]
 public sealed class ConsultantsController : ControllerBase
 {
     private readonly ISender _sender;

--- a/server/src/ScholarPath.API/Controllers/ResourcesController.cs
+++ b/server/src/ScholarPath.API/Controllers/ResourcesController.cs
@@ -34,7 +34,7 @@ public sealed class ResourcesController(IMediator mediator) : ControllerBase
 
     /// <summary>Browse/search published resources.</summary>
     [HttpGet]
-    [AllowAnonymous]
+    [Authorize]
     [ProducesResponseType(typeof(PaginatedList<ResourceListItemDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Search([FromQuery] SearchResourcesQuery query, CancellationToken ct)
         => Ok(await mediator.Send(query, ct));
@@ -45,21 +45,21 @@ public sealed class ResourcesController(IMediator mediator) : ControllerBase
     /// stay in sync.
     /// </summary>
     [HttpGet("categories")]
-    [AllowAnonymous]
+    [Authorize]
     [ProducesResponseType(typeof(IReadOnlyList<string>), StatusCodes.Status200OK)]
     public IActionResult Categories()
         => Ok(ResourceCategoryCatalog.Slugs);
 
     /// <summary>Featured resources for the homepage hub.</summary>
     [HttpGet("featured")]
-    [AllowAnonymous]
+    [Authorize]
     [ProducesResponseType(typeof(IReadOnlyList<ResourceListItemDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Featured(CancellationToken ct)
         => Ok(await mediator.Send(new GetFeaturedResourcesQuery(), ct));
 
     /// <summary>Full resource detail by id or slug.</summary>
     [HttpGet("{idOrSlug}")]
-    [AllowAnonymous]
+    [Authorize]
     [ProducesResponseType(typeof(ResourceDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetByIdOrSlug(string idOrSlug, CancellationToken ct)

--- a/server/src/ScholarPath.Application/Auth/Commands/Register/RegisterCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/Register/RegisterCommandHandler.cs
@@ -50,7 +50,19 @@ public sealed class RegisterCommandHandler(
         };
 
         db.Users.Add(user);
-        await db.SaveChangesAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            // RACE-03 — two concurrent registrations for the same email both pass the
+            // AnyAsync pre-check above, then race to insert. The unique index on the
+            // normalized user name (== email) rejects the loser with a duplicate-key
+            // DbUpdateException; translate it to the same friendly 409 the pre-check
+            // returns instead of leaking a raw 500.
+            throw new ConflictException("An account with this email already exists.");
+        }
 
         // Send the email-verification link (FR-215). Best-effort — email is a side
         // channel; a delivery failure must not break registration.

--- a/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandHandler.cs
+++ b/server/src/ScholarPath.Application/UpgradeRequests/Commands/SubmitConsultantUpgradeRequest/SubmitConsultantUpgradeRequestCommandHandler.cs
@@ -73,6 +73,25 @@ public sealed class SubmitConsultantUpgradeRequestCommandHandler(
                 "You already have a pending consultant upgrade request.");
         }
 
+        // GAP-1 / FR-ONB-08 — a Student-initiated consultant upgrade must clear the
+        // SAME document bar as a fresh Consultant onboarding (ConsultantIdentityProof,
+        // ConsultantDegreeCertificate, ConsultantCvResume). SelectRoleCommandHandler
+        // enforces this for first-time onboarding; the upgrade path previously enforced
+        // only the profile fields, letting a request reach the admin queue with no
+        // supporting documents. Mirror the defensive minimum-count check here.
+        const int RequiredConsultantDocs = 3;
+        var onboardingDocCount = await db.Documents
+            .Where(d => d.OwnerUserId == userId
+                        && d.Category == DocumentCategory.OnboardingDocument)
+            .CountAsync(ct).ConfigureAwait(false);
+        if (onboardingDocCount < RequiredConsultantDocs)
+        {
+            var missing = RequiredConsultantDocs - onboardingDocCount;
+            throw new ConflictException(
+                $"Upload {RequiredConsultantDocs} verification document(s) before requesting a consultant upgrade — "
+                + $"{missing} more required.");
+        }
+
         // Stamp the submitted consultant fields on the profile so the admin
         // reviews a complete picture. Student-only fields (AcademicLevel,
         // FieldOfStudy, …) are not touched.

--- a/server/tests/ScholarPath.UnitTests/UpgradeRequests/SubmitConsultantUpgradeRequestCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/UpgradeRequests/SubmitConsultantUpgradeRequestCommandHandlerTests.cs
@@ -42,7 +42,7 @@ public class SubmitConsultantUpgradeRequestCommandHandlerTests
             notifications ?? Substitute.For<INotificationDispatcher>(),
             NullLogger<SubmitConsultantUpgradeRequestCommandHandler>.Instance);
 
-    private static Guid SeedActiveStudent(ApplicationDbContext db)
+    private static Guid SeedActiveStudent(ApplicationDbContext db, bool withDocs = true)
     {
         var id = Guid.NewGuid();
         db.Users.Add(new ApplicationUser
@@ -54,6 +54,25 @@ public class SubmitConsultantUpgradeRequestCommandHandlerTests
             UserName = "student@scholarpath.local",
             AccountStatus = AccountStatus.Active,
         });
+        // GAP-1 / FR-ONB-08 — the upgrade handler now requires the same 3 onboarding
+        // verification documents a fresh Consultant onboarding does, so the happy-path
+        // fixtures seed them. Pass withDocs:false to exercise the missing-docs guard.
+        if (withDocs)
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                db.Documents.Add(new Document
+                {
+                    Id = Guid.NewGuid(),
+                    OwnerUserId = id,
+                    FileName = $"verification-{i}.pdf",
+                    ContentType = "application/pdf",
+                    SizeBytes = 1024,
+                    StoragePath = $"documents/{id}/verification-{i}.pdf",
+                    Category = DocumentCategory.OnboardingDocument,
+                });
+            }
+        }
         return id;
     }
 
@@ -242,6 +261,22 @@ public class SubmitConsultantUpgradeRequestCommandHandlerTests
 
         await act.Should().ThrowAsync<ConflictException>()
             .WithMessage("*account must be active*");
+    }
+
+    [Fact]
+    public async Task Blocked_when_verification_documents_missing()
+    {
+        // GAP-1 / FR-ONB-08 — an active Student with all profile fields but NO
+        // onboarding verification documents must be rejected, matching the bar a
+        // fresh Consultant onboarding enforces.
+        using var db = CreateDb();
+        var userId = SeedActiveStudent(db, withDocs: false);
+        await db.SaveChangesAsync();
+
+        var act = () => Sut(db, userId, Admin("Student")).Handle(ValidCommand(), default);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*verification document*");
     }
 
     [Fact]


### PR DESCRIPTION
## Auth / Onboarding module gap fixes

Fixes from the Auth+Onboarding module review (`~/.claude/plans/module-auth-onboarding-gap-analysis.md`). Independent of the ScholarshipProvider rename (PR #50) — branched off `main`. **824 unit tests pass.**

### Included
- **GAP-1 🟠 (real bug) — consultant-upgrade document enforcement** (`SubmitConsultantUpgradeRequestCommandHandler`). FR-ONB-08 requires the upgrade to clear the same document bar as a fresh Consultant onboarding, but the upgrade path enforced only profile fields — a request could reach the admin queue with **zero** verification documents. Now requires ≥3 `OnboardingDocument` uploads (mirrors `SelectRoleCommandHandler`). Added a passing/failing test pair.
- **FR-AUTH-02 — lock anonymous reads.** Community (`categories/posts/post-details`), Resources (list/categories/featured/detail), and Consultants (whole controller) now require `[Authorize]`. **Exception kept public:** the profile-photo endpoint (`ProfileController`) stays `[AllowAnonymous]` because it is served to `<img src>` tags that don't carry the JWT — locking it would break every avatar.
- **SEC-11 🟠 — logout revokes the refresh token server-side.** Both `PublicLayout` and `AuthenticatedLayout` sign-out handlers now call `authApi.logout(refreshToken)` (fire-and-forget) before clearing local state, so a leaked refresh token can't be reused after logout.
- **RACE-03 🟠 — registration TOCTOU.** Concurrent same-email registrations that both pass the pre-check now return a friendly **409** (via `DbUpdateException` on the unique index) instead of a raw 500.

### Deferred (follow-up)
- **GAP-2** SSO external-identity linking + OAuth `state` (SEC-06) — larger, own PR.
- **GAP-3** onboarding document **type** validation (currently count-based) — needs a per-document type/key field (schema change).
- **R3** rate-limit `verify-email` / `change-email`.

### Verification
`dotnet test` unit suite green (824 passed, 2 skipped). Backend build + frontend `tsc` both clean.
