### PR TITLE
fix: reopen closed scholarship [2:18] + admin report details [1:10]

### DIFF
--- a/client/src/locales/ar/moderation.json
+++ b/client/src/locales/ar/moderation.json
@@ -124,7 +124,9 @@
       "archive": "أرشفة",
       "archiveConfirm": "أرشفة هذه المنحة؟ لن يجدها الطلاب بعد ذلك.",
       "archiveSuccess": "تمت أرشفة المنحة.",
-      "reviewApplications": "مراجعة الطلبات"
+      "reviewApplications": "مراجعة الطلبات",
+      "reopen": "إعادة الفتح (إرسال للمراجعة)",
+      "reopenSuccess": "تم إعادة فتح المنحة — رجعت لمراجعة الأدمن."
     },
     "form": {
       "titleCreate": "إنشاء منحة",

--- a/client/src/locales/en/moderation.json
+++ b/client/src/locales/en/moderation.json
@@ -124,7 +124,9 @@
       "archive": "Archive",
       "archiveConfirm": "Archive this scholarship? Students can no longer find it after this.",
       "archiveSuccess": "Scholarship archived.",
-      "reviewApplications": "Review applications"
+      "reviewApplications": "Review applications",
+      "reopen": "Reopen (send for review)",
+      "reopenSuccess": "Scholarship reopened — sent back to admin review."
     },
     "form": {
       "titleCreate": "Create scholarship",

--- a/client/src/pages/admin/AdminCommunity.tsx
+++ b/client/src/pages/admin/AdminCommunity.tsx
@@ -156,13 +156,19 @@ export function AdminCommunity() {
                       count: p.validFlagCount,
                     })}
                   </span>
