### PR TITLE
fix(audit-p3-p4): design-flaw mitigations + docs/diagram reconciliation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ dotnet format --verify-no-changes   # style check
 ### Frontend
 ```bash
 cd client
+npm ci                    # install deps from package-lock (matches README setup)
 npm run typecheck
 npm run lint
 npm run test              # Vitest unit

--- a/docs/ANALYTICS-RLS.md
+++ b/docs/ANALYTICS-RLS.md
@@ -4,22 +4,45 @@
 
 ---
 
+> ### ⚠️ Critical: RLS role names must match the JWT role verbatim
+>
+> `PowerBiService.GetEmbedTokenAsync` sends **`roles = new[] { activeRole }`** — the
+> caller's active JWT role string, unmodified. So the RLS role defined in the `.pbix`
+> **must be named exactly** `Consultant`, `Student`, or `Company` (whatever the raw
+> role string is). There is **no `…Scope` suffix** anywhere in the code — an earlier
+> revision of this doc invented `ConsultantScope`/`StudentScope`/`CompanyScope`, which
+> the backend never sends.
+>
+> **This is a correctness gate, not a cosmetic one.** If the published workspace was
+> built to the old doc (roles named `…Scope`), the embed token references a role that
+> does not exist → Power BI **either rejects `GenerateToken` or applies no row filter**,
+> which is a **cross-tenant data leak**. Before the defense, open the published `.pbix`
+> (Modeling → Manage Roles) and confirm the three role names are `Consultant`,
+> `Student`, `Company`. Rename them if they still carry the `…Scope` suffix.
+>
+> _Note on the role rename:_ on `main` the third role is `Company`. If/when the
+> `Company → ScholarshipProvider` rename lands, the RLS role must be renamed to match,
+> since the code passes the role string through untouched.
+
+---
+
 ## Overview
 
 ScholarPath uses Power BI **Row-Level Security** to ensure every user only sees data
-that belongs to them or their scope:
+that belongs to them or their scope. The backend passes the caller's active role
+straight through as the RLS role name:
 
 | JWT Role        | RLS Role in Power BI | Data Scope                                                  |
 |-----------------|----------------------|-------------------------------------------------------------|
 | `Admin`         | *(no filter)*        | All data — no row-level filter applied                      |
 | `SuperAdmin`    | *(no filter)*        | All data                                                    |
-| `Consultant`    | `ConsultantScope`    | Rows where `ConsultantId = USERNAME()` or `ALL` in agg views |
-| `Student`       | `StudentScope`       | Rows where `StudentId = USERNAME()` or `ALL` in agg views  |
-| `Company`       | `CompanyScope`       | Rows where `CompanyId = USERNAME()` or `ALL` in agg views  |
+| `Consultant`    | `Consultant`         | Rows where `ConsultantEmail = USERNAME()` or `ALL` in agg views |
+| `Student`       | `Student`            | Rows where `StudentEmail = USERNAME()` or `ALL` in agg views  |
+| `Company`       | `Company`            | Rows where `CompanyEmail = USERNAME()` or `ALL` in agg views  |
 
 `USERNAME()` in Power BI RLS resolves to the `EffectiveIdentity.username` field
 sent in the embed token request. The backend (`PowerBiService.cs`) sets this to
-the user's email address and role.
+the user's email address, and the role to the caller's active role verbatim.
 
 ---
 
@@ -29,7 +52,7 @@ the user's email address and role.
 
 2. **Modeling tab → Manage Roles → Create roles:**
 
-   **Role: `ConsultantScope`**
+   **Role: `Consultant`**
    ```dax
    -- DimUser table
    [Email] = USERNAME()
@@ -38,7 +61,7 @@ the user's email address and role.
    [ConsultantEmail] = USERNAME()
    ```
 
-   **Role: `StudentScope`**
+   **Role: `Student`**
    ```dax
    -- DimUser table
    [Email] = USERNAME()
@@ -50,7 +73,7 @@ the user's email address and role.
    [StudentEmail] = USERNAME()
    ```
 
-   **Role: `CompanyScope`**
+   **Role: `Company`**
    ```dax
    -- DimUser table
    [Email] = USERNAME()
@@ -74,17 +97,20 @@ the user's email address and role.
 `PowerBiService.cs` (`GetEmbedTokenAsync`) sets the effective identity:
 
 ```csharp
-new EffectiveIdentity(
-    username: userEmail,          // e.g. "student@example.com"
-    datasets: [datasetId],
-    roles: activeRole switch {
-        "Consultant" => ["ConsultantScope"],
-        "Student"    => ["StudentScope"],
-        "Company"    => ["CompanyScope"],
-        _            => []           // Admin/SuperAdmin: no role filter
-    }
-)
+// GenerateToken request body (identities sent only when a DatasetId is configured):
+new
+{
+    username = userEmail,          // e.g. "student@example.com"
+    roles    = new[] { activeRole }, // the caller's active role, verbatim
+    datasets = new[] { datasetId },
+}
 ```
