### PR TITLE
fix(auth): select-role 409 traps role-less non-Unassigned accounts

### DIFF
--- a/server/src/ScholarPath.Application/Auth/Commands/SelectRole/SelectRoleCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Auth/Commands/SelectRole/SelectRoleCommandHandler.cs
@@ -43,10 +43,18 @@ public sealed class SelectRoleCommandHandler(
         if (!user.EmailConfirmed)
             throw new ConflictException("Please verify your email address before continuing.");
 
-        // Role selection is a one-time gate — only an Unassigned, role-less account qualifies.
+        // Role selection is a one-time gate keyed on whether a role was actually
+        // GRANTED — not on AccountStatus. A role-less account can legitimately be
+        // non-Unassigned (e.g. left Active by an older onboarding-rejection path or
+        // an admin status change); it must still be able to pick a role instead of
+        // being permanently stuck on a 409 ("A role has already been selected").
         var existingRoles = await userAdministration.GetRolesAsync(userId, ct);
-        if (existingRoles.Count > 0 || user.AccountStatus != AccountStatus.Unassigned)
+        if (existingRoles.Count > 0)
             throw new ConflictException("A role has already been selected for this account.");
+        if (user.AccountStatus == AccountStatus.PendingApproval)
+            throw new ConflictException("Your onboarding request is already awaiting review.");
+        if (user.AccountStatus is AccountStatus.Suspended or AccountStatus.Deactivated)
+            throw new ForbiddenAccessException("This account cannot select a role.");
 
         if (request.Role == "Student")
         {

--- a/server/tests/ScholarPath.UnitTests/Auth/SelectRoleCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Auth/SelectRoleCommandHandlerTests.cs
@@ -300,6 +300,64 @@ public class SelectRoleCommandHandlerTests
     }
 
     [Fact]
+    public async Task Role_less_Active_account_can_still_select_a_role()
+    {
+        // Regression: a role-less account left Active (e.g. by an older onboarding-
+        // rejection path or an admin status change) previously got a 409 "A role
+        // has already been selected" and was permanently stuck. It has NO role, so
+        // selection must be allowed and heal the account.
+        using var db = CreateDb();
+        var id = Guid.NewGuid();
+        db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Stuck",
+            LastName = "User",
+            Email = "stuck@scholarpath.local",
+            UserName = "stuck@scholarpath.local",
+            AccountStatus = AccountStatus.Active, // non-Unassigned but role-less
+            ActiveRole = null,
+            EmailConfirmed = true,
+        });
+        await db.SaveChangesAsync();
+
+        var admin = Substitute.For<IUserAdministration>();
+        admin.GetRolesAsync(id, Arg.Any<CancellationToken>()).Returns(Array.Empty<string>());
+
+        await Sut(db, id, admin).Handle(new SelectRoleCommand("Student"), default);
+
+        var user = await db.Users.FirstAsync(u => u.Id == id);
+        user.ActiveRole.Should().Be("Student");
+        await admin.Received().AddRoleAsync(id, "Student", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Rejects_selection_while_a_request_is_pending_approval()
+    {
+        using var db = CreateDb();
+        var id = Guid.NewGuid();
+        db.Users.Add(new ApplicationUser
+        {
+            Id = id,
+            FirstName = "Pending",
+            LastName = "User",
+            Email = "pending@scholarpath.local",
+            UserName = "pending@scholarpath.local",
+            AccountStatus = AccountStatus.PendingApproval,
+            ActiveRole = "Consultant",
+            EmailConfirmed = true,
+        });
+        await db.SaveChangesAsync();
+
+        var admin = Substitute.For<IUserAdministration>();
+        admin.GetRolesAsync(id, Arg.Any<CancellationToken>()).Returns(Array.Empty<string>());
+
+        var act = () => Sut(db, id, admin).Handle(new SelectRoleCommand("Student"), default);
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
     public void Validator_rejects_unknown_role()
     {
         var v = new SelectRoleCommandValidator();


### PR DESCRIPTION
## Symptom
`POST /api/auth/select-role` → **409 Conflict** during onboarding ('A role has already been selected for this account'), even for users who have never selected a role.

## Root cause (confirmed against prod)
The one-time gate rejected anyone whose `AccountStatus != Unassigned`, rather than checking whether a role was actually **granted**. A role-less account can legitimately be non-Unassigned (left `Active` by an older onboarding-rejection path or an admin status change). The onboarding wizard still shows such a user the role picker (they're email-confirmed and not `PendingApproval`), they pick a role, and the server 409s — permanently stuck.

Prod query found **5 role-less accounts stuck in `Active`**, including a real applicant (`12422024648139@pg.cu.edu.eg`) and `companyyyy.tasneem` (both with null `ActiveRole`).

## Fix (`SelectRoleCommandHandler`)
Gate on the granted role, not on status:
- Block only when the user already holds an Identity role (fully onboarded).
- Block `PendingApproval` (a request is already awaiting review).
- Forbid `Suspended`/`Deactivated`.
- **Allow `Unassigned` and role-less `Active`** → stuck accounts self-heal on their next role pick (no data migration needed).

## Tests
Added `Role_less_Active_account_can_still_select_a_role` and `Rejects_selection_while_a_request_is_pending_approval`; existing `Rejects_a_second_role_selection` (blocks when a role already exists) still passes. **847 unit tests green, 0 skipped.**