-                  {p.topFlagReason && (
-                    <p className="mt-1 text-xs text-text-tertiary">
-                      {t("moderation:communityModeration.topReason")}:{" "}
-                      <span className="text-text-secondary">
-                        {flagReasonLabel(p.topFlagReason, i18n.language)}
-                      </span>
-                    </p>
+                  {p.flags.length > 0 && (
+                    <ul className="mt-1.5 max-w-xs space-y-1">
+                      {p.flags.map((f, i) => (
+                        <li key={i} className="text-xs text-text-tertiary">
+                          <span className="font-medium text-text-secondary">
+                            {flagReasonLabel(f.reason, i18n.language)}
+                          </span>
+                          {f.additionalDetails && (
+                            <span> — {f.additionalDetails}</span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
                   )}
                 </td>
                 <td className="px-4 py-3">

--- a/client/src/pages/company/ScholarshipProviderScholarships.tsx
+++ b/client/src/pages/company/ScholarshipProviderScholarships.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { ar } from "date-fns/locale";
 import { toast } from "sonner";
-import { FileText, Pencil, Plus, Trash2 } from "lucide-react";
+import { FileText, Pencil, Plus, RotateCcw, Trash2 } from "lucide-react";
 import {
   scholarshipsApi,
   type MyScholarship,
@@ -59,6 +59,18 @@ export function ScholarshipProviderScholarships() {
       );
       setArchiveTargetId(null);
     },
+  });
+
+  const reopenMut = useMutation({
+    mutationFn: (id: string) => scholarshipsApi.reopen(id),
+    onSuccess: () => {
+      toast.success(t("moderation:scholarshipProviderScholarships.actions.reopenSuccess"));
+      void queryClient.invalidateQueries({ queryKey: ["company", "scholarships", "mine"] });
+    },
+    onError: (err) =>
+      toast.error(
+        apiErrorMessage(err, t("moderation:scholarshipProviderScholarships.form.error")),
+      ),
   });
 
   return (
@@ -175,6 +187,18 @@ export function ScholarshipProviderScholarships() {
                     >
                       <Pencil aria-hidden className="size-4" />
                     </Link>
+                    {s.status === "Closed" && (
+                      <button
+                        type="button"
+                        onClick={() => reopenMut.mutate(s.id)}
+                        disabled={reopenMut.isPending}
+                        title={t("moderation:scholarshipProviderScholarships.actions.reopen")}
+                        aria-label={t("moderation:scholarshipProviderScholarships.actions.reopen")}
+                        className="inline-flex size-8 items-center justify-center rounded-md text-text-secondary transition hover:bg-brand-50 hover:text-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        <RotateCcw aria-hidden className="size-4" />
+                      </button>
+                    )}
                     {s.status !== "Archived" && (
                       <button
                         type="button"

--- a/client/src/services/api/community.ts
+++ b/client/src/services/api/community.ts
@@ -48,6 +48,13 @@ export interface CommunityPagedResult<T> {
   totalCount: number;
 }
 
+/** An individual report on a flagged post (shown to the admin). */
+export interface FlagDetail {
+  reason: string;
+  additionalDetails: string | null;
+  flaggedAt: string;
+}
+
 /** Server FlaggedPostDto shape — a post in the admin moderation queue. */
 export interface FlaggedPost {
   id: string;
@@ -62,6 +69,7 @@ export interface FlaggedPost {
   isAutoHidden: boolean;
   autoHiddenAt: string | null;
   createdAt: string;
+  flags: FlagDetail[];
 }
 
 export interface GetPostsParams {

--- a/client/src/services/api/scholarships.ts
+++ b/client/src/services/api/scholarships.ts
@@ -452,6 +452,11 @@ export const scholarshipsApi = {
     await apiClient.delete(`/api/scholarships/${id}`);
   },
 
+  /** ScholarshipProvider / Admin: reopen a CLOSED listing — sends it back to review. */
+  async reopen(id: string): Promise<void> {
+    await apiClient.post(`/api/scholarships/${id}/reopen`);
+  },
+
   // ── Admin: featured scholarships management ──────────────────────────────────
 
   /**

--- a/server/src/ScholarPath.API/Controllers/ScholarshipController.cs
+++ b/server/src/ScholarPath.API/Controllers/ScholarshipController.cs
@@ -8,6 +8,7 @@ using ScholarPath.Application.Scholarships.Commands;
 using ScholarPath.Application.Scholarships.Commands.ApproveScholarship;
 using ScholarPath.Application.Scholarships.Commands.ConfigureReviewFee;
 using ScholarPath.Application.Scholarships.Commands.RejectScholarship;
+using ScholarPath.Application.Scholarships.Commands.ReopenScholarship;
 using ScholarPath.Application.Scholarships.Commands.ReorderFeaturedScholarships;
 using ScholarPath.Application.Scholarships.Commands.ToggleFeatureScholarship;
 using ScholarPath.Application.Scholarships.DTOs;
@@ -120,6 +121,20 @@ namespace ScholarPath.API.Controllers
         public async Task<IActionResult> Archive(Guid id, CancellationToken ct)
         {
             await mediator.Send(new ArchiveScholarshipCommand(id), ct);
+            return NoContent();
+        }
+
+        // PB-005: owning provider (or admin) reopens a CLOSED listing — it goes
+        // back to the admin moderation queue rather than straight back public.
+        [HttpPost("{id:guid}/reopen")]
+        [Authorize(Roles = "ScholarshipProvider,Admin,SuperAdmin")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
+        public async Task<IActionResult> Reopen(Guid id, CancellationToken ct)
+        {
+            await mediator.Send(new ReopenScholarshipCommand(id), ct);
             return NoContent();
         }
 

--- a/server/src/ScholarPath.Application/Community/Queries/GetFlaggedPosts/GetFlaggedPostsQuery.cs
+++ b/server/src/ScholarPath.Application/Community/Queries/GetFlaggedPosts/GetFlaggedPostsQuery.cs
@@ -9,6 +9,14 @@ namespace ScholarPath.Application.Community.Queries.GetFlaggedPosts;
 
 // ─── DTO ──────────────────────────────────────────────────────────────────────
 
+/// <summary>An individual report on a flagged post — shown to the admin so they can
+/// judge the reason(s) before deciding (PB-007). Reporter identity is intentionally
+/// omitted for privacy; the reason + details are what the decision needs.</summary>
+public sealed record FlagDetailDto(
+    string Reason,
+    string? AdditionalDetails,
+    DateTimeOffset FlaggedAt);
+
 /// <summary>A post that needs admin attention — flagged by users or auto-hidden (PB-007).</summary>
 public sealed record FlaggedPostDto(
     Guid Id,
@@ -22,7 +30,8 @@ public sealed record FlaggedPostDto(
     PostModerationStatus ModerationStatus,
     bool IsAutoHidden,
     DateTimeOffset? AutoHiddenAt,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    IReadOnlyList<FlagDetailDto> Flags);
 
 // ─── Query ────────────────────────────────────────────────────────────────────
 
@@ -84,7 +93,11 @@ public sealed class GetFlaggedPostsQueryHandler(
                 p.ModerationStatus,
                 p.IsAutoHidden,
                 p.AutoHiddenAt,
-                p.CreatedAt))
+                p.CreatedAt,
+                p.Flags.Where(f => f.IsValid)
+                    .OrderByDescending(f => f.FlaggedAt)
+                    .Select(f => new FlagDetailDto(f.Reason, f.AdditionalDetails, f.FlaggedAt))
+                    .ToList()))
             .ToList();
 
         return new PagedResult<FlaggedPostDto>(items, page, pageSize, total);

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ReopenScholarship/ReopenScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ReopenScholarship/ReopenScholarshipCommand.cs
@@ -1,0 +1,70 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ScholarPath.Application.Common.Auditing;
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+
+namespace ScholarPath.Application.Scholarships.Commands.ReopenScholarship;
+
+// ─── Command ──────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The owning provider (or an admin) reopens a CLOSED scholarship. It re-enters
+/// the admin moderation queue (UnderReview) exactly like a freshly-submitted
+/// listing, so it is never made public again without re-approval (PB-005).
+/// </summary>
+[Auditable(AuditAction.Update, "Scholarship",
+    TargetIdProperty = nameof(ScholarshipId),
+    SummaryTemplate = "Reopened scholarship {ScholarshipId}")]
+public sealed record ReopenScholarshipCommand(Guid ScholarshipId) : IRequest<bool>;
+
+// ─── Validator ────────────────────────────────────────────────────────────────
+
+public sealed class ReopenScholarshipCommandValidator : AbstractValidator<ReopenScholarshipCommand>
+{
+    public ReopenScholarshipCommandValidator() => RuleFor(x => x.ScholarshipId).NotEmpty();
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+public sealed class ReopenScholarshipCommandHandler(
+    IApplicationDbContext db,
+    ICurrentUserService currentUser,
+    ILogger<ReopenScholarshipCommandHandler> logger)
+    : IRequestHandler<ReopenScholarshipCommand, bool>
+{
+    public async Task<bool> Handle(ReopenScholarshipCommand request, CancellationToken ct)
+    {
+        var userId = currentUser.UserId
+            ?? throw new ForbiddenAccessException("Not authenticated.");
+
+        var scholarship = await db.Scholarships
+            .FirstOrDefaultAsync(s => s.Id == request.ScholarshipId && !s.IsDeleted, ct)
+            ?? throw new NotFoundException(nameof(Scholarship), request.ScholarshipId);
+
+        // Only the owning provider may reopen their listing; admins may reopen any
+        // (they own the platform-created external listings).
+        if (scholarship.OwnerScholarshipProviderId != userId
+            && !currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+            throw new ForbiddenAccessException("You can only reopen your own scholarships.");
+
+        if (scholarship.Status != ScholarshipStatus.Closed)
+            throw new ConflictException("Only a closed scholarship can be reopened.");
+
+        scholarship.Status = ScholarshipStatus.UnderReview;
+        scholarship.RejectionReason = null;
+        scholarship.RejectedAt = null;
+
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Scholarship {ScholarshipId} reopened by {UserId} — back to moderation.",
+            scholarship.Id, userId);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Reopen command+endpoint+UI (closed→UnderReview); admin moderation shows all flag reasons+details per post. 847 tests + client green.