### PR TITLE
fix(audit-p1): high-severity remediation — payments split, booking races, moderation, CSP, validation

### DIFF
--- a/client/public/staticwebapp.config.json
+++ b/client/public/staticwebapp.config.json
@@ -9,5 +9,12 @@
       "rewrite": "/index.html",
       "statusCode": 200
     }
+  },
+  "globalHeaders": {
+    "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss:; frame-src 'self' https://js.stripe.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
   }
 }

--- a/server/src/ScholarPath.API/Controllers/AuthController.cs
+++ b/server/src/ScholarPath.API/Controllers/AuthController.cs
@@ -21,6 +21,13 @@ using ScholarPath.Application.Common.Interfaces;
 
 namespace ScholarPath.API.Controllers;
 
+// SEC-10: this controller is intentionally MIXED — public flows (register/login/
+// refresh/forgot-password/SSO callbacks) and authenticated ones (logout/me/
+// switch-role/select-role/change-email). It must NOT carry a class-level
+// [AllowAnonymous] (that would override the method [Authorize]s and expose the
+// authenticated actions — ASP0026) NOR a class-level [Authorize] (that would 401
+// the public flows). Every action is therefore explicitly attributed at the
+// method level; the protected ones carry [Authorize].
 [ApiController]
 [Route("api/auth")]
 [Produces("application/json")]

--- a/server/src/ScholarPath.API/Controllers/ChatController.cs
+++ b/server/src/ScholarPath.API/Controllers/ChatController.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using ScholarPath.Application.Chat.Commands.BlockUser;
 using ScholarPath.Application.Chat.Commands.SendMessage;
 using ScholarPath.Application.Chat.Commands.UnblockUser;
@@ -38,6 +39,7 @@ public class ChatController(IMediator mediator) : ControllerBase
     }
 
     [HttpPost("messages")]
+    [EnableRateLimiting("messaging")]  // PERF-01: throttle chat sends per user
     public async Task<IActionResult> SendMessage([FromBody] SendMessageRequest request, CancellationToken ct)
     {
         var command = new SendMessageCommand(request.RecipientId, request.Body);

--- a/server/src/ScholarPath.API/Controllers/DiagnosticsController.cs
+++ b/server/src/ScholarPath.API/Controllers/DiagnosticsController.cs
@@ -5,7 +5,11 @@ using ScholarPath.Infrastructure.Hubs;
 
 namespace ScholarPath.API.Controllers;
 
+// SEC-10: explicit default posture. Every Diagnostics action is authenticated, so
+// the controller is deny-by-default at the class level — a newly-added action
+// inherits [Authorize] instead of silently shipping open.
 [ApiController]
+[Authorize]
 [Route("api/diagnostics")]
 [Produces("application/json")]
 public sealed class DiagnosticsController(IHubContext<NotificationHub> notificationHub) : ControllerBase

--- a/server/src/ScholarPath.API/Program.cs
+++ b/server/src/ScholarPath.API/Program.cs
@@ -152,6 +152,27 @@ builder.Services.AddRateLimiter(opts =>
             });
     });
 
+    // PERF-01: throttle chat message sends per user (fall back to IP for
+    // anonymous) so one account cannot spam/DoS recipients. Higher than "ai"
+    // since chat is a higher-frequency human action; only the REST send path is
+    // covered (a SignalR hub send path, if added, needs hub-level throttling).
+    opts.AddPolicy("messaging", httpContext =>
+    {
+        var userId = httpContext.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        var partition = !string.IsNullOrEmpty(userId)
+            ? $"user:{userId}"
+            : $"ip:{httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+
+        return System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: partition,
+            factory: _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                Window = TimeSpan.FromMinutes(1),
+                PermitLimit = 40,
+                QueueLimit = 0,
+            });
+    });
+
     opts.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 });
 

