### PR TITLE
fix(client): refetch on window focus + refresh lists on scholarship moderation

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -3,7 +3,7 @@ import { QueryClient } from "@tanstack/react-query";
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 60_000,
+      staleTime: 30_000,
       gcTime: 5 * 60_000,
       retry: (failureCount, error: unknown) => {
         if (typeof error === "object" && error !== null && "status" in error) {
@@ -12,7 +12,13 @@ export const queryClient = new QueryClient({
         }
         return failureCount < 2;
       },
-      refetchOnWindowFocus: false,
+      // Refetch stale data when the user returns to the tab. This is react-query's
+      // default and fixes the "I have to refresh to see updates" class of bugs
+      // (newly-approved scholarships, new comments/votes, eligibility, etc.):
+      // switching back to the tab now pulls fresh data instead of showing a
+      // stale snapshot. Only queries older than staleTime refetch, so it isn't
+      // chatty.
+      refetchOnWindowFocus: true,
     },
     mutations: {
       retry: 0,

--- a/client/src/pages/admin/AdminScholarships.tsx
+++ b/client/src/pages/admin/AdminScholarships.tsx
@@ -56,6 +56,9 @@ export function AdminScholarships() {
     onSuccess: () => {
       toast.success(t("moderation:scholarshipModeration.approveSuccess"));
       void qc.invalidateQueries({ queryKey: ["admin", "scholarships"] });
+      // An approved scholarship becomes publicly visible — refresh the
+      // student/public scholarship lists too so it shows without a manual reload.
+      void qc.invalidateQueries({ queryKey: ["scholarships"] });
     },
     onError: () => toast.error(t("moderation:scholarshipModeration.approveError")),
   });
@@ -68,6 +71,8 @@ export function AdminScholarships() {
     onSuccess: () => {
       toast.success(t("moderation:scholarshipModeration.rejectSuccess"));
       void qc.invalidateQueries({ queryKey: ["admin", "scholarships"] });
+      // A rejected scholarship must disappear from any public list it slipped into.
+      void qc.invalidateQueries({ queryKey: ["scholarships"] });
       setRejectTargetId(null);
     },
     onError: () => {


### PR DESCRIPTION
Fixes the 'must refresh to see updates' cluster. refetchOnWindowFocus:true + public scholarship list invalidation on admin approve/reject. Addresses [1:3,1:5,1:15,2:6,2:8].