### PR TITLE
fix: red-bug batch 1 (search, edit→review, self-vote, AI back, dup listings)

### DIFF
--- a/client/src/pages/community/Community.tsx
+++ b/client/src/pages/community/Community.tsx
@@ -42,10 +42,6 @@ export function Community() {
   const [tab, setTab] = useState<FeedTab>("all");
   const [askOpen, setAskOpen] = useState(false);
 
-  // The server returns 409 if someone tries to vote on a post they authored.
-  // We pre-empt that here by disabling the buttons for posts authored by the
-  // current user — single source of truth is the auth store.
-  const currentUserId = useAuthStore((state) => state.user?.id);
   const activeRole = useAuthStore((state) => state.user?.activeRole);
   const roles = useAuthStore((state) => state.user?.roles ?? []);
   const isStudent = activeRole === "Student" || roles.includes("Student");
@@ -439,8 +435,6 @@ export function Community() {
               ))
             ) : posts.length > 0 ? (
               posts.map((post, idx) => {
-                const isOwnPost = post.authorId === currentUserId;
-                const voteDisabledTitle = isOwnPost ? t("actions.voteOwnPost") : undefined;
                 const score = post.upvoteCount - post.downvoteCount;
                 const categoryName =
                   categories.find((c) => c.id === post.categoryId)?.[isRtl ? "nameAr" : "nameEn"] ||
@@ -463,8 +457,6 @@ export function Community() {
                             <button
                               type="button"
                               aria-label={t("thread.upvote")}
-                              disabled={isOwnPost}
-                              title={voteDisabledTitle}
                               onClick={(e) => handleVote(e, post.id, "Up")}
                               className="p-1.5 rounded-md text-text-tertiary hover:text-brand-600 hover:bg-brand-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                             >
@@ -478,8 +470,6 @@ export function Community() {
                             <button
                               type="button"
                               aria-label={t("thread.downvote")}
-                              disabled={isOwnPost}
-                              title={voteDisabledTitle}
                               onClick={(e) => handleVote(e, post.id, "Down")}
                               className="p-1.5 rounded-md text-text-tertiary hover:text-danger-500 hover:bg-danger-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                             >

--- a/client/src/pages/community/CommunityThread.tsx
+++ b/client/src/pages/community/CommunityThread.tsx
@@ -222,16 +222,11 @@ export function CommunityThread() {
         <div className="p-6 sm:p-8">
           <div className="flex gap-5 sm:gap-6">
             {/* Vote Side — students only */}
-            {isStudent && (() => {
-              const isOwnPost = thread.post.authorId === currentUserId;
-              const title = isOwnPost ? t("actions.voteOwnPost") : undefined;
-              return (
+            {isStudent && (
                 <div className="flex flex-col items-center gap-0.5 bg-bg-subtle/70 rounded-xl px-1.5 py-2 h-fit border border-border-subtle">
                   <button
                     type="button"
                     onClick={() => handleVote(thread.post.id, "Up")}
-                    disabled={isOwnPost}
-                    title={title}
                     aria-label={t("thread.upvote")}
                     className="p-1.5 rounded-md text-text-tertiary hover:text-brand-600 hover:bg-brand-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                   >
@@ -245,16 +240,13 @@ export function CommunityThread() {
                   <button
                     type="button"
                     onClick={() => handleVote(thread.post.id, "Down")}
-                    disabled={isOwnPost}
-                    title={title}
                     aria-label={t("thread.downvote")}
                     className="p-1.5 rounded-md text-text-tertiary hover:text-danger-500 hover:bg-danger-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                   >
                     <ArrowDown size={20} strokeWidth={2.5} aria-hidden />
                   </button>
                 </div>
-              );
-            })()}
+            )}
 
             <div className="flex-1 min-w-0">
               <div className="flex items-center justify-between mb-5 gap-3">

--- a/client/src/pages/student/ScholarshipDetail.tsx
+++ b/client/src/pages/student/ScholarshipDetail.tsx
@@ -226,14 +226,20 @@ export function ScholarshipDetail() {
   return (
     <div className="mx-auto max-w-6xl space-y-6">
 
-      {/* ── Back link ── */}
-      <Link
-        to="/student/scholarships"
+      {/* ── Back (history-aware: returns to where the student came from — the AI
+             recommendations, saved list, or browse — instead of always the browse) ── */}
+      <button
+        type="button"
+        onClick={() => {
+          const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
+          if (idx > 0) navigate(-1);
+          else navigate("/student/scholarships");
+        }}
         className="inline-flex items-center gap-1.5 text-sm font-medium text-text-secondary transition hover:text-brand-600"
       >
         <BackIcon aria-hidden className="size-4" />
         {t("scholarships:detail.back")}
-      </Link>
+      </button>
 
       {/* ── Hero banner ── */}
       <div className="relative overflow-hidden rounded-2xl border border-border-subtle">

--- a/client/src/pages/student/ScholarshipsPage.tsx
+++ b/client/src/pages/student/ScholarshipsPage.tsx
@@ -571,16 +571,27 @@ export function ScholarshipsPage() {
             </h2>
           )}
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {data!.items.map((s, i) => (
-              <ScholarshipCard
-                key={s.id}
-                scholarship={s}
-                isRtl={isRtl}
-                dateLocale={dateLocale}
-                onBookmark={handleBookmark}
-                index={i}
-              />
-            ))}
+            {(() => {
+              // On the default discovery view the featured strip above already
+              // shows the top 3 featured listings; drop them from the main grid
+              // so the same scholarship isn't rendered twice.
+              const stripIds =
+                !query && !hasActiveFilters && featured
+                  ? new Set(featured.slice(0, 3).map((f) => f.id))
+                  : new Set<string>();
+              return data!.items
+                .filter((s) => !stripIds.has(s.id))
+                .map((s, i) => (
+                  <ScholarshipCard
+                    key={s.id}
+                    scholarship={s}
+                    isRtl={isRtl}
+                    dateLocale={dateLocale}
+                    onBookmark={handleBookmark}
+                    index={i}
+                  />
+                ));
+            })()}
           </div>
         </section>
       )}

--- a/server/src/ScholarPath.Application/Community/Commands/ToggleVote/ToggleVoteCommand.cs
+++ b/server/src/ScholarPath.Application/Community/Commands/ToggleVote/ToggleVoteCommand.cs
@@ -40,9 +40,8 @@ public sealed class ToggleVoteCommandHandler(
             .FirstOrDefaultAsync(p => p.Id == request.PostId && !p.IsDeleted, ct)
             ?? throw new NotFoundException(nameof(ForumPost), request.PostId);
 
-        if (post.AuthorId == currentUser.UserId)
-            throw new ConflictException("You cannot vote on your own post.");
-
+        // Authors may upvote their own posts (the self-vote block was removed on
+        // request); the unique (post, user) vote guarantees one vote per user.
         var existingVote = post.Votes.FirstOrDefault(v => v.UserId == currentUser.UserId);
 
         if (existingVote != null)

--- a/server/src/ScholarPath.Application/Scholarships/Commands/UpdateScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/UpdateScholarshipCommand.cs
@@ -4,6 +4,7 @@ using ScholarPath.Application.Common;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
 using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Interfaces;
 
 namespace ScholarPath.Application.Scholarships.Commands;
@@ -98,6 +99,15 @@ public class UpdateScholarshipCommandHandler(IApplicationDbContext db, ICurrentU
                 }
                 entity.ReviewFeeUsd = fee;
             }
+        }
+
+        // PB-005: editing a live (Open) listing sends it back through moderation
+        // so the changed content is re-reviewed by an admin before it is public
+        // again. Drafts / under-review / closed listings are left as-is.
+        if (entity.Status == ScholarshipStatus.Open)
+        {
+            entity.Status = ScholarshipStatus.UnderReview;
+            entity.OpenedAt = null;
         }
 
         await db.SaveChangesAsync(ct);

--- a/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsQuery.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsQuery.cs
@@ -56,17 +56,26 @@ public class GetScholarshipsQueryHandler(IApplicationDbContext db, ICurrentUserS
         if (request.Status.HasValue)
             query = query.Where(s => s.Status == request.Status.Value);
 
-        //  Full-Text Search
+        //  Search (LIKE — no full-text index required)
         if (!string.IsNullOrWhiteSpace(request.Term))
         {
-            // SQL Server CONTAINS requires a quoted phrase for multi-word queries.
-            // Single-word terms also work fine inside quotes, so we always quote.
-            var sanitized = request.Term.Trim().Replace("\"", "");
+            // Previously used SQL Server CONTAINS, which needs a full-text catalog
+            // on Scholarships that is not provisioned in this DB — so every search
+            // threw and surfaced to users as "search failed". LIKE works without an
+            // index. Escape LIKE wildcards so user input can't act as a pattern.
+            var sanitized = request.Term.Trim();
             if (!string.IsNullOrWhiteSpace(sanitized))
             {
-                var ftsTerm = $"\"{sanitized}\"";
-                query = query.Where(s => EF.Functions.Contains(s.TitleEn, ftsTerm) ||
-                                         EF.Functions.Contains(s.TitleAr, ftsTerm));
+                var escaped = sanitized
+                    .Replace("[", "[[]")
+                    .Replace("%", "[%]")
+                    .Replace("_", "[_]");
+                var like = $"%{escaped}%";
+                query = query.Where(s =>
+                    EF.Functions.Like(s.TitleEn, like) ||
+                    EF.Functions.Like(s.TitleAr, like) ||
+                    EF.Functions.Like(s.DescriptionEn, like) ||
+                    EF.Functions.Like(s.DescriptionAr, like));
             }
         }
 

--- a/server/tests/ScholarPath.UnitTests/Community/ToggleVoteCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Community/ToggleVoteCommandHandlerTests.cs
@@ -10,14 +10,17 @@ public sealed class ToggleVoteCommandHandlerTests : IDisposable
     public void Dispose() => _h.Dispose();
 
     [Fact]
-    public async Task Self_vote_is_blocked()
+    public async Task Author_can_vote_on_own_post()
     {
+        // The self-vote block was removed on request — authors may upvote their
+        // own posts, and the unique (post, user) vote still caps it at one.
         var post = await _h.SeedPostAsync(_h.StudentA);
         _h.AsStudent(_h.StudentA);
         var handler = new ToggleVoteCommandHandler(_h.Db, _h.CurrentUser);
 
-        await Assert.ThrowsAsync<ConflictException>(() =>
-            handler.Handle(new ToggleVoteCommand(post.Id, VoteType.Up), CancellationToken.None));
+        await handler.Handle(new ToggleVoteCommand(post.Id, VoteType.Up), CancellationToken.None);
+
+        _h.Db.ForumPosts.Single(p => p.Id == post.Id).UpvoteCount.Should().Be(1);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes 5 confirmed 🔴 bugs: [1:16] search (CONTAINS→LIKE), [2:13] edit Open scholarship→UnderReview, [1:4] author can vote own post (server+client+test), [1:13b] history-aware back on scholarship detail, [2:15] featured/grid duplication. 847 server tests green; client green.