### PR TITLE
GAP-2/SEC-06: validate OAuth state nonce on SSO callback

### DIFF
--- a/client/src/pages/auth/SsoCallback.tsx
+++ b/client/src/pages/auth/SsoCallback.tsx
@@ -13,14 +13,17 @@ export function SsoCallback() {
   const ran = useRef(false);
 
   const code = params.get("code");
+  // SEC-06 / GAP-2 — the provider echoes the `state` nonce we sent; forward it so
+  // the server can validate the handshake and reject forged callbacks.
+  const state = params.get("state");
   const provider = authApi.pendingSsoProvider();
 
   useEffect(() => {
-    if (ran.current || !code || !provider) return;
+    if (ran.current || !code || !provider || !state) return;
     ran.current = true;
 
     authApi
-      .completeSso(provider, code)
+      .completeSso(provider, code, state)
       .then((res) => {
         const user = applyAuthSession(res);
         toast.success(t("auth:login.welcomeBack", { name: user.firstName || user.fullName }));
@@ -34,7 +37,7 @@ export function SsoCallback() {
 
   // A missing code / pending-provider is knowable at render time — no effect
   // is needed to flag it; only the async token exchange sets state (in catch).
-  const failed = exchangeFailed || !code || !provider;
+  const failed = exchangeFailed || !code || !provider || !state;
 
   return (
     <div className="mx-auto max-w-md px-4 py-20 text-center">

--- a/client/src/services/api/auth.ts
+++ b/client/src/services/api/auth.ts
@@ -122,10 +122,12 @@ export const authApi = {
     const value = sessionStorage.getItem(SSO_PROVIDER_KEY);
     return value === "google" || value === "microsoft" ? value : null;
   },
-  async completeSso(provider: SsoProvider, code: string): Promise<AuthTokensResponse> {
+  async completeSso(provider: SsoProvider, code: string, state: string): Promise<AuthTokensResponse> {
     sessionStorage.removeItem(SSO_PROVIDER_KEY);
+    // SEC-06 / GAP-2 — forward the `state` nonce the provider echoed back so the
+    // server can validate the OAuth handshake it started.
     const { data } = await apiClient.get<AuthTokensResponse>(`/api/auth/${provider}/callback`, {
-      params: { code, redirectUri: ssoRedirectUri() },
+      params: { code, redirectUri: ssoRedirectUri(), state },
     });
     return data;
   },

--- a/server/src/ScholarPath.API/Controllers/AuthController.cs
+++ b/server/src/ScholarPath.API/Controllers/AuthController.cs
@@ -24,7 +24,7 @@ namespace ScholarPath.API.Controllers;
 [ApiController]
 [Route("api/auth")]
 [Produces("application/json")]
-public sealed class AuthController(IMediator mediator, ISsoService ssoService) : ControllerBase
+public sealed class AuthController(IMediator mediator, ISsoService ssoService, ISsoStateStore ssoStateStore) : ControllerBase
 {
     /// <summary>Register a new account (Unassigned status) and return the initial token pair.</summary>
     [HttpPost("register")]
@@ -184,24 +184,45 @@ public sealed class AuthController(IMediator mediator, ISsoService ssoService) :
     [HttpGet("google/authorize")]
     [ProducesResponseType(StatusCodes.Status302Found)]
     public IActionResult GoogleAuthorize([FromQuery] string redirectUri)
-        => Redirect(ssoService.BuildGoogleAuthorizeUrl(redirectUri, Guid.NewGuid().ToString("N")));
+        => Redirect(ssoService.BuildGoogleAuthorizeUrl(redirectUri, IssueSsoState()));
 
     [HttpGet("google/callback")]
     [ProducesResponseType(typeof(AuthTokensDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<AuthTokensDto>> GoogleCallback(
-        [FromQuery] string code, [FromQuery] string redirectUri, CancellationToken ct)
-        => Ok(await mediator.Send(new SsoLoginCommand("Google", code, redirectUri), ct));
+        [FromQuery] string code, [FromQuery] string redirectUri, [FromQuery] string? state, CancellationToken ct)
+    {
+        if (!ValidateSsoState(state)) return BadRequest("Invalid or expired SSO state.");
+        return Ok(await mediator.Send(new SsoLoginCommand("Google", code, redirectUri), ct));
+    }
 
     [HttpGet("microsoft/authorize")]
     [ProducesResponseType(StatusCodes.Status302Found)]
     public IActionResult MicrosoftAuthorize([FromQuery] string redirectUri)
-        => Redirect(ssoService.BuildMicrosoftAuthorizeUrl(redirectUri, Guid.NewGuid().ToString("N")));
+        => Redirect(ssoService.BuildMicrosoftAuthorizeUrl(redirectUri, IssueSsoState()));
 
     [HttpGet("microsoft/callback")]
     [ProducesResponseType(typeof(AuthTokensDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<AuthTokensDto>> MicrosoftCallback(
-        [FromQuery] string code, [FromQuery] string redirectUri, CancellationToken ct)
-        => Ok(await mediator.Send(new SsoLoginCommand("Microsoft", code, redirectUri), ct));
+        [FromQuery] string code, [FromQuery] string redirectUri, [FromQuery] string? state, CancellationToken ct)
+    {
+        if (!ValidateSsoState(state)) return BadRequest("Invalid or expired SSO state.");
+        return Ok(await mediator.Send(new SsoLoginCommand("Microsoft", code, redirectUri), ct));
+    }
+
+    // SEC-06 / GAP-2 — issue a single-use CSPRNG `state` nonce and remember it
+    // server-side so the matching callback can prove the handshake it completes is
+    // the one this server started (anti-CSRF / anti account-linking).
+    private string IssueSsoState()
+    {
+        var state = System.Security.Cryptography.RandomNumberGenerator.GetHexString(32);
+        ssoStateStore.Store(state);
+        return state;
+    }
+
+    private bool ValidateSsoState(string? state)
+        => !string.IsNullOrWhiteSpace(state) && ssoStateStore.Consume(state);
 
     private string? ClientIp() => HttpContext.Connection.RemoteIpAddress?.ToString();
 

--- a/server/src/ScholarPath.Application/Common/Interfaces/ISsoStateStore.cs
+++ b/server/src/ScholarPath.Application/Common/Interfaces/ISsoStateStore.cs
@@ -1,0 +1,19 @@
+namespace ScholarPath.Application.Common.Interfaces;
+
+/// <summary>
+/// Server-side store for the OAuth <c>state</c> anti-CSRF nonce (SEC-06 / GAP-2).
+/// A value is issued when the SSO authorize redirect is built and consumed
+/// (single-use) when the provider calls back, so an attacker cannot replay a
+/// forged callback to hijack the OAuth handshake / link accounts.
+/// </summary>
+public interface ISsoStateStore
+{
+    /// <summary>Persist a freshly-minted state nonce with a short expiry.</summary>
+    void Store(string state);
+
+    /// <summary>
+    /// Returns <c>true</c> and removes the nonce if it was present (valid, unexpired,
+    /// unused); returns <c>false</c> for a missing / already-consumed / expired nonce.
+    /// </summary>
+    bool Consume(string state);
+}

--- a/server/src/ScholarPath.Infrastructure/DependencyInjection.cs
+++ b/server/src/ScholarPath.Infrastructure/DependencyInjection.cs
@@ -133,6 +133,11 @@ public static class DependencyInjection
             services.AddScoped<ISsoService, SsoService>();
         }
 
+        // SEC-06 / GAP-2 — server-side OAuth `state` nonce store (anti-CSRF).
+        // Registered regardless of stub/real SSO so the authorize↔callback
+        // handshake is validated in every environment.
+        services.AddSingleton<ISsoStateStore, MemorySsoStateStore>();
+
         // Email verification (FR-215) — wraps Identity's built-in confirmation tokens.
         services.AddScoped<IEmailVerificationService, EmailVerificationService>();
 

--- a/server/src/ScholarPath.Infrastructure/Services/MemorySsoStateStore.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/MemorySsoStateStore.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Caching.Memory;
+using ScholarPath.Application.Common.Interfaces;
+
+namespace ScholarPath.Infrastructure.Services;
+
+/// <summary>
+/// <see cref="IMemoryCache"/>-backed <see cref="ISsoStateStore"/> (SEC-06 / GAP-2).
+/// Nonces live for 10 minutes — long enough to complete an OAuth round-trip, short
+/// enough to bound replay. Single-use: <see cref="Consume"/> removes on read.
+///
+/// NOTE: in-process only. A scaled-out deployment where the authorize redirect and
+/// the callback can land on different instances must swap this for an
+/// <c>IDistributedCache</c>-backed implementation (same interface).
+/// </summary>
+public sealed class MemorySsoStateStore(IMemoryCache cache) : ISsoStateStore
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(10);
+
+    private static string Key(string state) => $"sso-state:{state}";
+
+    public void Store(string state)
+    {
+        if (string.IsNullOrWhiteSpace(state)) return;
+        cache.Set(Key(state), true, Ttl);
+    }
+
+    public bool Consume(string state)
+    {
+        if (string.IsNullOrWhiteSpace(state)) return false;
+        var key = Key(state);
+        if (cache.TryGetValue(key, out _))
+        {
+            cache.Remove(key);
+            return true;
+        }
+        return false;
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/Auth/MemorySsoStateStoreTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Auth/MemorySsoStateStoreTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using ScholarPath.Infrastructure.Services;
+using Xunit;
+
+namespace ScholarPath.UnitTests.Auth;
+
+/// <summary>SEC-06 / GAP-2 — OAuth <c>state</c> nonce store behaviour.</summary>
+public class MemorySsoStateStoreTests
+{
+    private static MemorySsoStateStore NewStore() =>
+        new(new MemoryCache(new MemoryCacheOptions()));
+
+    [Fact]
+    public void Stored_state_is_valid_once_then_rejected_on_replay()
+    {
+        var store = NewStore();
+        store.Store("abc123");
+
+        store.Consume("abc123").Should().BeTrue();   // legitimate callback
+        store.Consume("abc123").Should().BeFalse();  // single-use — replay rejected
+    }
+
+    [Fact]
+    public void Unknown_state_is_rejected()
+    {
+        NewStore().Consume("never-issued").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Blank_state_is_rejected()
+    {
+        var store = NewStore();
+        store.Consume("").Should().BeFalse();
+        store.Consume("   ").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## GAP-2 / SEC-06 — validate the OAuth `state` nonce on SSO callback

The Google/Microsoft authorize endpoints generated a `state` GUID but **never stored it**, and the callbacks **never validated it** — so an attacker could replay a forged OAuth callback to hijack the handshake / link an account. This adds proper anti-CSRF `state` validation.

### Changes
- **`ISsoStateStore` + `MemorySsoStateStore`** (IMemoryCache-backed, 10-min TTL, single-use). Registered in DI regardless of stub/real SSO.
- **`AuthController`**: `google/authorize` & `microsoft/authorize` now mint a CSPRNG `state` (`RandomNumberGenerator.GetHexString(32)`) and store it; `google/callback` & `microsoft/callback` take `state` and **reject with 400** if it is missing / unknown / already used / expired.
- **Frontend**: `SsoCallback.tsx` reads the `state` the provider echoes back and forwards it via `authApi.completeSso(provider, code, state)`.
- **Tests**: `MemorySsoStateStoreTests` (valid-once, replay-rejected, unknown/blank rejected). **827 unit tests pass.**

### Deployment note
`MemorySsoStateStore` is in-process. A scaled-out deployment (authorize and callback on different instances) should swap it for an `IDistributedCache`-backed implementation of the same interface.

### Still deferred (smaller follow-up)
Recording the external identity (`provider` + `providerUserId`) in a `UserLogins` row and preferring `FindByLogin` over email lookup. Practical risk is low because the SSO email is provider-verified, so email-based linking resolves to the same person; tracked for a later pass.

### Verification
Backend build + frontend `tsc` clean; unit suite green (827 passed, 2 skipped).
