### PR TITLE
ci(deploy): drop clean:true — fixes the false-red Linux rsync failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,10 +204,15 @@ jobs:
         with:
           app-name: ${{ vars.AZURE_API_APP_NAME }}
           package: ${{ github.workspace }}/publish
-          # clean wipes wwwroot before writing so stale/half-overwritten DLLs from a
-          # previous deploy can't linger and cause System.BadImageFormatException;
-          # restart forces a fresh assembly load afterwards.
-          clean: true
+          # NOTE: do NOT set `clean: true` here. On Linux App Service the action
+          # runs Kudu's parallel_rsync with the clean flag, which races and fails
+          # with "No such file or directory" (rsync exit 23) — the deploy still
+          # lands but the step goes red. rsync-without-clean overwrites each
+          # assembly atomically (temp file + rename), and `restart: true` then
+          # forces a fresh, consistent assembly load — which is what prevents the
+          # System.BadImageFormatException the clean flag was originally added for
+          # (that corruption predated restart:true). If a dropped dependency ever
+          # needs a true wipe, do a one-off Kudu `rm -rf /home/site/wwwroot/*`.
           restart: true
 
       - name: Azure logout


### PR DESCRIPTION
Every API deploy showed a red **"Failed to deploy to production"** even though the app deployed and came up healthy (200s). Root cause found in the run logs: `clean: true` makes `azure/webapps-deploy` run Kudu's `parallel_rsync.sh … True` on Linux App Service, which races between parallel workers and the wwwroot wipe → `rsync … No such file or directory … (code 23)` → step exits non-zero.

**Fix:** drop `clean: true`, keep `restart: true`. rsync-without-clean overwrites each assembly atomically (temp + rename) with no delete race, and the restart forces a fresh consistent assembly load — which is what actually prevents the `BadImageFormatException` clean was added for (that corruption predated `restart: true`). Deploys now report green.

Verified by test-deploying this change and confirming the run goes green + the site stays healthy.