+
+`activeRole` is the caller's current role string (`Consultant` / `Student` /
+`Company`). For Admin / SuperAdmin the backend does not request analytics through
+an effective identity that filters rows, so no RLS role is applied. There is no
+role-name remapping — whatever role name the token carries **is** the RLS role
+name Power BI looks up.
 
 ---
 
@@ -105,13 +131,19 @@ E2E_ADMIN_TOKEN=<jwt>        \
 python test-rls-impersonation.py
 ```
 
-Expected output:
+Expected output (the effective-identity role is opaque inside the embed token, so
+the script asserts only HTTP 200 + `isConfigured` + a non-null token per role):
 ```
-[PASS] Admin token: isConfigured=True, effectiveIdentity roles=[]
-[PASS] Consultant token: isConfigured=True, effectiveIdentity roles=['ConsultantScope']
-[PASS] Student token: isConfigured=True, effectiveIdentity roles=['StudentScope']
-[PASS] Company token: isConfigured=True, effectiveIdentity roles=['CompanyScope']
+[PASS] Admin token: HTTP 200, isConfigured=True
+[PASS] Consultant token: HTTP 200, isConfigured=True
+[PASS] Student token: HTTP 200, isConfigured=True
+[PASS] Company token: HTTP 200, isConfigured=True
 ```
+
+> The `expect_roles` labels inside `test-rls-impersonation.py` are cosmetic metadata
+> only — the script cannot read the role out of the opaque embed token, so it does
+> **not** verify the role name. Confirming the RLS role names match the JWT roles is
+> the manual `.pbix` check described in the banner at the top of this doc.
 
 ---
 
@@ -121,5 +153,5 @@ Expected output:
 |---------|-------|-----|
 | "Report not found" (404) | `ReportIds` in `appsettings.json` not set | Fill in the Power BI report GUIDs after publishing |
 | "Token generation failed" | Service principal not a Workspace Member | Add SP to workspace with Contributor role |
-| Empty data after approval | RLS role name mismatch | Role names in `.pbix` must match exactly: `ConsultantScope`, `StudentScope`, `CompanyScope` |
+| Empty data after approval | RLS role name mismatch | Role names in `.pbix` must match the JWT role **exactly**: `Consultant`, `Student`, `Company` (no `…Scope` suffix — see the banner at the top) |
 | Admin sees filtered data | `EffectiveIdentity` sent for Admin | Check `PowerBiService.cs` — Admin should pass `roles: []` |

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -70,6 +70,23 @@ Unassigned user
 
 Company/Consultant accounts can only access `/profile` and `/notifications` until approved.
 
+**Rejection behavior (FR-152 / BUG-03, shipped):** when an admin rejects onboarding
+in `/admin/onboarding`, `ReviewOnboardingCommandHandler` returns the account to a
+clean `Unassigned` state — it clears the pending `ActiveRole` (the requested-but-not-
+granted role) so the account never sits `Unassigned` while still reporting a role,
+and it **does not** grant the Identity role (the role is only added on approval). The
+rejection reason is stored on `UserProfile.LastOnboardingRejectionReason` /
+`LastOnboardingRejectedAt` and surfaced to the applicant (notification + re-shown in
+the onboarding wizard) so they can correct their details and resubmit rather than
+being locked out.
+
+**Dual-role approval semantics (DES-08):** each role a user holds must be approved
+**individually**. `SelectRole` sets the account's initial role at onboarding;
+`SwitchRole` flips an already-approved multi-role user's active role. Neither grants a
+role that hasn't been approved — approval happens via the onboarding/upgrade review.
+After a role is newly approved the client must **refresh the session** (new JWT) for
+the added role claim to take effect.
+
 ## Upgrade Student → Consultant
 
 `POST /api/users/upgrade-request` with files + links. Admin approves → user now holds both roles. Historical Student data is preserved.
@@ -77,7 +94,7 @@ Company/Consultant accounts can only access `/profile` and `/notifications` unti
 ## Gating enforcement — three layers
 
 1. **Frontend route guards** — `RequireAuth` / `RequireRole` in `client/src/routes/RequireAuth.tsx`. Redirects to `/login?redirect=<from>`.
-2. **Backend** — every controller except `AuthController` carries `[Authorize]` (global fallback policy in `Program.cs` will be added before production).
+2. **Backend** — every controller carries an **explicit** class-level authorization attribute (SEC-10): protected controllers are `[Authorize(...)]` (several role-scoped), and the genuinely public ones are explicitly `[AllowAnonymous]` (`WebhooksController`, `MeetingRecordingWebhookController`, `StatusController`). `AuthController` and `ScholarshipController` use method-level attributes (mix of anonymous + authorized actions). This removes the "a new action ships unprotected by omission" drift risk.
 3. **SignalR** — hubs inherit `AuthenticatedHub` which carries `[Authorize]`. JWT passed via `access_token` query string (handled by `JwtBearerEvents.OnMessageReceived`).
 
 ## Password policy (FR-021)

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,5 +1,18 @@
 # Entity Relationship Diagram
 
+> ### ⚠️ Deprecated — use the canonical diagrams
+>
+> This hand-maintained ER diagram has drifted from the schema (missing entities and
+> `ConsultantBooking` lifecycle fields, and it once showed a removed `MeetingUrl`
+> column). The **authoritative, reviewed** models are:
+>
+> - **[docs/diagrams/01-EERD.md](diagrams/01-EERD.md)** — the enhanced ER diagram
+> - **[docs/diagrams/02-RELATIONAL-MAPPING.md](diagrams/02-RELATIONAL-MAPPING.md)** — the relational mapping
+>
+> This page is kept only as a quick bounded-context overview. On any conflict, the
+> EF migrations under `server/src/ScholarPath.Infrastructure/Migrations/` are ground
+> truth, and the two diagrams above track them.
+
 Source of truth: the EF migration files under `server/src/ScholarPath.Infrastructure/Migrations/`. This page visualizes them using Mermaid (GitHub renders it natively).
 
 40 entities grouped by bounded context.
@@ -234,13 +247,29 @@ erDiagram
     datetimeoffset ScheduledEndAt
     int DurationMinutes
     decimal PriceUsd
+    string StudentNotes
+    string MeetingRoomId
+    datetimeoffset RecordingStartedAt
+    string RecordingId
     BookingStatus Status
-    string MeetingUrl
+    datetimeoffset RequestedAt
     datetimeoffset ConfirmedAt
+    datetimeoffset RejectedAt
+    datetimeoffset ExpiredAt
+    datetimeoffset CancelledAt
+    datetimeoffset CompletedAt
+    CancellationReason CancellationReason
+    Guid CancelledByUserId
     Guid PaymentId FK
     string StripePaymentIntentId
     bool IsNoShowStudent
     bool IsNoShowConsultant
+    datetimeoffset NoShowMarkedAt
+    datetimeoffset StudentJoinedAt
+    datetimeoffset ConsultantJoinedAt
+    bool IsDeleted
+    datetimeoffset DeletedAt
+    Guid DeletedByUserId
   }
   ConsultantReview {
     Guid Id PK

--- a/docs/PAYMENTS.md
+++ b/docs/PAYMENTS.md
@@ -5,7 +5,13 @@ Stripe powers all money flows. Two payment types; both flow through the shared `
 | Type                  | Trigger                             | Capture           | Payee            |
 |-----------------------|-------------------------------------|-------------------|------------------|
 | ConsultantBooking     | Student requests a consultant slot  | On accept (manual)| Consultant (Connect) |