--- a/server/src/ScholarPath.Application/AI/Common/AiCostGate.cs
+++ b/server/src/ScholarPath.Application/AI/Common/AiCostGate.cs
@@ -37,6 +37,15 @@ public sealed class AiCostGate(
             .ConfigureAwait(false)
             ?? 0m;
 
+        // RACE-05 (KNOWN LIMITATION — deliberately not closed here): this is a
+        // check-then-act read, so highly-concurrent same-user requests could each
+        // read the same rolling total and each pass, overrunning the daily cap by
+        // up to (N-1)*pendingCost. A SERIALIZABLE transaction does NOT fix it — the
+        // check is read-only, so shared range locks don't conflict and both pass.
+        // Genuinely closing it needs a cost-reservation row written INSIDE a
+        // transaction before the LLM call and reconciled to the real cost after
+        // (a schema + multi-handler change, deferred to v2). Practical impact is
+        // negligible: per-call cost (~$0.0003) is tiny versus the ~$1.00 cap.
         if (used + pendingCostUsd > limit)
         {
             throw new ConflictException(

--- a/server/src/ScholarPath.Application/Admin/Commands/SoftDeleteUser/SoftDeleteUserCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/SoftDeleteUser/SoftDeleteUserCommandHandler.cs
@@ -1,17 +1,45 @@
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
 
 namespace ScholarPath.Application.Admin.Commands.SoftDeleteUser;
 
 public sealed class SoftDeleteUserCommandHandler(
     IUserAdministration admin,
+    IApplicationDbContext context,
+    IDateTimeService clock,
     ILogger<SoftDeleteUserCommandHandler> logger)
     : IRequestHandler<SoftDeleteUserCommand, bool>
 {
     public async Task<bool> Handle(SoftDeleteUserCommand request, CancellationToken ct)
     {
+        // BUG-05: block deletion while the target consultant still owes live
+        // consulting sessions. Soft-delete deactivates the account and revokes
+        // sessions, so an orphaned future booking would leave the student in an
+        // empty room with an unreleased card hold. Require the admin to
+        // cancel/refund those bookings first (each party can cancel via the
+        // existing refund path). Deleting a plain student, or a consultant with
+        // only past/terminal bookings, is unaffected.
+        var now = clock.UtcNow;
+        var activeBookings = await context.Bookings
+            .CountAsync(
+                b => b.ConsultantId == request.UserId
+                     && b.ScheduledStartAt > now
+                     && (b.Status == BookingStatus.Requested || b.Status == BookingStatus.Confirmed),
+                ct)
+            .ConfigureAwait(false);
+
+        if (activeBookings > 0)
+        {
+            throw new ConflictException(
+                $"User has {activeBookings} active (requested/confirmed) upcoming consultation booking(s). " +
+                "Cancel and refund those bookings before deleting the account.");
+        }
+
         var ok = await admin.SoftDeleteAsync(request.UserId, ct).ConfigureAwait(false);
         if (!ok)
         {

--- a/server/src/ScholarPath.Application/Analytics/Queries/GetScholarshipProviderInsights/GetScholarshipProviderInsightsQuery.cs
+++ b/server/src/ScholarPath.Application/Analytics/Queries/GetScholarshipProviderInsights/GetScholarshipProviderInsightsQuery.cs
@@ -123,25 +123,34 @@ public sealed class GetScholarshipProviderInsightsQueryHandler(
                 (a.DecisionAt!.Value - a.SubmittedAt!.Value).TotalDays), 2)
             : 0m;
 
-        // Platform-wide acceptance rate (only decided in same window) for delta
-        var platformDecisionCounts = await db.Applications
-            .AsNoTracking()
-            .Where(a => !a.IsDeleted
-                && a.CreatedAt >= fromOffset
-                && a.CreatedAt <= toOffset
-                && (a.Status == ApplicationStatus.Accepted
-                    || a.Status == ApplicationStatus.Rejected))
-            .GroupBy(_ => 1)
-            .Select(g => new
-            {
-                Decided = g.Count(),
-                Accepted = g.Count(a => a.Status == ApplicationStatus.Accepted),
-            })
-            .FirstOrDefaultAsync(ct);
-        var platformAcceptanceRate = platformDecisionCounts != null && platformDecisionCounts.Decided > 0
-            ? Math.Round((decimal)platformDecisionCounts.Accepted * 100m / platformDecisionCounts.Decided, 2)
-            : 0m;
-        var comparisonDelta = Math.Round(acceptanceRate - platformAcceptanceRate, 2);
+        // DATA-05 (FR-207 competitive isolation): the platform-wide acceptance-rate
+        // delta is competitively sensitive — a ScholarshipProvider already receives
+        // its own AcceptanceRate in this DTO, so exposing the delta lets it invert
+        // the platform-wide average (and infer competitors' aggregate performance).
+        // Only admins may see the delta; non-admin owners get 0m (no platform
+        // figure disclosed). This also skips the extra aggregate query for them.
+        decimal comparisonDelta = 0m;
+        if (isAdmin)
+        {
+            var platformDecisionCounts = await db.Applications
+                .AsNoTracking()
+                .Where(a => !a.IsDeleted
+                    && a.CreatedAt >= fromOffset
+                    && a.CreatedAt <= toOffset
+                    && (a.Status == ApplicationStatus.Accepted
+                        || a.Status == ApplicationStatus.Rejected))
+                .GroupBy(_ => 1)
+                .Select(g => new
+                {
+                    Decided = g.Count(),
+                    Accepted = g.Count(a => a.Status == ApplicationStatus.Accepted),
+                })
+                .FirstOrDefaultAsync(ct);
+            var platformAcceptanceRate = platformDecisionCounts != null && platformDecisionCounts.Decided > 0
+                ? Math.Round((decimal)platformDecisionCounts.Accepted * 100m / platformDecisionCounts.Decided, 2)
+                : 0m;
+            comparisonDelta = Math.Round(acceptanceRate - platformAcceptanceRate, 2);
+        }
 
         // ── By country (resolved via student profile) ──────────────────────────
         var studentIds = applications.Select(a => a.StudentId).Distinct().ToList();

--- a/server/src/ScholarPath.Application/Applications/Commands/ReviewApplication/ReviewApplicationCommandValidator.cs
+++ b/server/src/ScholarPath.Application/Applications/Commands/ReviewApplication/ReviewApplicationCommandValidator.cs
@@ -8,7 +8,16 @@ public sealed class ReviewApplicationCommandValidator : AbstractValidator<Review
     public ReviewApplicationCommandValidator()
     {
         RuleFor(v => v.ApplicationId).NotEmpty();
-        RuleFor(v => v.Status).Must(s => s is ApplicationStatus.Accepted or ApplicationStatus.Rejected)
-            .WithMessage("Review status must be Accepted or Rejected.");
+        // BUG-02: the allowed decision set must stay in sync with
+        // ApplicationStateMachine (the authoritative from->to guard in the handler,
+        // which still rejects illegal transitions with a 409). Shortlisted and
+        // UnderReview are legitimate provider review targets; omitting Shortlisted
+        // wrongly 422'd a valid shortlist decision.
+        RuleFor(v => v.Status)
+            .Must(s => s is ApplicationStatus.UnderReview
+                        or ApplicationStatus.Shortlisted
+                        or ApplicationStatus.Accepted
+                        or ApplicationStatus.Rejected)
+            .WithMessage("Review status must be UnderReview, Shortlisted, Accepted, or Rejected.");
     }
 }

--- a/server/src/ScholarPath.Application/Chat/Commands/SendMessage/SendMessageCommand.cs
+++ b/server/src/ScholarPath.Application/Chat/Commands/SendMessage/SendMessageCommand.cs
@@ -61,11 +61,18 @@ public sealed class SendMessageCommandHandler(
             throw new ConflictException("Cannot send message. User is blocked.");
         }
 
+        // SEC-07 defense-in-depth: strip any HTML/script markup before persisting,
+        // mirroring community posts/replies. The chat UI renders the body as a React
+        // text node today, but the same string also fans out to a SignalR push and an
+        // email notification preview (a non-React sink), so sanitizing on store keeps
+        // every sink safe.
+        var sanitizedBody = new Ganss.Xss.HtmlSanitizer().Sanitize(request.Body);
+
         var message = new ChatMessage
         {
             ConversationId = conversation.Id,
             SenderId = senderId,
-            Body = request.Body,
+            Body = sanitizedBody,
             SentAt = DateTimeOffset.UtcNow
         };
 
@@ -90,7 +97,7 @@ public sealed class SendMessageCommandHandler(
                 MessageId: message.Id,
                 SenderId: senderId,
                 RecipientId: request.RecipientId,
-                BodyPreview: request.Body),
+                BodyPreview: sanitizedBody),
             ct).ConfigureAwait(false);
 
         return message.Id;

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/RequestBooking/RequestBookingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/RequestBooking/RequestBookingCommandHandler.cs
@@ -270,8 +270,9 @@ public sealed class RequestBookingCommandHandler : IRequestHandler<RequestBookin
                 DeletedByUserId = null
             };
 
-            _context.Bookings.Add(freeBooking);
-            await _context.SaveChangesAsync(cancellationToken);
+            await PersistBookingWithSlotGuardAsync(
+                freeBooking, request.ConsultantId, studentId,
+                scheduledStartAtUtc, scheduledEndAtUtc, cancellationToken);
 
             await _publisher.Publish(
                 new BookingRequestedEvent(
@@ -355,8 +356,9 @@ public sealed class RequestBookingCommandHandler : IRequestHandler<RequestBookin
             DeletedByUserId = null
         };
 
-        _context.Bookings.Add(booking);
-        await _context.SaveChangesAsync(cancellationToken);
+        await PersistBookingWithSlotGuardAsync(
+            booking, request.ConsultantId, studentId,
+            scheduledStartAtUtc, scheduledEndAtUtc, cancellationToken);
 
         payment.RelatedBookingId = booking.Id;
         await _context.SaveChangesAsync(cancellationToken);
@@ -372,5 +374,65 @@ public sealed class RequestBookingCommandHandler : IRequestHandler<RequestBookin
         // Return the intent's client secret so the checkout widget confirms
         // THIS intent — it must not create a second one (PB-006 Problem 1).
         return new RequestBookingResult(booking.Id, IsFree: false, paymentIntent.ClientSecret, paymentIntent.Id);
+    }
+
+    // RACE-04: the app-level overlap check above runs under READ COMMITTED with no
+    // transaction, so two concurrent requests for overlapping-but-different start
+    // times can both pass it and both insert (the unique index only guards the exact
+    // ScheduledStartAt). On a relational provider, re-check overlap and insert inside
+    // a SERIALIZABLE transaction so range locks force the second insert to block then
+    // fail the re-check. The Stripe intent is created BEFORE this (outside the tx) so
+    // no network call is held under the locks. The InMemory provider (unit tests) has
+    // no isolation levels, so fall back to a plain insert — the app-level check above
+    // still guards the non-concurrent case the tests exercise.
+    private async Task PersistBookingWithSlotGuardAsync(
+        ConsultantBooking booking,
+        Guid consultantId,
+        Guid studentId,
+        DateTimeOffset scheduledStartAtUtc,
+        DateTimeOffset scheduledEndAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (!_context.Database.IsRelational())
+        {
+            _context.Bookings.Add(booking);
+            await _context.SaveChangesAsync(cancellationToken);
+            return;
+        }
+
+        var blockingStatuses = new[] { BookingStatus.Requested, BookingStatus.Confirmed };
+
+        var strategy = _context.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await _context.Database.BeginTransactionAsync(
+                System.Data.IsolationLevel.Serializable, cancellationToken);
+
+            var consultantHasConflict = await _context.Bookings.AnyAsync(
+                b => b.ConsultantId == consultantId
+                     && blockingStatuses.Contains(b.Status)
+                     && scheduledStartAtUtc < b.ScheduledEndAt
+                     && scheduledEndAtUtc > b.ScheduledStartAt,
+                cancellationToken);
+            if (consultantHasConflict)
+            {
+                throw new BookingDomainException("Consultant already has a booking that overlaps this time.");
+            }
+
+            var studentHasConflict = await _context.Bookings.AnyAsync(
+                b => b.StudentId == studentId
+                     && blockingStatuses.Contains(b.Status)
+                     && scheduledStartAtUtc < b.ScheduledEndAt
+                     && scheduledEndAtUtc > b.ScheduledStartAt,
+                cancellationToken);
+            if (studentHasConflict)
+            {
+                throw new BookingDomainException("Student already has a booking that overlaps this time.");
+            }
+
+            _context.Bookings.Add(booking);
+            await _context.SaveChangesAsync(cancellationToken);
+            await tx.CommitAsync(cancellationToken);
+        });
     }
 }

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/RescheduleBooking/RescheduleBookingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/RescheduleBooking/RescheduleBookingCommandHandler.cs
@@ -124,38 +124,59 @@ public sealed class RescheduleBookingCommandHandler : IRequestHandler<Reschedule
             BookingStatus.Confirmed
         };
 
