### PR TITLE
Auth hardening: rate-limit verify/change-email (R3) + record SSO external identity (GAP-2/FR-AUTH-13)

### DIFF
--- a/server/src/ScholarPath.API/Controllers/AuthController.cs
+++ b/server/src/ScholarPath.API/Controllers/AuthController.cs
@@ -101,6 +101,7 @@ public sealed class AuthController(IMediator mediator, ISsoService ssoService, I
 
     /// <summary>Confirm an email address using the token from the verification link (FR-215).</summary>
     [HttpPost("verify-email")]
+    [EnableRateLimiting("auth")] // R3 — throttle token-guessing on the verification endpoint
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
@@ -171,6 +172,7 @@ public sealed class AuthController(IMediator mediator, ISsoService ssoService, I
     /// </summary>
     [HttpPost("change-email/confirm")]
     [Authorize]
+    [EnableRateLimiting("auth")] // R3 — throttle token-guessing on email-change confirmation
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]

--- a/server/src/ScholarPath.Application/Auth/Commands/SsoLogin/SsoLoginCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/SsoLogin/SsoLoginCommandHandler.cs
@@ -30,7 +30,14 @@ public sealed class SsoLoginCommandHandler(
         var normalizedEmail = email.ToUpperInvariant();
         var now = clock.UtcNow;
 
-        var user = await db.Users.FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, ct);
+        // GAP-2 / FR-AUTH-13 — resolve by the recorded external identity first; only
+        // then fall back to the provider-verified email. This makes account linking
+        // explicit (a provider identity maps to exactly one account) rather than
+        // implicitly re-binding by whatever email a provider currently reports.
+        var linkedUserId = await userAdministration.FindUserIdByExternalLoginAsync(info.Provider, info.ProviderUserId, ct);
+        var user = linkedUserId is { } lid
+            ? await db.Users.FirstOrDefaultAsync(u => u.Id == lid, ct)
+            : await db.Users.FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, ct);
 
         IReadOnlyList<string> roles;
         if (user is null)
@@ -64,6 +71,10 @@ public sealed class SsoLoginCommandHandler(
             await db.SaveChangesAsync(ct);
             roles = await userAdministration.GetRolesAsync(user.Id, ct);
         }
+
+        // Record the external identity link (idempotent) so the next sign-in — even
+        // if the provider later reports a different email — resolves to THIS account.
+        await userAdministration.AddExternalLoginAsync(user.Id, info.Provider, info.ProviderUserId, ct);
 
         var tokens = tokenService.IssueTokens(user, roles, user.ActiveRole, rememberMe: false);
         return AuthDtoFactory.Build(tokens, user, roles);

--- a/server/src/ScholarPath.Application/Common/Interfaces/IUserAdministration.cs
+++ b/server/src/ScholarPath.Application/Common/Interfaces/IUserAdministration.cs
@@ -20,4 +20,16 @@ public interface IUserAdministration
 
     /// <summary>Revokes all active refresh tokens for a user; called on suspend/deactivate.</summary>
     Task RevokeAllSessionsAsync(Guid userId, string reason, CancellationToken ct);
+
+    /// <summary>
+    /// GAP-2 / FR-AUTH-13 — records an external (SSO) login so the account can be
+    /// found by provider identity on the next sign-in. Idempotent.
+    /// </summary>
+    Task AddExternalLoginAsync(Guid userId, string provider, string providerKey, CancellationToken ct);
+
+    /// <summary>
+    /// GAP-2 / FR-AUTH-13 — resolves the user id previously linked to an external
+    /// (provider, providerKey) login, or <c>null</c> if none is recorded.
+    /// </summary>
+    Task<Guid?> FindUserIdByExternalLoginAsync(string provider, string providerKey, CancellationToken ct);
 }

--- a/server/src/ScholarPath.Infrastructure/Services/UserAdministration.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/UserAdministration.cs
@@ -96,4 +96,27 @@ public sealed class UserAdministration(
         }
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
+
+    public async Task AddExternalLoginAsync(Guid userId, string provider, string providerKey, CancellationToken ct)
+    {
+        var user = await users.FindByIdAsync(userId.ToString()).ConfigureAwait(false);
+        if (user is null) return;
+
+        // Idempotent — a repeat SSO sign-in must not add a duplicate (provider, key) login.
+        var existing = await users.GetLoginsAsync(user).ConfigureAwait(false);
+        if (existing.Any(l => l.LoginProvider == provider && l.ProviderKey == providerKey)) return;
+
+        var result = await users.AddLoginAsync(user, new UserLoginInfo(provider, providerKey, provider)).ConfigureAwait(false);
+        if (!result.Succeeded)
+        {
+            logger.LogWarning("Failed to record external login {Provider} for user {UserId}: {Errors}",
+                provider, userId, string.Join("; ", result.Errors.Select(e => e.Description)));
+        }
+    }
+
+    public async Task<Guid?> FindUserIdByExternalLoginAsync(string provider, string providerKey, CancellationToken ct)
+    {
+        var user = await users.FindByLoginAsync(provider, providerKey).ConfigureAwait(false);
+        return user?.Id;
+    }
 }


### PR DESCRIPTION
## Auth hardening follow-ups — R3 + GAP-2

Two of the three deferred items from the Auth/Onboarding module review. **827 unit tests pass.** (The third, GAP-3, needs a new FR + schema/UI change — sent separately for ratification, not in this PR.)

### R3 — rate-limit the remaining token endpoints
`POST /api/auth/verify-email` and `POST /api/auth/change-email/confirm` had no throttling (unlike register/login/forgot-password/resend). Both now carry `[EnableRateLimiting("auth")]` to bound token-guessing.

### GAP-2 / FR-AUTH-13 — record & resolve the SSO external identity
Previously SSO found/created the account by **email only** and never recorded which provider identity was linked. Now:
- `IUserAdministration` gains `AddExternalLoginAsync` + `FindUserIdByExternalLoginAsync`, implemented over ASP.NET Identity's existing `UserLogins` table (no schema change).
- `SsoLoginCommandHandler` resolves by the recorded `(provider, providerUserId)` **first**, falls back to the provider-verified email, and records the link (idempotent) on every sign-in — so a returning user maps to exactly one account even if the provider later reports a different email. This completes **FR-AUTH-13** (which requires the external identity to be *linked*, not just email-matched).

### Verification
Backend build clean; unit suite green (827 passed, 2 skipped). Existing SSO handler tests still pass (email fallback unchanged when no external link exists).