-| CompanyReview         | Student submits an in-app application to a listing with a review fee | On submit (automatic) | Company |
+| ScholarshipProviderReview (review fee) | Student submits an in-app application to a listing with a review fee | **Manual hold → capture when the provider reviews** | ScholarshipProvider |
+
+> **Shipped behavior (was mis-documented):** the review fee is **not** captured
+> instantly on submit. Like a booking, the card is authorized (`PaymentStatus.Held`)
+> when the application is submitted and captured only when the provider actually
+> reviews it. If the provider never reviews within the SLA the hold is cancelled
+> (no charge) or a captured payment is fully refunded — see the lifecycle below.
 
 ## Consultant booking lifecycle
 
@@ -50,20 +56,49 @@ POST /api/bookings/{id}/accept   POST /api/bookings/{id}/reject or SessionExpiry
 
 Implemented pure-function `RefundCalculatorService` with a state/reason input. Unit-test the whole matrix.
 
-## Company review lifecycle
+## Scholarship-provider review lifecycle
 
 ```
-Student submits application
+Student submits an in-app application to a listing with a review fee
    │
    ▼
-POST /api/payments/intent        (capture_method=automatic)
-   │  instant capture — no escrow
+POST /api/payments/intent        (capture_method=manual)
+   │  authorization HELD on card — no charge yet (Payment.Status = Held)
    ▼
-Payment captured, funds credited
-   ↓
-CompanyReviewTimeoutRefundJob (daily)
-   └─ if 14 days pass with no Company review → full refund
+Provider reviews the application (accept / shortlist / reject decision)
+   ├─ CaptureScholarshipProviderReviewPayment → Payment.Status = Captured
+   │
+   └─ Provider never reviews in time
+        ↓
+ScholarshipProviderReviewTimeoutRefundJob (daily)
+   ├─ Held    → cancel the hold (no charge), Status = Cancelled
+   └─ Captured→ full Stripe refund, Status = Refunded
 ```