-        // The booking being moved must not collide with itself.
-        var consultantHasConflict = await _context.Bookings.AnyAsync(
-            b => b.Id != booking.Id
-                 && b.ConsultantId == booking.ConsultantId
-                 && blockingStatuses.Contains(b.Status)
-                 && scheduledStartAtUtc < b.ScheduledEndAt
-                 && scheduledEndAtUtc > b.ScheduledStartAt,
-            cancellationToken);
-
-        if (consultantHasConflict)
+        // RACE-04: re-check overlap + apply the move atomically. The booking being
+        // moved must not collide with itself (b.Id != booking.Id). On a relational
+        // provider this runs under SERIALIZABLE so a concurrent reschedule into an
+        // overlapping slot blocks then fails the re-check; the InMemory provider
+        // (unit tests) has no isolation levels, so run the check+save directly.
+        async Task CheckAndSaveAsync()
         {
-            throw new BookingDomainException("Consultant already has a booking that overlaps this time.");
+            var consultantHasConflict = await _context.Bookings.AnyAsync(
+                b => b.Id != booking.Id
+                     && b.ConsultantId == booking.ConsultantId
+                     && blockingStatuses.Contains(b.Status)
+                     && scheduledStartAtUtc < b.ScheduledEndAt
+                     && scheduledEndAtUtc > b.ScheduledStartAt,
+                cancellationToken);
+            if (consultantHasConflict)
+            {
+                throw new BookingDomainException("Consultant already has a booking that overlaps this time.");
+            }
+
+            var studentHasConflict = await _context.Bookings.AnyAsync(
+                b => b.Id != booking.Id
+                     && b.StudentId == booking.StudentId
+                     && blockingStatuses.Contains(b.Status)
+                     && scheduledStartAtUtc < b.ScheduledEndAt
+                     && scheduledEndAtUtc > b.ScheduledStartAt,
+                cancellationToken);
+            if (studentHasConflict)
+            {
+                throw new BookingDomainException("Student already has a booking that overlaps this time.");
+            }
+
+            booking.ScheduledStartAt = scheduledStartAtUtc;
+            booking.ScheduledEndAt = scheduledEndAtUtc;
+            booking.AvailabilityId = request.AvailabilityId;
+
+            await _context.SaveChangesAsync(cancellationToken);
         }
 
