### PR TITLE
fix(client): self-heal stale-chunk crashes after deploy; widen SSO state TTL

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, RotateCcw } from "lucide-react";
+import { isChunkLoadError, recoverFromStaleChunk } from "@/lib/staleChunkRecovery";
 
 interface Props {
   children: ReactNode;
@@ -9,6 +10,9 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
+  // A stale lazy chunk after a deploy — self-heals with a one-shot reload
+  // rather than showing the crash screen.
+  recovering: boolean;
 }
 
 /**
@@ -24,14 +28,22 @@ interface State {
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, recovering: false };
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error };
+    // A failed lazy-route chunk (stale after a deploy) is a recoverable render
+    // error — show a neutral "updating" state, not the crash screen.
+    return { hasError: true, error, recovering: isChunkLoadError(error) };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    if (isChunkLoadError(error)) {
+      // A new deploy replaced the chunk this tab tried to lazy-load. Reload once
+      // to pull the fresh assets instead of stranding the user on an error page.
+      recoverFromStaleChunk();
+      return;
+    }
     // Print to console in every environment — visible in Playwright traces and
     // Azure App Service log streams without any external SDK dependency.
     console.error("[ErrorBoundary] Uncaught rendering error:", error, info.componentStack);
@@ -43,6 +55,10 @@ export class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      // While a stale-chunk reload is in flight, avoid flashing the crash screen.
+      if (this.state.recovering) {
+        return <div className="min-h-dvh bg-bg-canvas" aria-busy="true" />;
+      }
       return <ErrorFallback onReload={this.handleReload} />;
     }
     return this.props.children;

--- a/client/src/lib/staleChunkRecovery.ts
+++ b/client/src/lib/staleChunkRecovery.ts
@@ -1,0 +1,59 @@
+/**
+ * Stale-chunk recovery.
+ *
+ * A new client deployment replaces the content-hashed JS chunks. An already-open
+ * tab that lazy-loads a route AFTER a deploy then requests a chunk filename the
+ * new build deleted. Azure Static Web Apps serves the SPA fallback (index.html,
+ * `text/html`) for the missing `.js`, so the dynamic import fails with
+ * "Failed to fetch dynamically imported module" / a strict-MIME error and the
+ * page crashes. Recover by reloading ONCE to pull the fresh index.html + assets.
+ */
+
+const RELOAD_AT_KEY = "sp_chunk_reload_at";
+// Reload at most once per cooldown so a genuinely-broken chunk can't loop.
+const RELOAD_COOLDOWN_MS = 10_000;
+
+/** Reloads the page once (rate-limited) to fetch freshly-deployed assets. */
+export function recoverFromStaleChunk(): void {
+  try {
+    const last = Number(sessionStorage.getItem(RELOAD_AT_KEY) || 0);
+    if (Date.now() - last < RELOAD_COOLDOWN_MS) return; // avoid reload loops
+    sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
+  } catch {
+    // sessionStorage unavailable (rare private-mode edge) — fall through and
+    // reload anyway; the browser will de-dupe rapid reloads.
+  }
+  window.location.reload();
+}
+
+const CHUNK_ERROR_RE =
+  /(dynamically imported module|importing a module script failed|error loading dynamically imported module|failed to fetch dynamically|chunkloaderror|expected a javascript-or-wasm module script)/i;
+
+/** Heuristic: is this error a stale/missing lazy chunk (vs a real app bug)? */
+export function isChunkLoadError(error: unknown): boolean {
+  const msg =
+    error instanceof Error ? `${error.name} ${error.message}` : String(error ?? "");
+  return CHUNK_ERROR_RE.test(msg);
+}
+
+/**
+ * Registers global listeners for dynamic-import/preload failures so a stale-chunk
+ * error after a deploy self-heals instead of showing a crash screen. Call once at
+ * startup.
+ */
+export function installStaleChunkRecovery(): void {
+  // Vite fires this for its module-preload helper failures.
+  window.addEventListener("vite:preloadError", (event) => {
+    event.preventDefault(); // suppress the unhandled rejection; we recover instead
+    recoverFromStaleChunk();
+  });
+
+  // React.lazy import() rejections surface as unhandled promise rejections before
+  // (or instead of) reaching the ErrorBoundary in some paths.
+  window.addEventListener("unhandledrejection", (event) => {
+    if (isChunkLoadError(event.reason)) {
+      event.preventDefault();
+      recoverFromStaleChunk();
+    }
+  });
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,7 +6,12 @@ import { BrowserRouter } from "react-router";
 import "@/theme/globals.css";
 import "@/lib/i18n";
 import { queryClient } from "@/lib/queryClient";
+import { installStaleChunkRecovery } from "@/lib/staleChunkRecovery";
 import { App } from "@/App";
+
+// Self-heal "Failed to fetch dynamically imported module" after a new deploy
+// replaces the hashed chunks an already-open tab still references.
+installStaleChunkRecovery();
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root container not found");

--- a/server/src/ScholarPath.Infrastructure/Services/DataProtectionSsoStateStore.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/DataProtectionSsoStateStore.cs
@@ -17,7 +17,11 @@ namespace ScholarPath.Infrastructure.Services;
 /// </summary>
 public sealed class DataProtectionSsoStateStore : ISsoStateStore
 {
-    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(10);
+    // A real user may sit on the provider's consent screen (account picker, 2FA,
+    // "grant access") for several minutes; 10 min was tight enough to surface
+    // "Invalid or expired SSO state" on slow flows. 30 min keeps the window short
+    // (anti-replay comes from the single-use authorization code) while tolerating it.
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
     private readonly IDataProtector _protector;
 
     public DataProtectionSsoStateStore(IDataProtectionProvider provider)


### PR DESCRIPTION
## Symptoms (reported from prod)
- `Failed to fetch dynamically imported module …/StudentDashboard-*.js` and `Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"` → ErrorBoundary crash.
- SSO **"Sign-in could not be completed"** during a long testing session with several redeploys.

## Stale-chunk crash — root cause + fix
A new client deploy replaces the content-hashed JS chunks. An already-open tab that lazy-loads a route **after** the deploy requests a filename the new build deleted; Azure SWA serves the SPA fallback (`index.html`, `text/html`) for the missing `.js`, so the dynamic import fails and the page crashes — and can interrupt an in-flight flow (e.g. the SSO post-login navigation, which matches the pending `completeSso` XHR in the report).

Fix: `installStaleChunkRecovery()` reloads the tab **once** (rate-limited via sessionStorage) on Vite's `vite:preloadError` and on chunk-shaped `unhandledrejection`s; the `ErrorBoundary` also detects chunk-load errors and recovers (neutral 'updating' state) instead of the crash screen.

## SSO
Verified the DataProtection key ring **persists** in prod (`/home/ASP.NET/DataProtection-Keys`, a key dated 2026-05-17 survives restarts including today's deploys), so state validation is stable across restarts — not the cause. The redirect-URI is resolved identically for authorize + token-exchange, and the login handler is robust. The realistic cause was the **10-minute state TTL** expiring on slow/interrupted consent flows; widened to **30 min** (anti-replay still comes from the single-use auth code).

## Verification
Client `tsc -b` / `eslint --max-warnings 0` / `vite build` green. 847 server unit tests green, 0 skipped.
