### PR TITLE
revert: App Insights SDK (BadImageFormatException breaks many endpoints on .NET 10)

### DIFF
--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -58,10 +58,6 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-    <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-  </ItemGroup>
-  <ItemGroup Label="Observability — Application Insights">
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
   </ItemGroup>
   <ItemGroup Label="Background jobs + Stripe + Email + SignalR">
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.23" />

--- a/server/src/ScholarPath.API/Program.cs
+++ b/server/src/ScholarPath.API/Program.cs
@@ -2,7 +2,6 @@ using System.Text.Json.Serialization;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.SqlServer;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -27,35 +26,13 @@ using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// ─── Application Insights (prod error visibility) ────────────────────────────
-// On Linux App Service there is no codeless auto-instrumentation, so the app
-// must send telemetry itself. This reads APPLICATIONINSIGHTS_CONNECTION_STRING
-// from configuration and starts collecting requests, dependencies and
-// exceptions; it is a no-op when no connection string is set (local/dev).
-builder.Services.AddApplicationInsightsTelemetry();
-
 // ─── Serilog ─────────────────────────────────────────────────────────────────
 builder.Host.UseSerilog((ctx, sp, config) =>
-{
     config.ReadFrom.Configuration(ctx.Configuration)
           .ReadFrom.Services(sp)
           .Enrich.FromLogContext()
           .Enrich.WithEnvironmentName()
-          .Enrich.WithThreadId();
-
-    // Ship logs — including the exceptions ExceptionHandlerMiddleware catches and
-    // logs via ILogger — to Application Insights. Serilog replaces the default
-    // logging providers, so the App Insights SDK's own ILogger provider never
-    // sees these; this sink is what makes handled exceptions visible in prod.
-    var aiConnectionString = ctx.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]
-        ?? ctx.Configuration["ApplicationInsights:ConnectionString"];
-    if (!string.IsNullOrWhiteSpace(aiConnectionString))
-    {
-        var telemetryConfig = TelemetryConfiguration.CreateDefault();
-        telemetryConfig.ConnectionString = aiConnectionString;
-        config.WriteTo.ApplicationInsights(telemetryConfig, TelemetryConverter.Traces);
-    }
-});
+          .Enrich.WithThreadId());
 
 // ─── Controllers + JSON ──────────────────────────────────────────────────────
 builder.Services

--- a/server/src/ScholarPath.API/ScholarPath.API.csproj
+++ b/server/src/ScholarPath.API/ScholarPath.API.csproj
@@ -36,10 +36,6 @@
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Enrichers.Environment" />
     <PackageReference Include="Serilog.Enrichers.Thread" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" />
-  </ItemGroup>
-  <ItemGroup Label="Observability — Application Insights (prod error visibility)">
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Reverts #65. The `Microsoft.ApplicationInsights.AspNetCore` 2.23.0 SDK is incompatible with .NET 10 — it caused `System.BadImageFormatException: Bad binary signature` in MVC's `ObjectMethodExecutor`/`LambdaCompiler`, breaking many controller actions in prod (`/api/status`, `/api/bookings/me`, `/api/applications/me`, …). Reverting to restore prod; will re-add observability via the .NET 10-native Azure Monitor OpenTelemetry distro after local verification.