### PR TITLE
ci(deploy): clean+restart API deploy to stop stale-binary corruption

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,6 +204,11 @@ jobs:
         with:
           app-name: ${{ vars.AZURE_API_APP_NAME }}
           package: ${{ github.workspace }}/publish
+          # clean wipes wwwroot before writing so stale/half-overwritten DLLs from a
+          # previous deploy can't linger and cause System.BadImageFormatException;
+          # restart forces a fresh assembly load afterwards.
+          clean: true
+          restart: true
 
       - name: Azure logout
         if: always()


### PR DESCRIPTION
The API deploy overwrote wwwroot without cleaning → intermittent BadImageFormatException 500ing every endpoint (App Insights incident + batch 3). Add clean:true + restart:true so deploys land a consistent binary set.