### PR TITLE
feat(observability): send telemetry to Application Insights

### DIFF
--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -58,6 +58,10 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+  </ItemGroup>
+  <ItemGroup Label="Observability — Application Insights">
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
   </ItemGroup>
   <ItemGroup Label="Background jobs + Stripe + Email + SignalR">
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.23" />

--- a/server/src/ScholarPath.API/Program.cs
+++ b/server/src/ScholarPath.API/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.SqlServer;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -26,13 +27,35 @@ using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// ─── Application Insights (prod error visibility) ────────────────────────────
+// On Linux App Service there is no codeless auto-instrumentation, so the app
+// must send telemetry itself. This reads APPLICATIONINSIGHTS_CONNECTION_STRING
+// from configuration and starts collecting requests, dependencies and
+// exceptions; it is a no-op when no connection string is set (local/dev).
+builder.Services.AddApplicationInsightsTelemetry();
+
 // ─── Serilog ─────────────────────────────────────────────────────────────────
 builder.Host.UseSerilog((ctx, sp, config) =>
+{
     config.ReadFrom.Configuration(ctx.Configuration)
           .ReadFrom.Services(sp)
           .Enrich.FromLogContext()
           .Enrich.WithEnvironmentName()
-          .Enrich.WithThreadId());
+          .Enrich.WithThreadId();
+
+    // Ship logs — including the exceptions ExceptionHandlerMiddleware catches and
+    // logs via ILogger — to Application Insights. Serilog replaces the default
+    // logging providers, so the App Insights SDK's own ILogger provider never
+    // sees these; this sink is what makes handled exceptions visible in prod.
+    var aiConnectionString = ctx.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+        ?? ctx.Configuration["ApplicationInsights:ConnectionString"];
+    if (!string.IsNullOrWhiteSpace(aiConnectionString))
+    {
+        var telemetryConfig = TelemetryConfiguration.CreateDefault();
+        telemetryConfig.ConnectionString = aiConnectionString;
+        config.WriteTo.ApplicationInsights(telemetryConfig, TelemetryConverter.Traces);
+    }
+});
 
 // ─── Controllers + JSON ──────────────────────────────────────────────────────
 builder.Services

--- a/server/src/ScholarPath.API/ScholarPath.API.csproj
+++ b/server/src/ScholarPath.API/ScholarPath.API.csproj
@@ -36,6 +36,10 @@
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Enrichers.Environment" />
     <PackageReference Include="Serilog.Enrichers.Thread" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" />
+  </ItemGroup>
+  <ItemGroup Label="Observability — Application Insights (prod error visibility)">
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Problem
Application Insights (`appi-scholarpath-prod`) had a connection string configured on the App Service but received **zero telemetry** — `AppRequests`/`AppExceptions`/`AppTraces` were empty over 30h. So **production errors were invisible**: today's flag-500 and select-role-409 had to be diagnosed by connecting directly to the prod database and reading container logs.

## Root cause
The app logs via **Serilog → Console + File only** (no App Insights sink), and there's **no App Insights SDK**. On **Linux** App Service there is no codeless auto-instrumentation, so nothing ever used the connection string.

## Fix (API only)
- `Microsoft.ApplicationInsights.AspNetCore` + `AddApplicationInsightsTelemetry()` → auto-collects **requests, dependencies, exceptions** (reads `APPLICATIONINSIGHTS_CONNECTION_STRING`; **no-op when unset**, so local/dev is unaffected).
- `Serilog.Sinks.ApplicationInsights` sink → routes ILogger logs, including the exceptions `ExceptionHandlerMiddleware` catches and logs, into App Insights. (Serilog replaces the default logging providers, so the SDK's own ILogger provider never sees them — this sink is what makes *handled* exceptions visible.)

## Verification
API builds clean; **847 unit tests green, 0 skipped**. After deploy I'll confirm telemetry starts landing in `AppRequests`/`AppTraces`.
