### PR TITLE
fix: comprehensive bug hunt — crash guards, SRS gaps, doc-security hardening

### DIFF
--- a/client/src/components/application/KanbanBoard.tsx
+++ b/client/src/components/application/KanbanBoard.tsx
@@ -30,6 +30,17 @@ const COLUMNS: {
   { key: "Rejected",    members: ["Rejected", "Withdrawn"] },
 ];
 
+// Only EXTERNAL trackers are draggable, and FR-APP-33/34 limits them to the
+// three self-tracking states. Map each column to the external status it writes
+// back — the "In Review" column represents "waiting for the result", so it maps
+// to WaitingResult (which also makes that status reachable). Columns with no
+// entry (Accepted / Rejected — in-app provider decisions) reject the drop.
+const EXTERNAL_DROP_STATUS: Partial<Record<ApplicationStatus, ApplicationStatus>> = {
+  Intending: "Intending",
+  Applied: "Applied",
+  UnderReview: "WaitingResult",
+};
+
 export function KanbanBoard({ applications, onStatusChange }: KanbanBoardProps) {
   const { t } = useTranslation("applications");
 
@@ -61,7 +72,10 @@ export function KanbanBoard({ applications, onStatusChange }: KanbanBoardProps) 
               onDragOver={(e: React.DragEvent) => e.preventDefault()}
               onDrop={(e: React.DragEvent) => {
                 const id = e.dataTransfer.getData("applicationId");
-                if (id) onStatusChange(id, status);
+                const target = EXTERNAL_DROP_STATUS[status];
+                // No mapping = an in-app-only column (Accepted/Rejected): reject
+                // the drop rather than send a status the server will 409 on.
+                if (id && target) onStatusChange(id, target);
               }}
             >
               <AnimatePresence mode="popLayout">

--- a/client/src/pages/admin/AdminArticles.tsx
+++ b/client/src/pages/admin/AdminArticles.tsx
@@ -109,7 +109,7 @@ function PendingTab() {
                 </td>
                 <td className="px-4 py-3 text-text-secondary">{r.authorRole}</td>
                 <td className="px-4 py-3 text-xs text-text-tertiary">
-                  {r.tags.slice(0, 3).join(", ") || "—"}
+                  {(r.tags ?? []).slice(0, 3).join(", ") || "—"}
                 </td>
                 <td className="px-4 py-3 text-end">
                   <div className="inline-flex gap-2">
@@ -251,7 +251,7 @@ function PublishedTab() {
                   {t(`resources:resourceType.${r.type}`)}
                 </td>
                 <td className="px-4 py-3 text-xs text-text-tertiary">
-                  {r.tags.slice(0, 3).join(", ") || "—"}
+                  {(r.tags ?? []).slice(0, 3).join(", ") || "—"}
                 </td>
                 <td className="px-4 py-3 text-center">
                   <button

--- a/client/src/pages/author/MyResources.tsx
+++ b/client/src/pages/author/MyResources.tsx
@@ -139,9 +139,9 @@ export function MyResources() {
                   <tr key={r.id} className="transition hover:bg-bg-subtle/40">
                     <td className="max-w-xs px-4 py-3">
                       <p className="truncate font-medium text-text-primary">{title}</p>
-                      {r.tags.length > 0 && (
+                      {(r.tags ?? []).length > 0 && (
                         <p className="mt-0.5 truncate text-xs text-text-tertiary">
-                          {r.tags.slice(0, 3).join(" · ")}
+                          {(r.tags ?? []).slice(0, 3).join(" · ")}
                         </p>
                       )}
                     </td>

--- a/client/src/pages/community/Community.tsx
+++ b/client/src/pages/community/Community.tsx
@@ -495,9 +495,9 @@ export function Community() {
                           <p className="text-text-secondary text-sm line-clamp-2 mb-3 leading-relaxed">
                             {forumPostBody(post, isRtl)}
                           </p>
-                          {post.tags.length > 0 && (
+                          {(post.tags ?? []).length > 0 && (
                             <div className="mb-3 flex flex-wrap gap-1.5">
-                              {post.tags.map((tag) => (
+                              {(post.tags ?? []).map((tag) => (
                                 <button
                                   key={tag}
                                   type="button"

--- a/client/src/pages/community/CommunityThread.tsx
+++ b/client/src/pages/community/CommunityThread.tsx
@@ -353,9 +353,9 @@ export function CommunityThread() {
                 {forumPostTitle(thread.post, isRtl)}
               </h1>
 
-              {thread.post.tags.length > 0 && (
+              {(thread.post.tags ?? []).length > 0 && (
                 <div className="mb-4 flex flex-wrap gap-1.5">
-                  {thread.post.tags.map((tag) => (
+                  {(thread.post.tags ?? []).map((tag) => (
                     <Link
                       key={tag}
                       to={`/student/community?tag=${encodeURIComponent(tag)}`}
@@ -418,12 +418,12 @@ export function CommunityThread() {
 
       {/* Replies List */}
       <div className="space-y-3 relative">
-        {thread.replies.length > 0 && (
+        {(thread.replies ?? []).length > 0 && (
           <h2 className="text-sm font-bold text-text-secondary uppercase tracking-wider mb-2">
             {t("thread.commentsCount", { count: thread.post.replyCount })}
           </h2>
         )}
-        {thread.replies.map((reply, idx) => {
+        {(thread.replies ?? []).map((reply, idx) => {
           const isOwnReply = reply.authorId === currentUserId;
           const replyVoteTitle = isOwnReply ? t("actions.voteOwnPost") : undefined;
           const replyScore = reply.upvoteCount - reply.downvoteCount;

--- a/client/src/pages/company/Dashboard.tsx
+++ b/client/src/pages/company/Dashboard.tsx
@@ -223,7 +223,7 @@ export function ScholarshipProviderDashboard() {
               />
             ) : (
               <div className="grid gap-4 md:grid-cols-2">
-                {ratings.recentReviews.slice(0, 4).map((review) => (
+                {(ratings.recentReviews ?? []).slice(0, 4).map((review) => (
                   <article
                     key={review.reviewId}
                     className="rounded-2xl border border-border-subtle bg-bg-subtle/40 p-4 transition-all hover:border-brand-200 hover:bg-bg-subtle/70"

--- a/client/src/pages/company/ScholarshipProviderInsights.tsx
+++ b/client/src/pages/company/ScholarshipProviderInsights.tsx
@@ -398,7 +398,7 @@ export function ScholarshipProviderInsights() {
       >
         {isLoading || !data ? (
           <div className="h-48 animate-pulse rounded-lg bg-bg-subtle sm:h-56" />
-        ) : data.monthlyFunnel.length < 2 ? (
+        ) : (data.monthlyFunnel?.length ?? 0) < 2 ? (
           <p className="py-8 text-center text-sm text-text-tertiary">
             {t("analytics:reports.noData")}
           </p>

--- a/client/src/pages/student/BookmarksPage.tsx
+++ b/client/src/pages/student/BookmarksPage.tsx
@@ -334,9 +334,9 @@ function ResourcesTab() {
                 </p>
               )}
 
-              {r.tags.length > 0 && (
+              {(r.tags ?? []).length > 0 && (
                 <div className="mt-4 flex flex-wrap gap-1.5 border-t border-border-subtle pt-4">
-                  {r.tags.slice(0, 3).map((tag) => (
+                  {(r.tags ?? []).slice(0, 3).map((tag) => (
                     <span key={tag} className="badge badge-neutral text-[10.5px]">
                       {expertiseTagLabelByLang(tag, i18n.language)}
                     </span>

--- a/client/src/pages/student/ConsultantDetail.tsx
+++ b/client/src/pages/student/ConsultantDetail.tsx
@@ -230,8 +230,8 @@ export function ConsultantDetail() {
 
           {/* Expertise tags */}
           <div className="mt-5 flex flex-wrap gap-1.5">
-            {consultant.expertiseTags.length > 0 ? (
-              consultant.expertiseTags.map((tag) => (
+            {(consultant.expertiseTags ?? []).length > 0 ? (
+              (consultant.expertiseTags ?? []).map((tag) => (
                 <span key={tag} className="badge badge-brand">{expertiseTagLabelByLang(tag, i18n.language)}</span>
               ))
             ) : (
@@ -265,8 +265,8 @@ export function ConsultantDetail() {
               icon={Languages}
               label={t("detail.languages")}
               value={
-                consultant.languages.length > 0
-                  ? consultant.languages.map(c => languageNameByLang(c, i18n.language)).join(" · ")
+                (consultant.languages ?? []).length > 0
+                  ? (consultant.languages ?? []).map(c => languageNameByLang(c, i18n.language)).join(" · ")
                   : "—"
               }
             />
@@ -291,13 +291,13 @@ export function ConsultantDetail() {
             </section>
           )}
 
-          {consultant.recentReviews.length > 0 && (
+          {(consultant.recentReviews ?? []).length > 0 && (
             <section className="rounded-2xl border border-border-subtle bg-bg-elevated p-6 shadow-xs">
               <h2 className="mb-4 text-base font-semibold text-text-primary">
                 {t("detail.reviewsTitle")}
               </h2>
               <div className="space-y-4">
-                {consultant.recentReviews.map((review) => (
+                {(consultant.recentReviews ?? []).map((review) => (
                   <div
                     key={review.id}
                     className="rounded-xl border border-border-subtle bg-bg-muted p-4"

--- a/client/src/pages/student/ResourceDetail.tsx
+++ b/client/src/pages/student/ResourceDetail.tsx
@@ -257,7 +257,7 @@ export function ResourceDetail() {
   const content = isAr
     ? data.contentMarkdownAr ?? data.contentMarkdownEn
     : data.contentMarkdownEn ?? data.contentMarkdownAr;
-  const chapters = [...data.chapters].sort((a, b) => a.sortOrder - b.sortOrder);
+  const chapters = [...(data.chapters ?? [])].sort((a, b) => a.sortOrder - b.sortOrder);
   const Icon = TYPE_ICON[data.type];
   const typeBadge = TYPE_THEME[data.type];
 
@@ -323,9 +323,9 @@ export function ResourceDetail() {
                 </p>
               )}
 
-              {data.tags.length > 0 && (
+              {(data.tags ?? []).length > 0 && (
                 <div className="mt-5 flex flex-wrap gap-1.5">
-                  {data.tags.map((tag) => (
+                  {(data.tags ?? []).map((tag) => (
                     <span
                       key={tag}
                       className="rounded-md bg-bg-subtle border border-border-subtle px-2 py-0.5 text-xs font-medium text-text-secondary"

--- a/client/src/pages/student/StudentResources.tsx
+++ b/client/src/pages/student/StudentResources.tsx
@@ -280,9 +280,9 @@ function ResourceCard({
         )}
 
         <div className="mt-auto pt-3 space-y-2">
-          {resource.tags.length > 0 && (
+          {(resource.tags ?? []).length > 0 && (
             <div className="flex flex-wrap gap-1">
-              {resource.tags.slice(0, 4).map((tag) => (
+              {(resource.tags ?? []).slice(0, 4).map((tag) => (
                 <span
                   key={tag}
                   className="rounded-md bg-bg-subtle border border-border-subtle px-1.5 py-0.5 text-[10px] font-medium text-text-secondary"

--- a/client/src/services/api/consultants.ts
+++ b/client/src/services/api/consultants.ts
@@ -72,13 +72,24 @@ export const consultantsApi = {
   /** Lists every active consultant with a profile summary. Anonymous-accessible. */
   async browse(): Promise<ConsultantSummary[]> {
     const { data } = await apiClient.get<ConsultantSummary[]>("/api/consultants");
-    return data;
+    // Normalize array fields so a partial/omitting response can never crash a
+    // consumer doing `.map`/`.length` on them (the arrays are typed non-optional).
+    return (data ?? []).map((c) => ({
+      ...c,
+      expertiseTags: c.expertiseTags ?? [],
+      languages: c.languages ?? [],
+    }));
   },
 
   /** Returns one consultant's full public profile. Anonymous-accessible. */
   async getById(id: string): Promise<ConsultantDetail> {
     const { data } = await apiClient.get<ConsultantDetail>(`/api/consultants/${id}`);
-    return data;
+    return {
+      ...data,
+      expertiseTags: data.expertiseTags ?? [],
+      languages: data.languages ?? [],
+      recentReviews: data.recentReviews ?? [],
+    };
   },
 
   /** Returns a consultant's upcoming bookable slots (next 28 days). */

--- a/server/src/ScholarPath.Application/Applications/Commands/ReviewApplication/ReviewApplicationCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Applications/Commands/ReviewApplication/ReviewApplicationCommandHandler.cs
@@ -57,7 +57,7 @@ public sealed class ReviewApplicationCommandHandler(
         await notifications.DispatchAsync(
             application.StudentId,
             NotificationType.ApplicationStatusChanged,
-            new NotificationParams { StatusText = request.Status.ToString() },
+            new NotificationParams { StatusText = request.Status.ToString(), Reason = request.DecisionReason },
             null,
             null,
             ct);

--- a/server/src/ScholarPath.Application/Applications/Commands/SubmitApplication/SubmitApplicationCommand.cs
+++ b/server/src/ScholarPath.Application/Applications/Commands/SubmitApplication/SubmitApplicationCommand.cs
@@ -50,19 +50,19 @@ public sealed class SubmitApplicationCommandHandler(
                 throw new ConflictException("Complete the application form before submitting.");
             }
 
+            var attached = string.IsNullOrWhiteSpace(application.AttachedDocumentsJson)
+                ? []
+                : System.Text.Json.JsonSerializer
+                    .Deserialize<string[]>(application.AttachedDocumentsJson) ?? [];
+
             if (!string.IsNullOrWhiteSpace(scholarship.RequiredDocumentsJson))
             {
                 var required = System.Text.Json.JsonSerializer
                     .Deserialize<string[]>(scholarship.RequiredDocumentsJson) ?? [];
                 if (required.Length > 0)
                 {
-                    var attached = string.IsNullOrWhiteSpace(application.AttachedDocumentsJson)
-                        ? []
-                        : System.Text.Json.JsonSerializer
-                            .Deserialize<string[]>(application.AttachedDocumentsJson) ?? [];
-
                     // Parallel arrays: required[i] maps to attached[i].
-                    // Every slot must be filled (non-empty URL).
+                    // Every slot must be filled (non-empty file name).
                     var missing = required
                         .Select((name, i) => new { name, url = attached.ElementAtOrDefault(i) })
                         .Where(x => string.IsNullOrWhiteSpace(x.url))
@@ -73,6 +73,31 @@ public sealed class SubmitApplicationCommandHandler(
                         throw new ConflictException(
                             $"Missing required documents: {string.Join(", ", missing)}. Upload all required files before submitting.");
                 }
+            }
+
+            // FR-APP-13/14: every attached document must reference a file the
+            // student actually uploaded through the scanned Document vault (which
+            // enforces type/size/antivirus and fail-closes — a Document row only
+            // exists once the file passed those checks). Reject any attached entry
+            // that doesn't map to a Document owned by this student, so a
+            // hand-crafted draft PUT can't submit arbitrary, never-scanned
+            // "documents". Vault reuse (any owned file) is allowed by design.
+            var attachedNames = attached
+                .Where(a => !string.IsNullOrWhiteSpace(a))
+                .Distinct()
+                .ToList();
+            if (attachedNames.Count > 0)
+            {
+                var ownedNames = await db.Documents
+                    .Where(d => d.OwnerUserId == userId && !d.IsDeleted && attachedNames.Contains(d.FileName))
+                    .Select(d => d.FileName)
+                    .Distinct()
+                    .ToListAsync(ct);
+
+                var unbacked = attachedNames.Where(n => !ownedNames.Contains(n)).ToList();
+                if (unbacked.Count > 0)
+                    throw new ConflictException(
+                        $"These attached documents weren't found in your uploaded files: {string.Join(", ", unbacked)}. Upload them through the application form.");
             }
         }
 

--- a/server/src/ScholarPath.Application/Applications/Commands/UpdateExternalStatus/UpdateExternalStatusCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Applications/Commands/UpdateExternalStatus/UpdateExternalStatusCommandHandler.cs
@@ -27,6 +27,17 @@ public sealed class UpdateExternalStatusCommandHandler(
             throw new ConflictException("Only external applications can be manually updated by the student.");
         }
 
+        // FR-APP-33/34: external self-tracking only supports Intending / Applied /
+        // WaitingResult. Reject anything else so a student can't push an external
+        // tracker into an in-app review state (Accepted/UnderReview/Rejected/…).
+        if (request.Status is not (ApplicationStatus.Intending
+            or ApplicationStatus.Applied
+            or ApplicationStatus.WaitingResult))
+        {
+            throw new ConflictException(
+                "External applications can only be set to Intending, Applied, or WaitingResult.");
+        }
+
         application.Status = request.Status;
         application.UpdatedAt = DateTimeOffset.UtcNow;
 

--- a/server/src/ScholarPath.Application/Documents/Commands/UploadDocument/UploadDocumentCommand.cs
+++ b/server/src/ScholarPath.Application/Documents/Commands/UploadDocument/UploadDocumentCommand.cs
@@ -78,6 +78,25 @@ public sealed class UploadDocumentCommandHandler(
             [".odt"]  = ["application/vnd.oasis.opendocument.text"],
         };
 
+    // Magic-byte signatures per extension — the file's actual leading bytes must
+    // match, so a disguised file (e.g. an .exe renamed .pdf with a faked
+    // Content-Type) is rejected even when the antivirus provider is a no-op.
+    // Text (.txt) has no signature, so it's accepted on the extension+MIME check
+    // alone. .webp additionally requires "WEBP" at offset 8 (handled below).
+    private static readonly IReadOnlyDictionary<string, byte[][]> Signatures =
+        new Dictionary<string, byte[][]>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".pdf"]  = [[0x25, 0x50, 0x44, 0x46]],                          // %PDF
+            [".png"]  = [[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]],  // PNG
+            [".jpg"]  = [[0xFF, 0xD8, 0xFF]],
+            [".jpeg"] = [[0xFF, 0xD8, 0xFF]],
+            [".webp"] = [[0x52, 0x49, 0x46, 0x46]],                          // RIFF (+ WEBP@8)
+            [".docx"] = [[0x50, 0x4B, 0x03, 0x04]],                          // ZIP (OOXML)
+            [".odt"]  = [[0x50, 0x4B, 0x03, 0x04]],                          // ZIP (ODF)
+            [".doc"]  = [[0xD0, 0xCF, 0x11, 0xE0]],                          // OLE2
+            [".rtf"]  = [[0x7B, 0x5C, 0x72, 0x74, 0x66]],                    // {\rtf
+        };
+
     public async Task<DocumentDto> Handle(UploadDocumentCommand request, CancellationToken ct)
     {
         var userId = currentUser.UserId
@@ -95,6 +114,30 @@ public sealed class UploadDocumentCommandHandler(
         if (!allowedContentTypes.Contains(contentType, StringComparer.OrdinalIgnoreCase))
             throw new ConflictException(
                 "The file's declared content type does not match its extension.");
+
+        // Magic-byte verification: the file's actual leading bytes must match the
+        // declared extension, so a disguised binary (renamed executable, etc.) is
+        // rejected regardless of the client-declared type — and independently of
+        // whether the antivirus provider is active. Only runs on a seekable
+        // stream (buffered upload); the position is restored for the scan/upload.
+        if (request.Content.CanSeek && Signatures.TryGetValue(extension, out var signatures))
+        {
+            var header = new byte[12];
+            request.Content.Position = 0;
+            var read = await request.Content.ReadAsync(header.AsMemory(0, header.Length), ct).ConfigureAwait(false);
+            request.Content.Position = 0;
+
+            var matches = signatures.Any(sig =>
+                read >= sig.Length && header.Take(sig.Length).SequenceEqual(sig));
+
+            // WebP is "RIFF"....(4 bytes size)...."WEBP" — verify the WEBP tag too.
+            if (matches && extension.Equals(".webp", StringComparison.OrdinalIgnoreCase))
+                matches = read >= 12 && header.Skip(8).Take(4).SequenceEqual(new byte[] { 0x57, 0x45, 0x42, 0x50 });
+
+            if (!matches)
+                throw new ConflictException(
+                    "The file's contents don't match its type (possible disguised or corrupt file).");
+        }
 
         // A document may only be linked to one of the caller's own applications.
         if (request.ApplicationTrackerId is { } appId)

--- a/server/src/ScholarPath.Application/Notifications/NotificationCatalog.cs
+++ b/server/src/ScholarPath.Application/Notifications/NotificationCatalog.cs
@@ -15,8 +15,10 @@ public sealed class NotificationCatalog : INotificationCatalog
     {
         NotificationType.ApplicationStatusChanged => new(
             "Application updated", "تحديث على الطلب",
-            $"Your application status changed to {p.StatusText ?? "updated"}.",
-            $"تغيّرت حالة طلبك إلى {p.StatusText ?? "محدّثة"}."),
+            $"Your application status changed to {p.StatusText ?? "updated"}." +
+                (string.IsNullOrWhiteSpace(p.Reason) ? "" : $" Reason: {p.Reason}"),
+            $"تغيّرت حالة طلبك إلى {p.StatusText ?? "محدّثة"}." +
+                (string.IsNullOrWhiteSpace(p.Reason) ? "" : $" السبب: {p.Reason}")),
 
         // Sent to the scholarship's owning company when a student submits a new
         // in-app application (QA BUG-017 — the company was never told).
@@ -35,6 +37,17 @@ public sealed class NotificationCatalog : INotificationCatalog
             "Application submitted", "تم إرسال طلبك",
             $"Your application for \"{p.TitleEn ?? "the scholarship"}\" was submitted successfully.",
             $"تم إرسال طلبك للمنحة \"{p.TitleAr ?? "المنحة"}\" بنجاح."),
+
+        // Sent to the owning provider when an admin approves/rejects their listing.
+        NotificationType.ScholarshipApproved => new(
+            "Scholarship approved", "تمت الموافقة على المنحة",
+            $"Your scholarship \"{p.TitleEn ?? "listing"}\" was approved and is now live.",
+            $"تمت الموافقة على منحتك \"{p.TitleAr ?? "المنحة"}\" وأصبحت متاحة الآن."),
+
+        NotificationType.ScholarshipRejected => new(
+            "Scholarship needs changes", "المنحة تحتاج تعديلات",
+            $"Your scholarship \"{p.TitleEn ?? "listing"}\" was returned to draft: {p.Reason ?? "see the review notes"}.",
+            $"أُعيدت منحتك \"{p.TitleAr ?? "المنحة"}\" إلى المسودة: {p.Reason ?? "راجِع ملاحظات المراجعة"}."),
 
         NotificationType.ApplicationDeadlineApproaching => new(
             "Scholarship deadline approaching", "اقتراب موعد إغلاق المنحة",

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ApproveScholarship/ApproveScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ApproveScholarship/ApproveScholarshipCommand.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Auditing;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 
@@ -30,6 +31,7 @@ public sealed class ApproveScholarshipCommandValidator : AbstractValidator<Appro
 public sealed class ApproveScholarshipCommandHandler(
     IApplicationDbContext db,
     ICurrentUserService currentUser,
+    INotificationDispatcher notifications,
     ILogger<ApproveScholarshipCommandHandler> logger)
     : IRequestHandler<ApproveScholarshipCommand, bool>
 {
@@ -48,6 +50,14 @@ public sealed class ApproveScholarshipCommandHandler(
         if (scholarship.Status != ScholarshipStatus.UnderReview)
             throw new ConflictException("Only a scholarship under review can be approved.");
 
+        // FR-SCH-22: the 7-day deadline rule applies at PUBLISHING too, not just
+        // on create/update. A listing that sat in moderation until its deadline
+        // is within 7 days (or has passed) must not go Open — the provider has
+        // to extend the deadline (via edit) and resubmit first.
+        if (scholarship.Deadline <= DateTimeOffset.UtcNow.AddDays(7))
+            throw new ConflictException(
+                "Cannot approve: the application deadline must be at least 7 days away. Ask the provider to extend the deadline and resubmit.");
+
         scholarship.Status = ScholarshipStatus.Open;
         scholarship.OpenedAt ??= DateTimeOffset.UtcNow;
         // Clear any stale rejection feedback now that it's approved.
@@ -55,6 +65,19 @@ public sealed class ApproveScholarshipCommandHandler(
         scholarship.RejectedAt = null;
 
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // Notify the owning provider (US-SCH-13). Admin-created (ownerless)
+        // listings have no provider to tell.
+        if (scholarship.OwnerScholarshipProviderId is { } ownerId)
+        {
+            await notifications.DispatchAsync(
+                ownerId,
+                NotificationType.ScholarshipApproved,
+                new NotificationParams { TitleEn = scholarship.TitleEn, TitleAr = scholarship.TitleAr },
+                deepLink: "/company/scholarships",
+                idempotencyKey: $"scholarship-approved:{scholarship.Id}",
+                ct).ConfigureAwait(false);
+        }
 
         logger.LogInformation("Scholarship {ScholarshipId} approved by {AdminId}.", scholarship.Id, adminId);
         return true;

--- a/server/src/ScholarPath.Application/Scholarships/Commands/RejectScholarship/RejectScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/RejectScholarship/RejectScholarshipCommand.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Auditing;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 
@@ -39,6 +40,7 @@ public sealed class RejectScholarshipCommandValidator : AbstractValidator<Reject
 public sealed class RejectScholarshipCommandHandler(
     IApplicationDbContext db,
     ICurrentUserService currentUser,
+    INotificationDispatcher notifications,
     ILogger<RejectScholarshipCommandHandler> logger)
     : IRequestHandler<RejectScholarshipCommand, bool>
 {
@@ -62,6 +64,19 @@ public sealed class RejectScholarshipCommandHandler(
         scholarship.RejectedAt = DateTimeOffset.UtcNow;
 
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // Notify the owning provider with the reason (US-SCH-13). Ownerless
+        // (admin-created) listings have no provider to tell.
+        if (scholarship.OwnerScholarshipProviderId is { } ownerId)
+        {
+            await notifications.DispatchAsync(
+                ownerId,
+                NotificationType.ScholarshipRejected,
+                new NotificationParams { TitleEn = scholarship.TitleEn, TitleAr = scholarship.TitleAr, Reason = request.Reason },
+                deepLink: "/company/scholarships",
+                idempotencyKey: $"scholarship-rejected:{scholarship.Id}:{scholarship.RejectedAt:O}",
+                ct).ConfigureAwait(false);
+        }
 
         logger.LogInformation(
             "Scholarship {ScholarshipId} rejected by {AdminId}. Reason: {Reason}",

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ReopenScholarship/ReopenScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ReopenScholarship/ReopenScholarshipCommand.cs
@@ -55,6 +55,14 @@ public sealed class ReopenScholarshipCommandHandler(
         if (scholarship.Status != ScholarshipStatus.Closed)
             throw new ConflictException("Only a closed scholarship can be reopened.");
 
+        // FR-SCH-22: reopening is the most common past-deadline path (listings
+        // usually auto-close because the deadline passed). Require a valid
+        // ≥7-day deadline before it can re-enter moderation, so it can't be
+        // reopened straight into another immediate auto-close.
+        if (scholarship.Deadline <= DateTimeOffset.UtcNow.AddDays(7))
+            throw new ConflictException(
+                "Cannot reopen: update the application deadline to at least 7 days away first.");
+
         scholarship.Status = ScholarshipStatus.UnderReview;
         scholarship.RejectionReason = null;
         scholarship.RejectedAt = null;

--- a/server/src/ScholarPath.Application/Scholarships/Commands/UpdateScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/UpdateScholarshipCommand.cs
@@ -48,9 +48,16 @@ public class UpdateScholarshipCommandHandler(IApplicationDbContext db, ICurrentU
     {
         var entity = await db.Scholarships
             .Include(x => x.Applications)
-            .FirstOrDefaultAsync(x => x.Id == request.Id, ct);
+            .FirstOrDefaultAsync(x => x.Id == request.Id && !x.IsDeleted, ct);
 
         if (entity == null) throw new NotFoundException(nameof(Scholarship), request.Id);
+
+        // FR-SCH-35: a Closed or Archived listing is terminal — it can't be
+        // edited in place (a Closed one must be reopened first; an Archived one
+        // is soft-deleted). Only Draft / UnderReview / Open are editable.
+        if (entity.Status is ScholarshipStatus.Closed or ScholarshipStatus.Archived)
+            throw new ConflictException(
+                "This scholarship can no longer be edited. Reopen a closed listing before editing it.");
 
         // FR-SCH-18/19: a provider may edit only their OWN listing. An
         // admin-created (ownerless) listing — e.g. an External scholarship — is

--- a/server/src/ScholarPath.Domain/Enums/Enums.cs
+++ b/server/src/ScholarPath.Domain/Enums/Enums.cs
@@ -191,6 +191,10 @@ public enum NotificationType
     // Student-facing "your application was submitted" confirmation (FR-APP-17).
     ApplicationSubmittedConfirmation = 105,
 
+    // Scholarship moderation outcome → owning provider (US-SCH-13).
+    ScholarshipApproved = 106,
+    ScholarshipRejected = 107,
+
     // ScholarshipProvider review + payment (PB-005)
     ScholarshipProviderRatingReceived = 110,
     ScholarshipProviderReviewPaymentSuccess = 111,

--- a/server/tests/ScholarPath.UnitTests/Documents/DocumentVaultTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Documents/DocumentVaultTests.cs
@@ -60,7 +60,10 @@ public sealed class DocumentVaultTests
         return s;
     }
 
-    private static MemoryStream Bytes(string content = "file-content") =>
+    // Default content carries a valid %PDF magic header so the upload handler's
+    // magic-byte check (files are uploaded as .pdf here) passes; the specific
+    // bytes are otherwise irrelevant to these tests.
+    private static MemoryStream Bytes(string content = "%PDF-1.4\nfile-content") =>
         new(Encoding.UTF8.GetBytes(content));
 
     private static UploadDocumentCommand UploadCmd(
@@ -109,6 +112,30 @@ public sealed class DocumentVaultTests
             default);
 
         await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Upload_rejects_disguised_file_with_wrong_magic_bytes()
+    {
+        using var db = CreateDb();
+        var storage = Storage();
+        var sut = new UploadDocumentCommandHandler(
+            db, User(Guid.NewGuid()), storage, Scanner(), Clock(),
+            NullLogger<UploadDocumentCommandHandler>.Instance);
+
+        // A .pdf whose actual bytes are not a PDF (e.g. a renamed binary) is
+        // rejected on the magic-byte check — before storage or the AV scan, and
+        // regardless of whether the AV provider is active.
+        using var content = new MemoryStream(Encoding.UTF8.GetBytes("MZ not-really-a-pdf"));
+        var act = () => sut.Handle(UploadCmd(content), default);
+
+        (await act.Should().ThrowAsync<ConflictException>())
+            .Which.Message.Should().Contain("don't match its type");
+
+        await storage.DidNotReceive().UploadAsync(
+            Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        (await db.Documents.AnyAsync()).Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
Triggered by a real production crash (`Cannot read properties of undefined (reading 'length')` on the application-detail page). Root cause + a full sweep.

### Client runtime-crash guards (12+ sites)
The crash class: unguarded `.map`/`.length`/spread on array fields TS types non-optional but the server can omit. Guarded across community feed + thread, resources (detail/list/bookmarks/author/admin), consultant detail, company dashboard + insights. Consultant array fields normalized once at the service layer.

### KanbanBoard
External trackers now map columns to valid external statuses (In-Review → **WaitingResult**, now reachable); drops into in-app-only columns are ignored instead of 409'ing.

### Server SRS gaps
- **FR-SCH-22** — 7-day deadline re-checked on **approve** + **reopen** (not just create/update).
- **US-SCH-13** — provider notified on scholarship **approve/reject** (new notification types; reject carries the reason).
- **FR-APP-33/34** — `UpdateExternalStatus` rejects any status outside {Intending, Applied, WaitingResult}.
- **FR-SCH-35** — Closed/Archived listings no longer editable (+ `!IsDeleted`).
- Status-change notification now includes the decision reason.

### Document-security hardening (the two deferred items)
- **FR-APP-13/14** — on submit, every attached document must reference a real file the student uploaded through the scanned vault (owned `Document` row) — closes the "inject arbitrary document references" hole; vault reuse still works.
- **Upload magic-byte verification** — the file's actual bytes must match its extension (rejects a disguised `.exe`-as-`.pdf` even with AV off). Real AV still needs clamd provisioned.

## Verification
- Server build + **851 unit tests** green (added magic-byte + field-filter cases). Client tsc + eslint + build clean.
- Three adversarial reviews (crash/SRS batch, then the two security fixes): all **PASS**, no blocking bugs.