-        var studentHasConflict = await _context.Bookings.AnyAsync(
-            b => b.Id != booking.Id
-                 && b.StudentId == booking.StudentId
-                 && blockingStatuses.Contains(b.Status)
-                 && scheduledStartAtUtc < b.ScheduledEndAt
-                 && scheduledEndAtUtc > b.ScheduledStartAt,
-            cancellationToken);
-
-        if (studentHasConflict)
+        if (_context.Database.IsRelational())
         {
-            throw new BookingDomainException("Student already has a booking that overlaps this time.");
+            var strategy = _context.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
+            {
+                await using var tx = await _context.Database.BeginTransactionAsync(
+                    System.Data.IsolationLevel.Serializable, cancellationToken);
+                await CheckAndSaveAsync();
+                await tx.CommitAsync(cancellationToken);
+            });
         }
-
-        booking.ScheduledStartAt = scheduledStartAtUtc;
-        booking.ScheduledEndAt = scheduledEndAtUtc;
-        booking.AvailabilityId = request.AvailabilityId;
-
-        await _context.SaveChangesAsync(cancellationToken);
+        else
+        {
+            await CheckAndSaveAsync();
+        }
 
         await _publisher.Publish(
             new BookingRescheduledEvent(

--- a/server/src/ScholarPath.Application/Documents/Commands/UploadDocument/UploadDocumentCommand.cs
+++ b/server/src/ScholarPath.Application/Documents/Commands/UploadDocument/UploadDocumentCommand.cs
@@ -61,8 +61,22 @@ public sealed class UploadDocumentCommandHandler(
     private const string Container = "documents";
 
     // Extensions a document vault is expected to hold — keeps executables out.
-    private static readonly string[] AllowedExtensions =
-        [".pdf", ".doc", ".docx", ".jpg", ".jpeg", ".png", ".webp", ".txt", ".rtf", ".odt"];
+    // Each maps to the MIME type(s) the declared ContentType must match, so a
+    // spoofed/mismatched client ContentType is rejected up front (DATA-03).
+    private static readonly IReadOnlyDictionary<string, string[]> AllowedTypes =
+        new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".pdf"]  = ["application/pdf"],
+            [".doc"]  = ["application/msword"],
+            [".docx"] = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+            [".jpg"]  = ["image/jpeg"],
+            [".jpeg"] = ["image/jpeg"],
+            [".png"]  = ["image/png"],
+            [".webp"] = ["image/webp"],
+            [".txt"]  = ["text/plain"],
+            [".rtf"]  = ["application/rtf", "text/rtf"],
+            [".odt"]  = ["application/vnd.oasis.opendocument.text"],
+        };
 
     public async Task<DocumentDto> Handle(UploadDocumentCommand request, CancellationToken ct)
     {
@@ -70,9 +84,17 @@ public sealed class UploadDocumentCommandHandler(
             ?? throw new ForbiddenAccessException("Not authenticated.");
 
         var extension = Path.GetExtension(request.FileName);
-        if (!AllowedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+        if (!AllowedTypes.TryGetValue(extension, out var allowedContentTypes))
             throw new ConflictException(
                 "Unsupported file type. Allowed: PDF, Word, image, or text documents.");
+
+        // DATA-03: the declared MIME type must match the file's extension — a
+        // spoofed/arbitrary client ContentType is rejected before the bytes are
+        // stored. (Magic-byte verification is the v2 hardening.)
+        var contentType = (request.ContentType ?? string.Empty).Trim();
+        if (!allowedContentTypes.Contains(contentType, StringComparer.OrdinalIgnoreCase))
+            throw new ConflictException(
+                "The file's declared content type does not match its extension.");
 
         // A document may only be linked to one of the caller's own applications.
         if (request.ApplicationTrackerId is { } appId)
@@ -107,7 +129,7 @@ public sealed class UploadDocumentCommandHandler(
         }
 
         var storagePath = await storage
-            .UploadAsync(request.Content, safeName, request.ContentType, Container, ct)
+            .UploadAsync(request.Content, safeName, contentType, Container, ct)
             .ConfigureAwait(false);
 
         var now = clock.UtcNow;
@@ -116,7 +138,7 @@ public sealed class UploadDocumentCommandHandler(
             Id = Guid.NewGuid(),
             OwnerUserId = userId,
             FileName = safeName,
-            ContentType = request.ContentType,
+            ContentType = contentType,
             SizeBytes = request.Length,
             StoragePath = storagePath,
             Category = request.Category,

--- a/server/src/ScholarPath.Application/Payments/Commands/ProcessStripeWebhook/ProcessStripeWebhookCommand.cs
+++ b/server/src/ScholarPath.Application/Payments/Commands/ProcessStripeWebhook/ProcessStripeWebhookCommand.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.FinancialConfig;
 using ScholarPath.Application.Notifications;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
@@ -200,13 +201,27 @@ public sealed class ProcessStripeWebhookCommandHandler(
                 break;
 
             case "charge.refunded":
-                var refunded = request.AmountCents ?? payment.AmountCents;
+                // DATA-02: clamp the webhook-reported refund to [0, AmountCents] so
+                // the retained split can never go negative (Stripe should never
+                // overstate it, but a malformed/duplicated event must not corrupt
+                // the ledger into a negative payee amount).
+                var refunded = Math.Clamp(
+                    request.AmountCents ?? payment.AmountCents, 0, payment.AmountCents);
                 payment.RefundedAmountCents = refunded;
                 payment.RefundedAt = DateTimeOffset.UtcNow;
                 payment.RefundReason = "charge.refunded";
                 payment.Status = refunded >= payment.AmountCents
                     ? PaymentStatus.Refunded
                     : PaymentStatus.PartiallyRefunded;
+                // MON-02: a refund shrinks the payable base, so recompute the split
+                // off the RETAINED amount (gross - refunded). Without this, a refund
+                // that arrives via webhook (not the admin RefundPaymentCommand) left
+                // ProfitShare/Payee at capture-time values and the nightly payout
+                // overpaid the payee. Mirrors RefundPaymentCommand's retained split.
+                var refundSplit = await FinancialRuleResolver.ResolveSplitFromRetainedAsync(
+                    db, payment.Type, payment.AmountCents, payment.RefundedAmountCents, ct);
+                payment.ProfitShareAmountCents = refundSplit.PlatformTakeCents;
+                payment.PayeeAmountCents = refundSplit.PayeeNetCents;
                 break;
 
             case "charge.dispute.created":

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/CaptureScholarshipProviderReviewPayment/CaptureScholarshipProviderReviewPaymentCommand.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/CaptureScholarshipProviderReviewPayment/CaptureScholarshipProviderReviewPaymentCommand.cs
@@ -57,41 +57,51 @@ public sealed class CaptureScholarshipProviderReviewPaymentCommandHandler(
             return false;
         }
 
-        try
+        // ERR-01: do NOT wrap the Stripe capture in a catch-all. StripeService
+        // already surfaces a real StripeException as a BookingDomainException (422),
+        // and any other failure must PROPAGATE so the capture is retried — the old
+        // blanket `catch => return false` silently left the payment Held, so the
+        // consultant/provider was never paid and nothing surfaced. The benign
+        // non-success status (already-captured / requires_action) still returns
+        // false explicitly below, mirroring CapturePaymentIntentCommandHandler.
+        var stripeResult = await stripeService.CapturePaymentIntentAsync(
+            payment.StripePaymentIntentId,
+            amountToCaptureCents: null,
+            idempotencyKey: $"company-review-capture:{payment.Id:N}",
+            ct: ct);
+
+        if (stripeResult.Status != "succeeded")
         {
-            var stripeResult = await stripeService.CapturePaymentIntentAsync(
-                payment.StripePaymentIntentId,
-                amountToCaptureCents: null,
-                idempotencyKey: $"company-review-capture:{payment.Id:N}",
-                ct: ct);
+            logger.LogWarning(
+                "Capture for application {ApplicationId} returned Stripe status {Status}; payment left as {Original}.",
+                request.ApplicationId, stripeResult.Status, payment.Status);
+            return false;
+        }
 
-            if (stripeResult.Status != "succeeded")
-            {
-                logger.LogWarning(
-                    "Capture for application {ApplicationId} returned Stripe status {Status}; payment left as {Original}.",
-                    request.ApplicationId, stripeResult.Status, payment.Status);
-                return false;
-            }
+        var nowUtc = DateTimeOffset.UtcNow;
+        payment.Status = PaymentStatus.Captured;
+        payment.CapturedAt = nowUtc;
+        if (!string.IsNullOrWhiteSpace(stripeResult.LatestChargeId))
+        {
+            payment.StripeChargeId = stripeResult.LatestChargeId;
+        }
 
-            var nowUtc = DateTimeOffset.UtcNow;
-            payment.Status = PaymentStatus.Captured;
-            payment.CapturedAt = nowUtc;
-            if (!string.IsNullOrWhiteSpace(stripeResult.LatestChargeId))
-            {
-                payment.StripeChargeId = stripeResult.LatestChargeId;
-            }
+        // Re-resolve the split at capture time so the snapshot reflects the
+        // rule in force right now (an admin can change the active rule
+        // between intent creation and capture). PB-014 v1 = 10% default.
+        var split = await FinancialRuleResolver.ResolvePaymentSplitAsync(
+            db, payment.Type, payment.AmountCents, ct);
+        payment.ProfitShareAmountCents = split.PlatformTakeCents;
+        payment.PayeeAmountCents = split.PayeeNetCents;
 
-            // Re-resolve the split at capture time so the snapshot reflects the
-            // rule in force right now (an admin can change the active rule
-            // between intent creation and capture). PB-014 v1 = 10% default.
-            var split = await FinancialRuleResolver.ResolvePaymentSplitAsync(
-                db, payment.Type, payment.AmountCents, ct);
-            payment.ProfitShareAmountCents = split.PlatformTakeCents;
-            payment.PayeeAmountCents = split.PayeeNetCents;
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
 
-            await db.SaveChangesAsync(ct).ConfigureAwait(false);
-
-            if (payment.PayeeUserId is Guid payee)
+        // The payment is captured + persisted; a notification failure must not
+        // undo that success (and must not report the capture as failed), so the
+        // dispatch is best-effort — same stance as StripePayoutJob.SafeNotifyAsync.
+        if (payment.PayeeUserId is Guid payee)
+        {
+            try
             {
                 await notifications.DispatchAsync(
                     payee,
@@ -101,15 +111,14 @@ public sealed class CaptureScholarshipProviderReviewPaymentCommandHandler(
                     idempotencyKey: $"company-review-paid:{payment.Id:N}",
                     ct).ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Capture succeeded for application {ApplicationId} but the payment-success notification failed to dispatch.",
+                    request.ApplicationId);
+            }
+        }
 
-            return true;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex,
-                "Failed to capture ScholarshipProviderReview payment for application {ApplicationId}",
-                request.ApplicationId);
-            return false;
-        }
+        return true;
     }
 }

--- a/server/src/ScholarPath.Infrastructure/Services/KnowledgeBaseIndexer.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/KnowledgeBaseIndexer.cs
@@ -30,12 +30,37 @@ public sealed class KnowledgeBaseIndexer(
     private const int EmbedBatchSize = 16;
     private const string FaqDatasetName = "scholarpath-faq";
 
+    // RACE-06: a rebuild reads every document, (re)embeds the pending ones against
+    // the paid embedding provider, then SaveChanges. Two overlapping rebuilds —
+    // e.g. the startup RAG bootstrap and an admin-triggered rebuild — would embed
+    // the same documents twice (duplicate spend) and race their writes. The indexer
+    // is registered Scoped, so a process-wide static gate is required to serialize
+    // across requests. Prod runs a single App Service instance, so this suffices;
+    // a DB sp_getapplock would be needed only for a multi-instance deployment.
+    private static readonly SemaphoreSlim RebuildGate = new(1, 1);
+
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         PropertyNameCaseInsensitive = true,
     };
 
     public async Task<KnowledgeBaseRebuildResultDto> RebuildAsync(bool force, CancellationToken ct)
+    {
+        // Serialize rebuilds so a startup bootstrap and an admin rebuild never
+        // overlap. WaitAsync honours the token, so a queued caller cancelling
+        // throws OperationCanceledException rather than hanging.
+        await RebuildGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await RebuildCoreAsync(force, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            RebuildGate.Release();
+        }
+    }
+
+    private async Task<KnowledgeBaseRebuildResultDto> RebuildCoreAsync(bool force, CancellationToken ct)
     {
         var desired = new List<DesiredDoc>();
         desired.AddRange(await BuildScholarshipDocsAsync(ct).ConfigureAwait(false));

--- a/server/src/ScholarPath.Infrastructure/Services/UserAdministration.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/UserAdministration.cs
@@ -27,6 +27,11 @@ public sealed class UserAdministration(
         if (status == AccountStatus.Suspended || status == AccountStatus.Deactivated)
         {
             await RevokeAllSessionsAsync(userId, reason ?? $"Status changed to {status}", ct).ConfigureAwait(false);
+            // DATA-04: a suspended/deactivated author's community content is hidden
+            // platform-wide, reusing the IsAutoHidden flag every forum read query
+            // already filters on. Reinstating to Active does NOT auto-unhide — a
+            // moderator unhides deliberately.
+            await AutoHideForumContentAsync(userId, reason ?? $"Author status changed to {status}", ct).ConfigureAwait(false);
         }
 
         if (!result.Succeeded)
@@ -50,7 +55,35 @@ public sealed class UserAdministration(
         user.UpdatedAt = now;
         await users.UpdateAsync(user).ConfigureAwait(false);
         await RevokeAllSessionsAsync(userId, "Account deleted by admin", ct).ConfigureAwait(false);
+        // DATA-04: hide the deleted author's community content too.
+        await AutoHideForumContentAsync(userId, "Author account deleted by admin", ct).ConfigureAwait(false);
         return true;
+    }
+
+    // DATA-04: hide a user's non-deleted, currently-visible forum posts/replies
+    // (roots + replies) when they are suspended/deactivated/deleted. Uses a tracked
+    // update (load → mutate → SaveChanges) rather than ExecuteUpdate so it works on
+    // both SQL Server and the EF InMemory provider used by tests; a user's post
+    // count is small and this only runs on rare admin actions. Already-hidden and
+    // soft-deleted rows are left untouched; reinstating to Active does NOT
+    // auto-unhide (a moderator unhides deliberately).
+    private async Task AutoHideForumContentAsync(Guid userId, string note, CancellationToken ct)
+    {
+        var posts = await db.ForumPosts
+            .Where(p => p.AuthorId == userId && !p.IsDeleted && !p.IsAutoHidden)
+            .ToListAsync(ct).ConfigureAwait(false);
+        if (posts.Count == 0) return;
+
+        var now = clock.UtcNow;
+        foreach (var p in posts)
+        {
+            p.IsAutoHidden = true;
+            p.AutoHiddenAt = now;
+            p.ModerationStatus = PostModerationStatus.Hidden;
+            p.ModeratedAt = now;
+            p.ModerationNote = note;
+        }
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<string>> GetRolesAsync(Guid userId, CancellationToken ct)

--- a/server/tests/ScholarPath.UnitTests/Applications/ReviewApplicationCommandValidatorTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Applications/ReviewApplicationCommandValidatorTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using ScholarPath.Application.Applications.Commands.ReviewApplication;
+using ScholarPath.Domain.Enums;
+using Xunit;
+
+namespace ScholarPath.UnitTests.Applications;
+
+// BUG-02: the ReviewApplication validator must admit every status that is a
+// legitimate provider review decision — previously it rejected the valid
+// Shortlisted (and UnderReview) with a 422.
+public class ReviewApplicationCommandValidatorTests
+{
+    private readonly ReviewApplicationCommandValidator _v = new();
+
+    [Theory]
+    [InlineData(ApplicationStatus.Shortlisted)]
+    [InlineData(ApplicationStatus.UnderReview)]
+    [InlineData(ApplicationStatus.Accepted)]
+    [InlineData(ApplicationStatus.Rejected)]
+    public void Valid_review_statuses_pass(ApplicationStatus status)
+    {
+        _v.Validate(new ReviewApplicationCommand(Guid.NewGuid(), status, null))
+            .IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(ApplicationStatus.Draft)]
+    [InlineData(ApplicationStatus.Pending)]
+    [InlineData(ApplicationStatus.Withdrawn)]
+    public void Non_decision_statuses_fail(ApplicationStatus status)
+    {
+        _v.Validate(new ReviewApplicationCommand(Guid.NewGuid(), status, null))
+            .IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_application_id_is_rejected()
+    {
+        _v.Validate(new ReviewApplicationCommand(Guid.Empty, ApplicationStatus.Accepted, null))
+            .IsValid.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Scope
**P1 (high)** findings from the deep audit. Each was **re-confirmed on current code → fixed → adversarially refute-checked** by independent agents. The verify pass caught **one self-introduced bug (RACE-05)** which was reverted before this PR.

| ID | Verdict | Fix |
|---|---|---|
| MON-02 | ✅ closed | webhook refund recomputes profit/payee split (was overpaying payee) |
| DATA-02 | ✅ closed | clamp webhook refund to [0, AmountCents] (no negative split) |
| ERR-01 | ✅ closed | review-payment capture no longer swallows Stripe failures |
| RACE-04 | ✅ closed | double-booking: SERIALIZABLE re-check+insert (request+reschedule) |
| RACE-06 | ✅ closed | KB rebuild serialized behind a semaphore |
| SEC-07 | ✅ closed | chat body sanitized on store |
| SEC-10 | ✅ closed | Diagnostics class `[Authorize]`; Auth kept method-level (ASP0026) |
| PERF-01 | ✅ closed | chat-send rate limit (40/min/user) |
| DATA-03 | ✅ closed | document upload MIME↔extension allowlist |
| DATA-04 | ✅ closed | suspend/delete auto-hides the user's community posts |
| DATA-05 | ✅ closed | platform-avg delta is admin-only (FR-207 isolation) |
| BUG-05 | ✅ closed | block deleting a consultant with future active bookings |
| BUG-02 | ✅ closed | ReviewApplication validator admits Shortlisted/UnderReview |
| SEC-09 / SEC-08(a) | ✅ closed | staticwebapp CSP + HSTS + security headers |
| **RACE-05** | ↩️ reverted | serializable read-only tx doesn't serialize AND crashes under retry — documented as negligible-impact v2 item |

**Already remediated (verified, no change):** SEC-06, RACE-03, SEC-11, BUG-03, LEGAL-01, PII-01. **BUG-04** not applicable.

## Adversarial verify caught (and this PR corrects)
- **RACE-05**: called `BeginTransactionAsync` directly; prod uses `EnableRetryOnFailure` which forbids user transactions without `CreateExecutionStrategy().ExecuteAsync` → would have thrown on **every** AI call (chatbot/recommendations/eligibility). Unit tests missed it (InMemory skips the branch). Reverted to the safe original + documented.

## Checks
- **842** server unit tests green (incl. new ReviewApplication validator tests). Backend + client build clean.
- InMemory-vs-relational guards verified on RACE-04 / DATA-04 so unit tests stay green.

## Deploy note
The CSP is a prod-only behavior (SWA `globalHeaders`); it allows Stripe, Google Fonts, and `https:`/`wss:` for API/ACS/SignalR, and omits Permissions-Policy so ACS camera/mic + Stripe payment keep working. Verify the live console has no CSP violations after deploy.