### PR TITLE
fix: SRS audit batch E — low-priority cleanups

### DIFF
--- a/client/src/pages/profile/Profile.tsx
+++ b/client/src/pages/profile/Profile.tsx
@@ -1433,7 +1433,7 @@ export function Profile() {
               <div>
                 <textarea
                   rows={5}
-                  maxLength={500}
+                  maxLength={2000}
                   className="input-premium font-normal"
                   placeholder={t("profile:fields.biographyPlaceholder")}
                   value={form.biography}
@@ -1444,7 +1444,7 @@ export function Profile() {
                     {t("profile:fields.biographyHelp")}
                   </p>
                   <p className="text-text-tertiary">
-                    {form.biography.length}/500
+                    {form.biography.length}/2000
                   </p>
                 </div>
               </div>

--- a/server/src/ScholarPath.API/Controllers/ScholarshipController.cs
+++ b/server/src/ScholarPath.API/Controllers/ScholarshipController.cs
@@ -87,10 +87,12 @@ namespace ScholarPath.API.Controllers
             return await mediator.Send(command);
         }
 
-        // ScholarshipProvider edits one of its own listings — title/description/category/deadline only.
-        // FundingType and TargetLevel are create-only; the update command doesn't accept them.
+        // ScholarshipProvider edits one of its own listings; an Admin may edit an
+        // admin-created (ownerless) listing such as an External scholarship. The
+        // command enforces ownership either way. Title/description/category/
+        // deadline/country only — FundingType and TargetLevel are create-only.
         [HttpPut("{id:guid}")]
-        [Authorize(Roles = "ScholarshipProvider")]
+        [Authorize(Roles = "ScholarshipProvider,Admin,SuperAdmin")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]

--- a/server/src/ScholarPath.Application/Scholarships/Commands/UpdateScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/UpdateScholarshipCommand.cs
@@ -52,8 +52,20 @@ public class UpdateScholarshipCommandHandler(IApplicationDbContext db, ICurrentU
 
         if (entity == null) throw new NotFoundException(nameof(Scholarship), request.Id);
 
-        if (entity.OwnerScholarshipProviderId != user.UserId)
+        // FR-SCH-18/19: a provider may edit only their OWN listing. An
+        // admin-created (ownerless) listing — e.g. an External scholarship — is
+        // editable only by an Admin/SuperAdmin. Providers still cannot touch
+        // another provider's listing.
+        var isAdmin = user.IsInRole("Admin") || user.IsInRole("SuperAdmin");
+        if (entity.OwnerScholarshipProviderId is { } ownerId)
+        {
+            if (ownerId != user.UserId)
+                throw new ForbiddenAccessException();
+        }
+        else if (!isAdmin)
+        {
             throw new ForbiddenAccessException();
+        }
 
         if (entity.Applications.Any() && entity.CategoryId != request.CategoryId)
             throw new ConflictException("Cannot change scholarship category while applications are in progress.");
@@ -109,11 +121,13 @@ public class UpdateScholarshipCommandHandler(IApplicationDbContext db, ICurrentU
             }
         }
 
-        // PB-005: editing a live (Open) listing sends it back through moderation
-        // so the changed content is re-reviewed by an admin before it is public
-        // again. Editing a REJECTED draft resubmits it (clears the feedback and
-        // re-enters the queue). Plain drafts / under-review / closed are untouched.
-        if (entity.Status == ScholarshipStatus.Open)
+        // PB-005: editing a live (Open) PROVIDER listing sends it back through
+        // moderation so the changed content is re-reviewed before it is public
+        // again. Admin-created (ownerless) listings skip this — the admin IS the
+        // moderator, so their edit stays live. Editing a REJECTED draft resubmits
+        // it (clears the feedback and re-enters the queue). Plain drafts /
+        // under-review / closed are untouched.
+        if (entity.OwnerScholarshipProviderId is not null && entity.Status == ScholarshipStatus.Open)
         {
             entity.Status = ScholarshipStatus.UnderReview;
             entity.OpenedAt = null;


### PR DESCRIPTION
Final batch of the audit — the low-priority cleanups.

- **Bio limit** — the profile biography textarea + counter used 500 while the server allows 2000; aligned both to 2000.
- **FR-SCH-18/19** — an Admin can now edit an ownerless (admin-created) listing, e.g. an External scholarship created via the admin flow, which previously had no editable path. Providers still edit only their own listings and can't touch another provider's; admins can't edit provider-owned listings. Editing an ownerless Open listing keeps it Open (admin is the moderator); provider edits still re-enter moderation.

## Verification
- Server build clean + **850 unit tests** green.
- Client `tsc` + `eslint --max-warnings 0` + `build` all clean.
- Adversarial review: PASS — no privilege-escalation or lockout in the authorization change.