+
+**Timeout SLA (FR-068):** the job refunds when `Scholarship.Deadline + 14 days < now`.
+This is deliberately keyed to the **scholarship deadline**, not the submission date —
+a provider reviews applications only after the listing closes, so the 14-day
+response window starts at the deadline. (An audit finding suggested keying it to the
+submission date; that was a mis-read caused by the naming overlap described next —
+the deadline-based rule matches FR-068 and is the intended behavior, so the job was
+left unchanged.)
+
+> ### Terminology — two different "review" concepts (do not confuse)
+>
+> - **`ScholarshipProviderReview` (review fee, above)** — the paid flow where a
+>   student pays a fee for a provider to review their **in-app application**. It is
+>   tied to an `Application` (`Payment.RelatedApplicationId`) and its timeout is
+>   deadline-based (FR-068).
+> - **`ScholarshipProviderReviewRequest`** — a separate direct "request a review"
+>   entity with its own hold-then-capture lifecycle (`Start` → `ConfirmHold` →
+>   `Accept`/`Reject`/`Expire` → `Complete`). Its pending window is keyed to the
+>   **submission** date via `PendingExpiresAt = submittedAt + PendingTtlDays`.
+> - **`ScholarshipProviderReview` rating** (community/ratings) — a *star rating* a
+>   student leaves for a provider. **Carries no money.**
+>
+> These share a name prefix but are distinct; a v2 rename could disambiguate. When
+> reading payment code, follow the `Payment.Type` / `RelatedApplicationId` /
+> `RelatedBookingId` link, not the type name alone.
 
 ## Profit share (PB-014)
 
