### PR TITLE
fix: SRS audit batch C — medium-priority discovery/timeline/profile gaps

### DIFF
--- a/client/src/pages/profile/Profile.tsx
+++ b/client/src/pages/profile/Profile.tsx
@@ -998,6 +998,10 @@ export function Profile() {
       }
       setPhotoVersion(Date.now());
       setPhotoFailed(false);
+      // FR-PROF-08: the photo is a completeness field, so refetch the profile
+      // to pick up the recalculated completenessPercent (setQueryData above only
+      // patches the image URL, leaving the meter stale until a full refetch).
+      void qc.invalidateQueries({ queryKey: PROFILE_KEY });
       toast.success(t("profile:photo.saved"));
     },
     onError: (err) => toast.error(apiErrorMessage(err, t("profile:photo.error"))),

--- a/client/src/pages/student/StudentApplicationDetail.tsx
+++ b/client/src/pages/student/StudentApplicationDetail.tsx
@@ -307,6 +307,29 @@ export function StudentApplicationDetail() {
               : t("moderation:appDetail.notProvided")}
           </Field>
         </dl>
+
+        {/* FR-APP-19: the real recorded status history, oldest-first. */}
+        {data.statusHistory.length > 0 && (
+          <ol className="mt-5 space-y-3 border-t border-border-subtle pt-4">
+            {data.statusHistory.map((entry, i) => (
+              <li key={`${entry.status}-${entry.occurredAt}-${i}`} className="flex items-start gap-3">
+                <span
+                  className={`mt-1.5 size-2 shrink-0 rounded-full ${
+                    i === data.statusHistory.length - 1 ? "bg-brand-500" : "bg-border-strong"
+                  }`}
+                />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-text-primary">
+                    {t(`moderation:applicationStatus.${entry.status}`, { defaultValue: entry.status })}
+                  </p>
+                  <p className="text-xs text-text-tertiary">
+                    {format(new Date(entry.occurredAt), "dd MMM yyyy, HH:mm", { locale: dateLocale })}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
       </section>
 
       {data.decisionReason && (

--- a/client/src/services/api/applications.ts
+++ b/client/src/services/api/applications.ts
@@ -122,6 +122,14 @@ export interface ApplicationDetail {
    */
   scholarshipProviderId: string | null;
   hasReview: boolean;
+  /** FR-APP-19: recorded status transitions, oldest-first. */
+  statusHistory: ApplicationStatusEntry[];
+}
+
+/** One recorded status transition on the application timeline. */
+export interface ApplicationStatusEntry {
+  status: ApplicationStatus;
+  occurredAt: string;
 }
 
 /** Result of `POST /api/applications` — mirrors the server's StartApplicationResult. */

--- a/client/src/services/signalR/chatHub.ts
+++ b/client/src/services/signalR/chatHub.ts
@@ -42,8 +42,10 @@ export function createTypedChatHub(handlers?: ConnectionLifecycleHandlers): Chat
     onUserOffline: (callback) => connection.on("UserOffline", callback),
     offUserOffline: (callback) => connection.off("UserOffline", callback),
 
-    onNewMessage: (callback) => connection.on("NewMessage", callback),
-    offNewMessage: (callback) => connection.off("NewMessage", callback),
+    // Server emits "MessageReceived" (see ChatRealtimeNotifier); the previous
+    // "NewMessage" name silently received nothing.
+    onNewMessage: (callback) => connection.on("MessageReceived", callback),
+    offNewMessage: (callback) => connection.off("MessageReceived", callback),
 
     onTypingStart: (callback) => connection.on("TypingStart", callback),
     offTypingStart: (callback) => connection.off("TypingStart", callback),

--- a/server/src/ScholarPath.Application/Applications/Commands/ReviewApplication/ReviewApplicationCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Applications/Commands/ReviewApplication/ReviewApplicationCommandHandler.cs
@@ -37,6 +37,10 @@ public sealed class ReviewApplicationCommandHandler(
         ApplicationStateMachine.EnsureTransition(oldStatus, request.Status);
 
         application.Status = request.Status;
+        // FR-APP-19: stamp when review actually started so the student timeline
+        // can show a real "Review started" date instead of always "not provided".
+        if (request.Status == ApplicationStatus.UnderReview && application.ReviewStartedAt is null)
+            application.ReviewStartedAt = DateTimeOffset.UtcNow;
         application.DecisionAt = DateTimeOffset.UtcNow;
         application.DecisionReason = request.DecisionReason;
 

--- a/server/src/ScholarPath.Application/Applications/Queries/GetApplicationDetail/GetApplicationDetailQuery.cs
+++ b/server/src/ScholarPath.Application/Applications/Queries/GetApplicationDetail/GetApplicationDetailQuery.cs
@@ -37,7 +37,13 @@ public sealed record ApplicationDetailDto(
     // student UI show a "Rate provider" action after a final decision and hide
     // it once a rating exists. Null provider = external listing (nothing to rate).
     Guid? ScholarshipProviderId,
-    bool HasReview);
+    bool HasReview,
+    // FR-APP-19: the real recorded status transitions, oldest-first, so the
+    // student sees an actual timeline rather than a fixed set of scalar dates.
+    IReadOnlyList<ApplicationStatusEntryDto> StatusHistory);
+
+/// <summary>One recorded status transition on the application timeline.</summary>
+public sealed record ApplicationStatusEntryDto(string Status, DateTimeOffset OccurredAt);
 
 // ─── Query ────────────────────────────────────────────────────────────────────
 
@@ -81,6 +87,15 @@ public sealed class GetApplicationDetailQueryHandler(
             .AsNoTracking()
             .AnyAsync(r => r.ApplicationTrackerId == application.Id, ct);
 
+        // FR-APP-19: the recorded status-transition rows (written by
+        // ApplicationStatusHistoryEventHandler), oldest-first.
+        var statusHistory = await db.ApplicationChildren
+            .AsNoTracking()
+            .Where(c => c.ApplicationTrackerId == application.Id && c.ChildType == "StatusHistory")
+            .OrderBy(c => c.OccurredAt)
+            .Select(c => new ApplicationStatusEntryDto(c.Title ?? "", c.OccurredAt))
+            .ToListAsync(ct);
+
         return new ApplicationDetailDto(
             application.Id,
             application.ScholarshipId,
@@ -103,6 +118,7 @@ public sealed class GetApplicationDetailQueryHandler(
             application.DecisionAt,
             scholarship?.ReviewFeeUsd,
             scholarship?.OwnerScholarshipProviderId,
-            hasReview);
+            hasReview,
+            statusHistory);
     }
 }

--- a/server/src/ScholarPath.Application/Profile/ProfileCompletenessCalculator.cs
+++ b/server/src/ScholarPath.Application/Profile/ProfileCompletenessCalculator.cs
@@ -10,8 +10,9 @@ public static class ProfileCompletenessCalculator
 {
     public static int Calculate(ApplicationUser user, UserProfile? profile)
     {
-        object?[] fields =
-        [
+        // Common fields count toward completeness for every role.
+        var fields = new List<object?>
+        {
             Blank(user.FirstName),
             Blank(user.LastName),
             Blank(user.ProfileImageUrl),
@@ -19,15 +20,22 @@ public static class ProfileCompletenessCalculator
             profile?.Biography is { Length: > 0 } ? profile.Biography : null,
             profile?.Nationality,
             profile?.DateOfBirth,
-            profile?.FieldOfStudy,
-            profile?.AcademicLevel,
-            profile?.CurrentInstitution,
             profile?.LinkedInUrl,
             profile?.WebsiteUrl,
-        ];
+        };
+
+        // Academic background only applies to Students — counting it for a
+        // ScholarshipProvider or Consultant would cap their meter below 100%
+        // forever (they have no academic fields to fill). FR-PROF-09/08.
+        if (string.Equals(user.ActiveRole, "Student", StringComparison.OrdinalIgnoreCase))
+        {
+            fields.Add(profile?.FieldOfStudy);
+            fields.Add(profile?.AcademicLevel);
+            fields.Add(profile?.CurrentInstitution);
+        }
 
         var filled = fields.Count(f => f is not null);
-        return (int)Math.Round(filled * 100.0 / fields.Length, MidpointRounding.AwayFromZero);
+        return (int)Math.Round(filled * 100.0 / fields.Count, MidpointRounding.AwayFromZero);
     }
 
     private static string? Blank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;

--- a/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsQuery.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsQuery.cs
@@ -98,8 +98,19 @@ public class GetScholarshipsQueryHandler(IApplicationDbContext db, ICurrentUserS
             query = query.Where(s => s.TargetCountriesJson!.Contains(request.Country));
 
         if (!string.IsNullOrEmpty(request.FieldOfStudy))
+        {
+            // FR-SCH-05: match the field as a whole JSON-array element, not a raw
+            // substring — otherwise "Art" wrongly matched "Smart Materials".
+            // Serialize the needle with the SAME serializer used to store the
+            // array (CreateScholarshipCommand). That way the surrounding quotes
+            // AND the default encoder's escaping of characters such as ampersand
+            // both line up with the stored value, so fields like "Arts and
+            // Humanities" written with an ampersand still match. A listing with
+            // no fields declared is unrestricted (matches every field filter).
+            var fieldNeedle = JsonSerializer.Serialize(request.FieldOfStudy);
             query = query.Where(s => s.FieldsOfStudyJson == null ||
-                                     s.FieldsOfStudyJson.Contains(request.FieldOfStudy));
+                                     s.FieldsOfStudyJson.Contains(fieldNeedle));
+        }
 
         //  Sorting with Tie-break for Pagination Stability
         // `Sort` is an opt-in override. The default keeps featured-first then

--- a/server/tests/ScholarPath.UnitTests/Scholarships/ScholarshipTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Scholarships/ScholarshipTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using ScholarPath.Application.Common.Exceptions;
@@ -115,6 +116,31 @@ public sealed class ScholarshipTests : IDisposable
         result.Should().NotBeNull();
         result.Id.Should().Be(id);
         result.Title.Should().Be("Test Scholarship");
+    }
+
+    // FR-SCH-05: the field-of-study filter matches a whole JSON-array element
+    // (not a raw substring). This mirrors the handler's exact logic —
+    // storedJson.Contains(JsonSerializer.Serialize(field)) — where BOTH the stored
+    // array and the needle go through the same default serializer, so the quoting
+    // and the '&'→& escaping line up. (A DB-backed test can't run here: the
+    // query's DateTimeOffset ORDER BY is unsupported by the SQLite test harness,
+    // though SQL Server handles it in prod.)
+    [Fact]
+    public void FieldFilter_SerializedNeedle_MatchesStoredElement_IncludingAmpersand()
+    {
+        var stored = JsonSerializer.Serialize(new[] { "Arts & Humanities", "Engineering" });
+
+        // Exact-element matches, ampersand handled by identical encoding.
+        stored.Contains(JsonSerializer.Serialize("Arts & Humanities")).Should().BeTrue();
+        stored.Contains(JsonSerializer.Serialize("Engineering")).Should().BeTrue();
+
+        // Partial-word needle must NOT match (the bug this fix closes).
+        JsonSerializer.Serialize(new[] { "Smart Materials" })
+            .Contains(JsonSerializer.Serialize("Art")).Should().BeFalse();
+
+        // A RAW (unserialized) ampersand needle would NOT match — proving why the
+        // handler must serialize the needle rather than build "\"{field}\"".
+        stored.Contains("\"Arts & Humanities\"").Should().BeFalse();
     }
 
     public void Dispose()


### PR DESCRIPTION
Third batch of the code-vs-SRS conformance audit — the **medium-priority** gaps.

- **FR-SCH-05** — fields-of-study filter matches a whole JSON element (no more "Art" ↔ "Smart Materials"), and serializes the needle with the same serializer as storage so `&`-containing fields (7/15) match instead of returning nothing. Locked with a unit test.
- **FR-APP-19** — the student application detail now renders the **real recorded status history** (oldest-first) instead of static scalar dates; `ReviewStartedAt` is stamped on Submitted → In Assessment.
- **FR-PROF-08/09** — profile completeness is **role-aware** (academic fields count only for Students, so providers/consultants can reach 100%); uploading a photo refetches so the meter updates.
- **chatHub.ts** — the typed wrapper now subscribes to the real `"MessageReceived"` event (was the dead `"NewMessage"`).

## Verification
- Server build clean + **850 unit tests** green.
- Client `tsc` + `eslint --max-warnings 0` + `build` all clean.
- Adversarial diff review caught a real `&`-escaping bug in the field filter — **fixed and re-tested** before merge; the other three fixes passed.