### PR TITLE
fix: reliable API deploy (stale-DLL) + defensive client crash guards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,20 +199,33 @@ jobs:
             --output none
           echo "Applied ${#settings[@]} integration app setting(s)."
 
+      # CRITICAL: the running app holds its loaded assemblies open, so a plain
+      # rsync deploy CANNOT overwrite the *.dll on disk — rsync fails with
+      # "No such file or directory" (exit 23) and the API keeps serving STALE
+      # code (verified: server fixes silently didn't go live). Delete the
+      # deployed assemblies FIRST so the deploy writes a fresh, consistent set
+      # into place with no locked-file conflict; the app keeps running on its
+      # in-memory copies until restart:true reloads the new ones. Only *.dll is
+      # removed — uploads/, logs/, appsettings, and web.config are preserved.
+      - name: Release locked assemblies before deploy
+        run: |
+          token=$(az account get-access-token --resource https://management.azure.com --query accessToken -o tsv)
+          scm="https://${{ vars.AZURE_API_APP_NAME }}.scm.azurewebsites.net/api/command"
+          code=$(curl -s -o /tmp/clean.json -w "%{http_code}" -X POST "$scm" \
+            -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
+            -d '{"command":"find /home/site/wwwroot -maxdepth 2 -name \"*.dll\" -delete","dir":"/home"}')
+          echo "assembly-clean HTTP $code"; cat /tmp/clean.json || true
+          if [ "$code" != "200" ]; then echo "Assembly clean failed — aborting to avoid a partial deploy."; exit 1; fi
+
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ vars.AZURE_API_APP_NAME }}
           package: ${{ github.workspace }}/publish
-          # NOTE: do NOT set `clean: true` here. On Linux App Service the action
-          # runs Kudu's parallel_rsync with the clean flag, which races and fails
-          # with "No such file or directory" (rsync exit 23) — the deploy still
-          # lands but the step goes red. rsync-without-clean overwrites each
-          # assembly atomically (temp file + rename), and `restart: true` then
-          # forces a fresh, consistent assembly load — which is what prevents the
-          # System.BadImageFormatException the clean flag was originally added for
-          # (that corruption predated restart:true). If a dropped dependency ever
-          # needs a true wipe, do a one-off Kudu `rm -rf /home/site/wwwroot/*`.
+          # `clean: true` is intentionally NOT set — on Linux App Service it runs
+          # Kudu's parallel_rsync with a delete flag that races (exit 23). We
+          # release locked assemblies in the step above instead, then rsync writes
+          # into the freed slots and restart:true loads the fresh set.
           restart: true
 
       - name: Azure logout

--- a/client/src/pages/admin/AdminCommunity.tsx
+++ b/client/src/pages/admin/AdminCommunity.tsx
@@ -156,9 +156,9 @@ export function AdminCommunity() {
                       count: p.validFlagCount,
                     })}
                   </span>
-                  {p.flags.length > 0 && (
+                  {(p.flags ?? []).length > 0 && (
                     <ul className="mt-1.5 max-w-xs space-y-1">
-                      {p.flags.map((f, i) => (
+                      {(p.flags ?? []).map((f, i) => (
                         <li key={i} className="text-xs text-text-tertiary">
                           <span className="font-medium text-text-secondary">
                             {flagReasonLabel(f.reason, i18n.language)}

--- a/client/src/pages/student/StudentApplicationDetail.tsx
+++ b/client/src/pages/student/StudentApplicationDetail.tsx
@@ -186,6 +186,9 @@ export function StudentApplicationDetail() {
   const isDraft = data.status === "Draft";
   const scholarshipTitle = isRtl ? data.scholarshipTitleAr : data.scholarshipTitleEn;
   const attachedDocs = parseStringArray(data.attachedDocumentsJson);
+  // Defensive: an older API build (or a partial deploy) may omit statusHistory —
+  // never let a missing array crash the whole page.
+  const statusHistory = data.statusHistory ?? [];
 
   // FR-APP-35: rating is offered once, only for an in-app application that has
   // reached a final decision and whose provider hasn't been rated yet.
@@ -309,13 +312,13 @@ export function StudentApplicationDetail() {
         </dl>
 
         {/* FR-APP-19: the real recorded status history, oldest-first. */}
-        {data.statusHistory.length > 0 && (
+        {statusHistory.length > 0 && (
           <ol className="mt-5 space-y-3 border-t border-border-subtle pt-4">
-            {data.statusHistory.map((entry, i) => (
+            {statusHistory.map((entry, i) => (
               <li key={`${entry.status}-${entry.occurredAt}-${i}`} className="flex items-start gap-3">
                 <span
                   className={`mt-1.5 size-2 shrink-0 rounded-full ${
-                    i === data.statusHistory.length - 1 ? "bg-brand-500" : "bg-border-strong"
+                    i === statusHistory.length - 1 ? "bg-brand-500" : "bg-border-strong"
                   }`}
                 />
                 <div className="min-w-0">


### PR DESCRIPTION
## The real bug behind the crash
A student hit `TypeError: Cannot read properties of undefined (reading 'length')` on the application detail page. Investigation (Kudu) showed the deployed `ScholarPath.Application.dll` timestamp was **before** the batch A–E deploys — **the API was serving stale code**. Cause: the running app holds its loaded `*.dll` open, so the rsync deploy can't overwrite them (`rsync … No such file or directory`, exit 23 — the long-standing red). New DTO fields (e.g. `ApplicationDetailDto.StatusHistory`) were therefore absent from responses → the client crashed.

## Fix
- **deploy.yml** — before the rsync step, delete the deployed `*.dll` via Kudu so the new assemblies land in freed slots with no locked-file conflict; the app keeps running on its in-memory copies until `restart: true` reloads the fresh set. `uploads/`, `logs/`, appsettings are preserved. This makes deploys **actually replace server code** (and should clear the red).
- **StudentApplicationDetail.tsx** / **AdminCommunity.tsx** — defensively guard `statusHistory` / `flags` (`?? []`) so a missing array can never crash the page again.

Client tsc + eslint + build clean. This deploy will be the first to verify the assembly-clean step lands all of batch A–E server code.