@@ -100,6 +135,49 @@ incoming payload
 ```
 
 Any handler failure lets the event be retried on next Stripe delivery (event keeps `IsProcessed=false`).
+
+## No-show refunds & the clawback gap (DES-02)
+
+No-show handling is intentionally asymmetric (FR-091/FR-193):
+
+| Who is absent      | Outcome                                             |
+|--------------------|-----------------------------------------------------|
+| Consultant no-show | **Full refund** to the student; the consultant earns nothing — the payment split is zeroed (`ProfitShareAmountCents = PayeeAmountCents = 0`) so the payout job can never pay a consultant for a session they didn't attend. |
+| Student no-show    | **No refund** — the session fee is forfeited.       |
+
+Both the manual `MarkNoShow` path and the automated `MeetingNoShowSweepJob` refund
+off the **captured `Payment.AmountCents`** (the source of truth), never a re-derived
+`PriceUsd` — `PriceUsd` can drift (re-price, free-mode toggle, prior partial refund).
+
+**Known limitation (v2):** there is no *clawback* if a consultant is paid out and the
+student is only later refunded on a dispute. The mitigation today is that the no-show
+and refund paths zero the split **before** payout, so the common cases can't overpay;
+a genuine `CompensationClawback` ledger (reducing the consultant's next payout) is a
+deferred v2 item.
+
+## Free mode (payments.enabled master switch)
+
+The `payments.enabled` platform setting puts the whole platform in **free mode**
+(PB-005R/PB-006R): new bookings and review requests are created with a $0 effective
+fee and skip Stripe entirely.
+
+**Non-retroactive by design (DES-01):** toggling to free mode does **not** waive
+commission on payments already captured before the toggle. Those keep their
+`ProfitShareAmountCents` and are still paid out normally. To surface the exposure,
+`UpdatePlatformSettingCommand` logs a warning listing the count / gross / commission
+of captured (not-yet-paid-out) payments whenever an admin flips `payments.enabled`
+true → false, so they can review those rows before the next payout. Whether a
+retroactive waiver is intended is an open team decision (do not assume it).
+
+## Data erasure vs financial retention (LEGAL-01 / FR-210)
+
+A GDPR-style delete request **anonymizes** rather than hard-deletes a user who is
+referenced by financial rows. Payment / refund / payout / audit records are retained
+for tax and accounting; the `User`'s identifying fields are scrubbed (name →
+"Deleted User", contact fields nulled). This keeps financial history intact and
+prevents FK/read breakage on payment queries that still reference the user. Financial
+records are therefore explicitly **exempt** from erasure — documented here and in
+`docs/SRS.md` (FR-210).
 
 ## Currency
 

--- a/docs/REMEDIATION-PLAN.md
+++ b/docs/REMEDIATION-PLAN.md
@@ -1,6 +1,6 @@
 # ScholarPath — Remediation & Clarity Plan
 
-**Owner:** @ma7moudalysalem (team lead) · **Created:** 2026-06-02 · **Last updated:** 2026-06-29 · **Status:** living document
+**Owner:** @ma7moudalysalem (team lead) · **Created:** 2026-06-02 · **Last updated:** 2026-07-03 · **Status:** living document
 
 > ✅ **Status update 2026-06-29 — system is fully deployed and operational.**
 > All P0 and P1 items are resolved. Azure resources are ScholarPath-branded.
@@ -23,7 +23,7 @@ code wins** and the doc is flagged below as stale.
 - **Payments**: Stripe hold/capture/refund/payout, profit-share split, free-mode master switch, webhook idempotency.
 - **AI**: Local + OpenAI + Azure providers behind `Ai:Provider`, per-user cost gate, RAG, PII redaction.
 - **Cross-cutting**: audit log, GDPR export/delete, notifications + SignalR, community/chat, resources, analytics pages.
-- **Tests**: 518 backend unit tests green (per `docs/reviews/calculations-audit-2026-05-21.md`).
+- **Tests**: 842 backend unit tests green (up from the 518 counted in `docs/reviews/calculations-audit-2026-05-21.md`, before the P0–P2 security remediation added coverage).
 
 **Conclusion:** the remaining work is **clarity, configuration, and polish — not missing features.**
 
@@ -62,7 +62,7 @@ These were audited and found correct. Listed so we don't re-open settled questio
 |---|---|---|
 | P1-1 | **Azure OpenAI** → knowledge-base/rebuild 503 | ✅ **RESOLVED 2026-06-02** — `ai-scholarpath-prod` (GlobalStandard gpt-4o-mini + text-embedding-3-small) wired in App Service; rebuild → 200, 849 docs indexed, chat live |
 | P1-2 | **Pre-prod secrets** — KV, Stripe, SendGrid, ACS, SSO | ✅ **DONE 2026-06-29** — all secrets configured in Azure Key Vault + App Service + GitHub Actions |
-| P1-3 | **Global authorization** — fallback policy check | ✅ **VERIFIED** — all 32 controllers carry `[Authorize]`; selective `[AllowAnonymous]` on public endpoints (webhooks, public content). Pattern is correct; no fallback policy needed. |
+| P1-3 | **Global authorization** — fallback policy check | ✅ **VERIFIED** — 26 controllers, each explicitly authorized: 21 with class-level `[Authorize]` (4 of them role-scoped `[Authorize(Roles="Admin,SuperAdmin")]`), 3 with class-level `[AllowAnonymous]` for webhook/public endpoints (`WebhooksController`, `MeetingRecordingWebhookController`, `StatusController`), and `AuthController` + `ScholarshipController` gating per action at the method level. `DiagnosticsController` got explicit class attributes in SEC-10; `AuthController` intentionally stays method-level. Pattern is correct; no fallback policy needed. |
 
 ### 🟢 P2 — Polish & consistency
 

--- a/server/src/ScholarPath.API/Middleware/MaintenanceMiddleware.cs
+++ b/server/src/ScholarPath.API/Middleware/MaintenanceMiddleware.cs
@@ -45,6 +45,11 @@ public sealed class MaintenanceMiddleware(
         "/api/status",
         "/api/auth",
         "/api/admin/settings",
+        // DES-09: the in-app notifications feed + its SignalR hub stay reachable so
+        // signed-in clients can still pull items they missed during a maintenance
+        // window. Both are [Authorize]-gated, so nothing unauthenticated is exposed.
+        "/api/notifications",
+        "/hubs/notifications",
         "/api/profiles",
         "/scalar",
         "/openapi",

--- a/server/src/ScholarPath.API/appsettings.json
+++ b/server/src/ScholarPath.API/appsettings.json
@@ -95,8 +95,10 @@
   },
   "Ai": {
     "Provider": "Stub",
+    "FineTuningEnabled": false,
     "RagTopK": 4,
     "RagMinScore": 0.15,
+    "IncludeCommunityPostsInKb": false,
     "OpenAi": {
       "ApiKey": "PLACEHOLDER_OPENAI_API_KEY",
       "Model": "gpt-4o-mini"

--- a/server/src/ScholarPath.Application/AI/Commands/FineTuning/StartFineTuningJobCommand.cs
+++ b/server/src/ScholarPath.Application/AI/Commands/FineTuning/StartFineTuningJobCommand.cs
@@ -1,4 +1,6 @@
 using MediatR;
+using Microsoft.Extensions.Options;
+using ScholarPath.Application.Ai.Common;
 using ScholarPath.Application.Ai.DTOs;
 using ScholarPath.Application.Ai.Queries.ExportFineTuningDataset;
 using ScholarPath.Application.Common;
@@ -25,7 +27,8 @@ public sealed record StartFineTuningJobResult(
 public sealed class StartFineTuningJobCommandHandler(
     IApplicationDbContext db,
     IAzureFineTuningService fineTuning,
-    IMediator mediator) : IRequestHandler<StartFineTuningJobCommand, StartFineTuningJobResult>
+    IMediator mediator,
+    IOptions<AiCostOptionsSnapshot> aiOptions) : IRequestHandler<StartFineTuningJobCommand, StartFineTuningJobResult>
 {
     private static readonly HashSet<string> TerminalStatuses =
         new(StringComparer.OrdinalIgnoreCase) { "succeeded", "failed", "cancelled", "canceled" };
@@ -33,6 +36,15 @@ public sealed class StartFineTuningJobCommandHandler(
     public async Task<StartFineTuningJobResult> Handle(
         StartFineTuningJobCommand request, CancellationToken ct)
     {
+        // DES-04: fine-tuning is dormant by default (Ai:FineTuningEnabled=false).
+        // The whole pipeline is over-engineered for v1 — keep the code but refuse
+        // to spend on an Azure fine-tuning run until the flag is explicitly turned
+        // on. This runs before the in-flight-job check so a disabled platform never
+        // even polls Azure.
+        if (!aiOptions.Value.FineTuningEnabled)
+            throw new ConflictException(
+                "Fine-tuning is disabled (Ai:FineTuningEnabled=false). Enable it in configuration before starting a job.");
+
         // 0. BUG-06: reject a duplicate submission while a prior job is still in
         //    flight. Only ONE job id is tracked (FineTuningLastJobId); starting a
         //    new job would overwrite it and orphan the running one. Poll the LIVE

--- a/server/src/ScholarPath.Application/AI/Common/AiCostGate.cs
+++ b/server/src/ScholarPath.Application/AI/Common/AiCostGate.cs
@@ -62,4 +62,8 @@ public sealed class AiCostOptionsSnapshot : IAiCostOptions
 {
     public decimal DailyUserCostLimitUsd { get; set; } = 1.00m;
     public int RecommendationTopN { get; set; } = 5;
+
+    /// <summary>DES-04 — projected from AiOptions.FineTuningEnabled. Gates the admin
+    /// fine-tuning start command in the Application layer. Off by default.</summary>
+    public bool FineTuningEnabled { get; set; }
 }

--- a/server/src/ScholarPath.Application/PlatformSettings/Commands/UpdatePlatformSetting/UpdatePlatformSettingCommand.cs
+++ b/server/src/ScholarPath.Application/PlatformSettings/Commands/UpdatePlatformSetting/UpdatePlatformSettingCommand.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using ScholarPath.Application.Common;
 using ScholarPath.Application.Common.Auditing;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
@@ -67,6 +68,8 @@ public sealed class UpdatePlatformSettingCommandHandler(
 
         ValidateValueForType(setting.ValueType, request.Value);
 
+        var oldValue = setting.Value;
+
         setting.Value = request.Value;
         setting.UpdatedByAdminId = adminId;
 
@@ -75,9 +78,62 @@ public sealed class UpdatePlatformSettingCommandHandler(
         logger.LogInformation(
             "Platform setting {Key} changed by admin {AdminId}.", setting.Key, adminId);
 
+        // DES-01: switching the platform to free mode (payments.enabled true→false)
+        // does NOT retroactively waive commission on already-captured paid bookings/
+        // reviews — those still carry a ProfitShareAmountCents that will be paid out.
+        // A full retroactive reconciliation is a deliberate v2 decision (needs a
+        // team call on whether the waiver is intended), so the safe mitigation now
+        // is to surface the exposure: log the captured, not-yet-paid-out rows that
+        // still carry commission so an admin can review them before the next payout.
+        if (setting.Key == PlatformSettingsKeys.PaymentsEnabled &&
+            IsTrue(oldValue) && !IsTrue(request.Value))
+        {
+            await WarnOnCapturedCommissionAsync(db, adminId, logger, ct).ConfigureAwait(false);
+        }
+
         return new PlatformSettingDto(
             setting.Id, setting.Key, setting.Value, setting.ValueType,
             setting.DescriptionEn, setting.DescriptionAr, setting.Category, setting.UpdatedAt);
+    }
+
+    private static bool IsTrue(string? value) =>
+        bool.TryParse(value, out var b) && b;
+
+    /// <summary>
+    /// DES-01 mitigation — logs the captured (or partially-refunded) payments that
+    /// have not been paid out yet but still carry a platform commission, so an admin
+    /// can decide whether to waive them before the payout job runs. Read-only; never
+    /// mutates the ledger (retroactive waiver is a v2 decision).
+    /// </summary>
+    private static async Task WarnOnCapturedCommissionAsync(
+        IApplicationDbContext db, Guid adminId,
+        ILogger logger, CancellationToken ct)
+    {
+        var affected = await db.Payments
+            .Where(p =>
+                (p.Status == PaymentStatus.Captured || p.Status == PaymentStatus.PartiallyRefunded) &&
+                p.PayoutId == null &&
+                p.ProfitShareAmountCents > 0)
+            .Select(p => new { p.AmountCents, p.ProfitShareAmountCents })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (affected.Count == 0)
+        {
+            logger.LogInformation(
+                "Free-mode toggle by admin {AdminId}: no captured, not-yet-paid-out payments carry commission.",
+                adminId);
+            return;
+        }
+
+        var grossCents = affected.Sum(p => p.AmountCents);
+        var commissionCents = affected.Sum(p => p.ProfitShareAmountCents);
+
+        logger.LogWarning(
+            "Free-mode toggle by admin {AdminId}: {Count} captured/partially-refunded payment(s) " +
+            "still awaiting payout carry a platform commission that free mode will NOT retroactively waive " +
+            "(gross ${GrossUsd:0.00}, commission ${CommissionUsd:0.00}). Review before the next payout.",
+            adminId, affected.Count, grossCents / 100m, commissionCents / 100m);
     }
 
     /// <summary>Rejects values that do not match the setting's declared type.</summary>

--- a/server/src/ScholarPath.Infrastructure/DependencyInjection.cs
+++ b/server/src/ScholarPath.Infrastructure/DependencyInjection.cs
@@ -45,6 +45,7 @@ public static class DependencyInjection
             var ai = config.GetSection(AiOptions.SectionName).Get<AiOptions>() ?? new AiOptions();
             snap.DailyUserCostLimitUsd = ai.DailyUserCostLimitUsd;
             snap.RecommendationTopN = ai.RecommendationTopN;
+            snap.FineTuningEnabled = ai.FineTuningEnabled;
         });
 
         // ─── Database ───────────────────────────────────────────────────────────

--- a/server/src/ScholarPath.Infrastructure/Jobs/MeetingNoShowSweepJob.cs
+++ b/server/src/ScholarPath.Infrastructure/Jobs/MeetingNoShowSweepJob.cs
@@ -132,6 +132,13 @@ public sealed class MeetingNoShowSweepJob : IMeetingNoShowSweepJob
                     payment.RefundedAmountCents = payment.AmountCents;
                     payment.RefundedAt = nowUtc;
                     payment.RefundReason = CancellationReason.ConsultantNoShow.ToString();
+                    // DES-02: a consultant no-show is a FULL refund — the consultant
+                    // earns nothing. Zero the split (as the manual MarkNoShow handler
+                    // and RefundPaymentCommand do) so StripePayoutJob (which pays any
+                    // PayeeAmountCents > 0) can't still pay the consultant for a
+                    // session they didn't attend after the student was refunded.
+                    payment.ProfitShareAmountCents = 0;
+                    payment.PayeeAmountCents = 0;
                 }
             }
         }

--- a/server/src/ScholarPath.Infrastructure/Services/KnowledgeBaseIndexer.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/KnowledgeBaseIndexer.cs
@@ -3,12 +3,14 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ScholarPath.Application.Ai.DTOs;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Infrastructure.Persistence;
+using ScholarPath.Infrastructure.Settings;
 
 namespace ScholarPath.Infrastructure.Services;
 
@@ -25,6 +27,7 @@ public sealed class KnowledgeBaseIndexer(
     ApplicationDbContext db,
     IEmbeddingService embeddings,
     IDatasetProvider datasets,
+    IOptions<AiOptions> aiOptions,
     ILogger<KnowledgeBaseIndexer> logger) : IKnowledgeBaseIndexer
 {
     private const int EmbedBatchSize = 16;
@@ -70,7 +73,15 @@ public sealed class KnowledgeBaseIndexer(
         // help articles.
         desired.AddRange(await BuildConsultantDocsAsync(ct).ConfigureAwait(false));
         desired.AddRange(await BuildResourceDocsAsync(ct).ConfigureAwait(false));
-        desired.AddRange(await BuildTopCommunityPostDocsAsync(ct).ConfigureAwait(false));
+        // DES-05: community forum threads are unvetted user-generated content, so
+        // they are grounded into the chatbot's KB only when explicitly enabled
+        // (Ai:IncludeCommunityPostsInKb=true). Off by default until a moderation /
+        // vetting workflow exists — otherwise the assistant could surface unverified
+        // claims from arbitrary users as if they were curated platform content.
+        if (aiOptions.Value.IncludeCommunityPostsInKb)
+        {
+            desired.AddRange(await BuildTopCommunityPostDocsAsync(ct).ConfigureAwait(false));
+        }
 
         var existing = await db.KnowledgeDocuments.ToListAsync(ct).ConfigureAwait(false);
         var byKey = existing.ToDictionary(d => (d.SourceType, d.SourceKey));

--- a/server/src/ScholarPath.Infrastructure/Settings/AppSettings.cs
+++ b/server/src/ScholarPath.Infrastructure/Settings/AppSettings.cs
@@ -178,6 +178,14 @@ public sealed class AiOptions
     public const string SectionName = "Ai";
     public string Provider { get; set; } = "Stub";
 
+    /// <summary>
+    /// DES-04 — master switch for the admin fine-tuning flow. Off by default:
+    /// fine-tuning is optional for v1 and the code is kept but dormant (the
+    /// StartFineTuningJobCommand returns 409 when false). Flip to true only once an
+    /// Azure OpenAI fine-tuning deployment/quota is available.
+    /// </summary>
+    public bool FineTuningEnabled { get; set; }
+
     /// <summary>How many recommendations to return per call. Stub scores the whole open catalog then trims to this.</summary>
     public int RecommendationTopN { get; set; } = 5;
 
@@ -189,6 +197,15 @@ public sealed class AiOptions
 
     /// <summary>RAG: minimum cosine similarity for a retrieved document to be treated as relevant context.</summary>
     public double RagMinScore { get; set; } = 0.15;
+
+    /// <summary>
+    /// DES-05 — when true, the RAG knowledge base also indexes up to 200 top-voted
+    /// community forum threads. Those are unvetted user-generated content, so this
+    /// is OFF by default: the chatbot is grounded only on curated content
+    /// (scholarships, FAQs, verified consultants, published resources) until a
+    /// moderation/vetting workflow exists.
+    /// </summary>
+    public bool IncludeCommunityPostsInKb { get; set; }
 
     public OpenAiOptions OpenAi { get; set; } = new();
     public AzureOpenAiOptions AzureOpenAi { get; set; } = new();

--- a/server/tests/ScholarPath.UnitTests/Ai/KnowledgeBaseIndexerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Ai/KnowledgeBaseIndexerTests.cs
@@ -2,12 +2,14 @@ using System.Net.Http;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Infrastructure.Persistence;
 using ScholarPath.Infrastructure.Services;
+using ScholarPath.Infrastructure.Settings;
 using Xunit;
 
 namespace ScholarPath.UnitTests.Ai;
@@ -41,7 +43,9 @@ public sealed class KnowledgeBaseIndexerTests
             "\"answerEn\":\"A\",\"answerAr\":\"ج\"}]}");
 
         var indexer = new KnowledgeBaseIndexer(
-            db, embeddings, datasets, NullLogger<KnowledgeBaseIndexer>.Instance);
+            db, embeddings, datasets,
+            Options.Create(new AiOptions()),
+            NullLogger<KnowledgeBaseIndexer>.Instance);
 
         var act = () => indexer.RebuildAsync(force: false, CancellationToken.None);
 

--- a/server/tests/ScholarPath.UnitTests/Ai/StartFineTuningJobGuardTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Ai/StartFineTuningJobGuardTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using ScholarPath.Application.Ai.Commands.FineTuning;
+using ScholarPath.Application.Ai.Common;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using Xunit;
+
+namespace ScholarPath.UnitTests.Ai;
+
+/// <summary>
+/// DES-04 — the admin fine-tuning pipeline is dormant by default. Starting a job
+/// with <c>Ai:FineTuningEnabled=false</c> must be refused before any Azure call,
+/// so a disabled platform never spends on (or polls) a fine-tuning run.
+/// </summary>
+public sealed class StartFineTuningJobGuardTests
+{
+    [Fact]
+    public async Task Start_is_refused_when_fine_tuning_is_disabled()
+    {
+        var db = Substitute.For<IApplicationDbContext>();
+        var fineTuning = Substitute.For<IAzureFineTuningService>();
+        var mediator = Substitute.For<IMediator>();
+        var opts = Options.Create(new AiCostOptionsSnapshot { FineTuningEnabled = false });
+
+        var sut = new StartFineTuningJobCommandHandler(db, fineTuning, mediator, opts);
+
+        var act = () => sut.Handle(new StartFineTuningJobCommand(), default);
+
+        (await act.Should().ThrowAsync<ConflictException>())
+            .Which.Message.Should().Contain("disabled");
+
+        // The guard runs first — nothing was uploaded to Azure and no dataset was
+        // exported.
+        await fineTuning.DidNotReceive()
+            .UploadTrainingFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await mediator.DidNotReceive().Send(Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/MeetingNoShowTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/MeetingNoShowTests.cs
@@ -90,6 +90,12 @@ public sealed class MeetingNoShowTests
         saved.IsNoShowConsultant.Should().BeTrue();
         saved.NoShowMarkedAt.Should().NotBeNull();
         saved.Payment!.Status.Should().Be(PaymentStatus.Refunded);
+        saved.Payment.RefundedAmountCents.Should().Be(saved.Payment.AmountCents);
+        // DES-02: a consultant no-show is a full refund, so the payout split must be
+        // zeroed — the consultant earns nothing for a session they didn't attend and
+        // StripePayoutJob (which pays any PayeeAmountCents > 0) must never pay them.
+        saved.Payment.ProfitShareAmountCents.Should().Be(0);
+        saved.Payment.PayeeAmountCents.Should().Be(0);
         await stripe.Received(1).RefundPaymentAsync(
             Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<string?>(),
             Arg.Any<string>(), Arg.Any<CancellationToken>());


### PR DESCRIPTION
Completes the P3 (docs/diagram reconciliation) and P4 (design-flaw mitigations) phases of the deep-audit remediation plan.

## P4 — design mitigations (small, feature-flagged; large fixes deferred to v2)
- **DES-04** fine-tuning pipeline feature-flagged OFF by default (`Ai:FineTuningEnabled=false`); handler returns 409 before any Azure/DB call when disabled. New guard test.
- **DES-05** community forum posts flagged OUT of the RAG KB by default (`Ai:IncludeCommunityPostsInKb=false`).
- **DES-01** free-mode toggle logs captured, not-yet-paid-out payments still carrying commission for admin review (read-only).
- **DES-02** automated consultant no-show now zeroes the payout split (mirrors the manual handler); test strengthened.
- **DES-09** `/api/notifications` + `/hubs/notifications` bypass maintenance mode (both `[Authorize]`-gated).

## P3 — docs reconciled to code
- **DOC-01** `ANALYTICS-RLS.md`: corrected fictional `…Scope` RLS role names to real `roles = new[]{ activeRole }` + manual `.pbix` verification banner (old doc = silent RLS leak).
- **DOC-02** `ERD.md`: deprecation banner → canonical diagrams; `MeetingUrl`→`MeetingRoomId` + missing lifecycle fields.
- **DOC-06/07** `PAYMENTS.md` capture-timing + review-terminology (DES-03) + no-show/free-mode/erasure sections; `AUTH.md` onboarding-reject (BUG-03), dual-role (DES-08), SEC-10 correction. `CONTRIBUTING.md` npm ci (DOC-04).

## Note on BUG-04
Re-confirmed as a **mis-read**: the timeout-refund job handles the in-app application-review fee, whose deadline-based SLA matches FR-068 by design. Code left unchanged; the distinction is now documented.

## Verification
- 843 unit tests green (0 failed, 2 skipped).
- P4 code changes adversarially verified by an independent multi-agent pass — 5/5 clean.
