### PR TITLE
feat(consultant): persisted rating snapshot + penalty factor (PB-006R B1)

### DIFF
--- a/server/src/ScholarPath.Application/Analytics/Queries/GetConsultantKpis/GetConsultantKpisQuery.cs
+++ b/server/src/ScholarPath.Application/Analytics/Queries/GetConsultantKpis/GetConsultantKpisQuery.cs
@@ -49,14 +49,15 @@ public sealed class GetConsultantKpisQueryHandler(
             })
             .FirstOrDefaultAsync(ct);
 
-        var reviews = await db.ConsultantReviews
+        // PB-006R: read the penalized rating snapshot off UserProfile rather than
+        // live-aggregating raw reviews, so the KPI card reflects reputation penalties.
+        var reviews = await db.UserProfiles
             .AsNoTracking()
-            .Where(r => r.ConsultantId == userId && !r.IsDeleted && !r.IsHiddenByAdmin)
-            .GroupBy(_ => 1)
-            .Select(g => new
+            .Where(p => p.UserId == userId)
+            .Select(p => new
             {
-                Count = g.Count(),
-                Avg = (decimal?)g.Average(r => (decimal)r.Rating),
+                Count = p.ConsultantReviewCount,
+                Avg = p.ConsultantAverageRating,
             })
             .FirstOrDefaultAsync(ct);
 

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/SubmitConsultantRating/SubmitConsultantRatingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/SubmitConsultantRating/SubmitConsultantRatingCommandHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ScholarPath.Application.Common;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.ConsultantBookings.Services;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Exceptions;
@@ -17,16 +18,19 @@ public sealed class SubmitConsultantRatingCommandHandler : IRequestHandler<Submi
     private readonly ICurrentUserService _currentUser;
     private readonly ILogger<SubmitConsultantRatingCommandHandler> _logger;
     private readonly BookingOptions _bookingOptions;
+    private readonly ConsultantRatingService _ratingService;
 
     public SubmitConsultantRatingCommandHandler(
         IApplicationDbContext context,
         ICurrentUserService currentUser,
         IOptions<BookingOptions> bookingOptions,
+        ConsultantRatingService ratingService,
         ILogger<SubmitConsultantRatingCommandHandler> logger)
     {
         _context = context;
         _currentUser = currentUser;
         _bookingOptions = bookingOptions.Value;
+        _ratingService = ratingService;
         _logger = logger;
     }
 
@@ -91,6 +95,12 @@ public sealed class SubmitConsultantRatingCommandHandler : IRequestHandler<Submi
 
         _context.ConsultantReviews.Add(review);
         await _context.SaveChangesAsync(cancellationToken);
+
+        // PB-006R: recompute the persisted rating snapshot (penalized average +
+        // review count) and evaluate the admin low-rating flag. Runs after the new
+        // review is saved so the aggregate sees it. The penalty factor is unchanged
+        // by a normal rating submit, so here penalized == raw average.
+        await _ratingService.RecalculateSnapshotAsync(booking.ConsultantId, cancellationToken);
 
         // FR-094: when the consultant's recent ratings fall below the configured
         // threshold, auto-suspend their *booking intake* (not the whole account)

--- a/server/src/ScholarPath.Application/ConsultantBookings/ConsultantRatingThresholds.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/ConsultantRatingThresholds.cs
@@ -1,0 +1,38 @@
+namespace ScholarPath.Application.ConsultantBookings;
+
+/// <summary>
+/// Tunable thresholds + penalty factors for the Consultant rating/penalty policy
+/// (PB-006R, FR-CBR-15..39). Mirrors <c>ScholarshipProviderRatingThresholds</c> but
+/// adds the reputation-deduction multipliers.
+///
+/// <para>
+/// The consultant's <c>UserProfile.ConsultantAverageRating</c> is the DISPLAYED
+/// average, computed as <c>round(clamp(rawVisibleAvg * ConsultantRatingPenaltyFactor, 0, 5), 2)</c>.
+/// A penalty event multiplies the persisted factor by one of the constants below;
+/// the factor survives future review recomputes, so a deduction lingers
+/// proportionally rather than being erased by the next new review.
+/// </para>
+/// </summary>
+public static class ConsultantRatingThresholds
+{
+    /// <summary>Penalized average below which the consultant is flagged for Admin review.</summary>
+    public const decimal LowRatingThreshold = 2.5m;
+
+    /// <summary>
+    /// Minimum number of visible reviews required before the penalized-average
+    /// flag check fires. A penalized average needs at least one review to be
+    /// non-null, so 1 matches the literal spec.
+    /// </summary>
+    public const int MinimumReviewsForFlagging = 1;
+
+    // ── Penalty factors (compounding multipliers on the rating average) ──────────
+
+    /// <summary>Consultant cancels a confirmed booking &lt;24h before start: −20% (FR-CBR-16/20).</summary>
+    public const decimal CancelLessThan24HoursFactor = 0.80m;
+
+    /// <summary>Admin-validated consultant no-show: −40% (FR-CBR-29).</summary>
+    public const decimal ValidatedNoShowFactor = 0.60m;
+
+    /// <summary>Consultant who falsely reported a student no-show: −70% (FR-CBR-32).</summary>
+    public const decimal FalseReportFactor = 0.30m;
+}

--- a/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetMyReceivedReviews/GetMyReceivedConsultantReviewsQueryHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetMyReceivedReviews/GetMyReceivedConsultantReviewsQueryHandler.cs
@@ -29,13 +29,17 @@ public sealed class GetMyReceivedConsultantReviewsQueryHandler(
 
         var total = await baseQuery.CountAsync(ct).ConfigureAwait(false);
 
-        double averageRating = 0;
-        if (total > 0)
-        {
-            averageRating = await baseQuery
-                .AverageAsync(r => (double)r.Rating, ct)
-                .ConfigureAwait(false);
-        }
+        // PB-006R: the summary average is the PENALIZED snapshot the consultant's
+        // students also see (ConsultantAverageRating), not a live raw mean — so a
+        // reputation deduction is reflected in the consultant's own dashboard. The
+        // individual review rows below stay raw (each shows its own submitted stars).
+        var snapshotAverage = await db.UserProfiles
+            .AsNoTracking()
+            .Where(p => p.UserId == consultantId)
+            .Select(p => p.ConsultantAverageRating)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+        double averageRating = (double)(snapshotAverage ?? 0m);
 
         var rows = await baseQuery
             .OrderByDescending(r => r.CreatedAt)

--- a/server/src/ScholarPath.Application/ConsultantBookings/Services/ConsultantRatingService.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Services/ConsultantRatingService.cs
@@ -1,0 +1,176 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.Notifications;
+using ScholarPath.Domain.Enums;
+
+namespace ScholarPath.Application.ConsultantBookings.Services;
+
+/// <summary>
+/// Single source of truth for the consultant rating snapshot + penalty ledger
+/// (PB-006R, FR-CBR-33..39). Every handler that changes a consultant's standing —
+/// rating submit, validated no-show, false-report, late cancellation — funnels
+/// through here so the penalized-average formula and the admin low-rating flag
+/// never drift between call sites.
+/// </summary>
+public sealed class ConsultantRatingService(
+    IApplicationDbContext db,
+    INotificationDispatcher notifications,
+    ILogger<ConsultantRatingService> logger)
+{
+    /// <summary>
+    /// Multiplies the consultant's persisted penalty factor (compounding) and then
+    /// recomputes the snapshot. The factor lingers across future review recomputes,
+    /// so the deduction persists proportionally. Multiplier examples:
+    /// 0.80 (cancel &lt;24h), 0.60 (validated no-show), 0.30 (false report).
+    /// </summary>
+    public async Task ApplyPenaltyFactorAsync(Guid consultantId, decimal multiplier, CancellationToken ct)
+    {
+        var profile = await db.UserProfiles
+            .FirstOrDefaultAsync(p => p.UserId == consultantId, ct)
+            .ConfigureAwait(false);
+
+        if (profile is null)
+        {
+            logger.LogWarning(
+                "UserProfile not found for consultant {ConsultantId} — penalty factor not applied.",
+                consultantId);
+            return;
+        }
+
+        // Guard against a corrupted zero/negative factor collapsing all future
+        // ratings; treat anything non-positive as a fresh 1.0 baseline.
+        var baseFactor = profile.ConsultantRatingPenaltyFactor <= 0m
+            ? 1.0m
+            : profile.ConsultantRatingPenaltyFactor;
+
+        profile.ConsultantRatingPenaltyFactor = decimal.Round(baseFactor * multiplier, 4, MidpointRounding.AwayFromZero);
+
+        logger.LogInformation(
+            "Applied penalty factor {Multiplier} to consultant {ConsultantId} (new factor {Factor}).",
+            multiplier, consultantId, profile.ConsultantRatingPenaltyFactor);
+
+        await RecalculateSnapshotAsync(consultantId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Recomputes <c>ConsultantAverageRating</c>/<c>ConsultantReviewCount</c> from the
+    /// consultant's visible reviews and the persisted penalty factor, evaluates the
+    /// sticky low-rating flag on the PENALIZED average, persists, and notifies admins
+    /// on the first flag. Callers should apply any factor/status changes to the tracked
+    /// context first, then call this last — it commits the whole unit of work.
+    /// </summary>
+    public async Task RecalculateSnapshotAsync(Guid consultantId, CancellationToken ct)
+    {
+        var visibleReviews = db.ConsultantReviews
+            .AsNoTracking()
+            .Where(r => r.ConsultantId == consultantId && !r.IsHiddenByAdmin && !r.IsDeleted);
+
+        var reviewCount = await visibleReviews.CountAsync(ct).ConfigureAwait(false);
+        decimal? rawAverage = reviewCount == 0
+            ? null
+            : await visibleReviews.AverageAsync(r => (decimal)r.Rating, ct).ConfigureAwait(false);
+
+        var profile = await db.UserProfiles
+            .FirstOrDefaultAsync(p => p.UserId == consultantId, ct)
+            .ConfigureAwait(false);
+
+        if (profile is null)
+        {
+            logger.LogWarning(
+                "UserProfile not found for consultant {ConsultantId} — rating snapshot not updated.",
+                consultantId);
+            return;
+        }
+
+        var factor = profile.ConsultantRatingPenaltyFactor <= 0m ? 1.0m : profile.ConsultantRatingPenaltyFactor;
+
+        // Penalized, displayed average. Null when there are no visible reviews —
+        // the factor is still persisted so it applies the moment the first review lands.
+        decimal? penalized = rawAverage is null
+            ? null
+            : decimal.Round(Math.Clamp(rawAverage.Value * factor, 0m, 5m), 2, MidpointRounding.AwayFromZero);
+
+        profile.ConsultantAverageRating = penalized;
+        profile.ConsultantReviewCount = reviewCount;
+
+        var shouldFlag = penalized is { } avg
+            && reviewCount >= ConsultantRatingThresholds.MinimumReviewsForFlagging
+            && avg < ConsultantRatingThresholds.LowRatingThreshold;
+
+        // Sticky flag: the original flag time is what the admin queue surfaces; a
+        // later sub-threshold recompute must not overwrite it — only an admin clears it.
+        var firstFlagging = shouldFlag && profile.ConsultantLowRatingFlaggedAt is null;
+        if (firstFlagging)
+        {
+            profile.ConsultantLowRatingFlaggedAt = DateTimeOffset.UtcNow;
+        }
+
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        if (firstFlagging)
+        {
+            await NotifyAdminsAsync(consultantId, penalized!.Value, reviewCount, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task NotifyAdminsAsync(Guid consultantId, decimal average, int reviewCount, CancellationToken ct)
+    {
+        try
+        {
+            var adminIds = await db.Users
+                .Where(u => (u.ActiveRole == "Admin" || u.ActiveRole == "SuperAdmin")
+                            && u.AccountStatus == AccountStatus.Active)
+                .Select(u => u.Id)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            if (adminIds.Count == 0) return;
+
+            var consultantName = await db.Users
+                .Where(u => u.Id == consultantId)
+                .Select(u => (u.FirstName + " " + u.LastName).Trim())
+                .FirstOrDefaultAsync(ct)
+                .ConfigureAwait(false);
+
+            var parameters = new NotificationParams
+            {
+                CounterpartyName = string.IsNullOrWhiteSpace(consultantName) ? "A consultant" : consultantName,
+                AmountText = average.ToString("0.00", CultureInfo.InvariantCulture),
+                Count = reviewCount,
+            };
+
+            foreach (var adminId in adminIds)
+            {
+                var idempotencyKey = $"cbr-low-rating:{consultantId:N}:{adminId:N}";
+                try
+                {
+                    await notifications.DispatchAsync(
+                        adminId,
+                        NotificationType.ConsultantLowRatingFlagged,
+                        parameters,
+                        deepLink: "/admin/consultants",
+                        idempotencyKey: idempotencyKey,
+                        ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to dispatch ConsultantLowRatingFlagged to admin {AdminId} for consultant {ConsultantId}.",
+                        adminId, consultantId);
+                }
+            }
+
+            logger.LogInformation(
+                "Flagged consultant {ConsultantId} for low (penalized) rating: avg={Avg} count={Count}, notified {AdminCount} admins.",
+                consultantId, average, reviewCount, adminIds.Count);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Could not resolve admin recipients for ConsultantLowRatingFlagged on consultant {ConsultantId}.",
+                consultantId);
+        }
+    }
+}

--- a/server/src/ScholarPath.Application/DependencyInjection.cs
+++ b/server/src/ScholarPath.Application/DependencyInjection.cs
@@ -31,6 +31,7 @@ public static class DependencyInjection
 
         // Consultant booking services
         services.AddScoped<RefundCalculatorService>();
+        services.AddScoped<ConsultantRatingService>();
 
         return services;
     }

--- a/server/src/ScholarPath.Application/Notifications/NotificationCatalog.cs
+++ b/server/src/ScholarPath.Application/Notifications/NotificationCatalog.cs
@@ -234,6 +234,12 @@ public sealed class NotificationCatalog : INotificationCatalog
             $"{p.CounterpartyName ?? "A company"} dropped to an average rating of {p.AmountText ?? "below threshold"} over {p.Count ?? 0} review(s). Review and decide whether to suspend the account.",
             $"انخفض متوسط تقييم {p.CounterpartyName ?? "إحدى الشركات"} إلى {p.AmountText ?? "أقل من الحد"} عبر {p.Count ?? 0} تقييم. راجِع الحساب وقرّر ما إذا كان يجب إيقافه."),
 
+        // Admin-inbound: a consultant's penalized average dropped below threshold (PB-006R).
+        NotificationType.ConsultantLowRatingFlagged => new(
+            "Consultant flagged for low rating", "تم تنبيه على مستشار بسبب تقييم منخفض",
+            $"{p.CounterpartyName ?? "A consultant"} dropped to an average rating of {p.AmountText ?? "below threshold"} over {p.Count ?? 0} review(s). Review the consultant and decide on any action.",
+            $"انخفض متوسط تقييم {p.CounterpartyName ?? "أحد المستشارين"} إلى {p.AmountText ?? "أقل من الحد"} عبر {p.Count ?? 0} تقييم. راجِع المستشار وقرّر الإجراء المناسب."),
+
         // Admin-inbound: a community post was reported and needs a moderation decision.
         NotificationType.ContentReported => new(
             "Post reported", "تم الإبلاغ عن منشور",

--- a/server/src/ScholarPath.Domain/Entities/Identity.cs
+++ b/server/src/ScholarPath.Domain/Entities/Identity.cs
@@ -172,6 +172,24 @@ public class UserProfile : AuditableEntity
     /// </summary>
     public DateTimeOffset? BookingIntakeSuspendedAt { get; set; }
 
+    // Consultant rating snapshot + penalty ledger (PB-006R, FR-CBR-33..39).
+    // Mirrors the ScholarshipProvider snapshot triplet above, but adds a
+    // persisted penalty FACTOR so reputation deductions (cancel −20% / validated
+    // no-show −40% / false report −70%) survive future review recomputes:
+    //
+    //   ConsultantAverageRating   the DISPLAYED average = round(clamp(rawAvg * factor, 0, 5), 2);
+    //                             null when the consultant has no visible reviews.
+    //   ConsultantReviewCount     count of visible (not soft-deleted / admin-hidden) reviews.
+    //   ConsultantLowRatingFlaggedAt sticky admin-queue flag when the *penalized* average
+    //                             dips below threshold. Distinct from BookingIntakeSuspendedAt
+    //                             (which the *raw* trailing-window average drives).
+    //   ConsultantRatingPenaltyFactor compounding multiplier, default 1.0; only a penalty
+    //                             event mutates it (*= 0.80/0.60/0.30). A recompute never resets it.
+    public decimal? ConsultantAverageRating { get; set; }
+    public int ConsultantReviewCount { get; set; }
+    public DateTimeOffset? ConsultantLowRatingFlaggedAt { get; set; }
+    public decimal ConsultantRatingPenaltyFactor { get; set; } = 1.0m;
+
     // Stripe Connect — payee payout onboarding
     public string? StripeConnectAccountId { get; set; }
     public StripeConnectStatus StripeConnectStatus { get; set; } = StripeConnectStatus.None;

--- a/server/src/ScholarPath.Domain/Enums/Enums.cs
+++ b/server/src/ScholarPath.Domain/Enums/Enums.cs
@@ -220,6 +220,9 @@ public enum NotificationType
     BookingReminder = 205,
     BookingCompleted = 206,
     ConsultantRatingReceived = 207,
+    // Admin-inbound: a consultant's penalized average rating dropped below the
+    // low-rating threshold and needs admin review (PB-006R).
+    ConsultantLowRatingFlagged = 208,
 
     // Payments (PB-013)
     PaymentSuccess = 300,

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704122817_AddConsultantRatingSnapshotAndPenalty_PB006R.Designer.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704122817_AddConsultantRatingSnapshotAndPenalty_PB006R.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScholarPath.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using ScholarPath.Infrastructure.Persistence;
 namespace ScholarPath.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704122817_AddConsultantRatingSnapshotAndPenalty_PB006R")]
+    partial class AddConsultantRatingSnapshotAndPenalty_PB006R
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704122817_AddConsultantRatingSnapshotAndPenalty_PB006R.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704122817_AddConsultantRatingSnapshotAndPenalty_PB006R.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScholarPath.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConsultantRatingSnapshotAndPenalty_PB006R : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "ConsultantAverageRating",
+                table: "UserProfiles",
+                type: "decimal(3,2)",
+                precision: 3,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ConsultantLowRatingFlaggedAt",
+                table: "UserProfiles",
+                type: "datetimeoffset",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "ConsultantRatingPenaltyFactor",
+                table: "UserProfiles",
+                type: "decimal(5,4)",
+                precision: 5,
+                scale: 4,
+                nullable: false,
+                defaultValue: 1.0m);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ConsultantReviewCount",
+                table: "UserProfiles",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_ConsultantLowRatingFlagged",
+                table: "UserProfiles",
+                column: "ConsultantLowRatingFlaggedAt",
+                filter: "[ConsultantLowRatingFlaggedAt] IS NOT NULL");
+
+            // Backfill the snapshot from existing visible reviews so already-rated
+            // consultants show their average immediately (factor defaults to 1.0, so
+            // penalized == raw for pre-existing rows). New rows are kept current by
+            // ConsultantRatingService on every rating submit / penalty event.
+            migrationBuilder.Sql(@"
+                UPDATE p
+                SET p.ConsultantAverageRating =
+                        ROUND(CAST(agg.AvgRating AS decimal(3,2)), 2),
+                    p.ConsultantReviewCount = agg.Cnt
+                FROM UserProfiles p
+                INNER JOIN (
+                    SELECT ConsultantId,
+                           AVG(CAST(Rating AS decimal(3,2))) AS AvgRating,
+                           COUNT(*) AS Cnt
+                    FROM ConsultantReviews
+                    WHERE IsHiddenByAdmin = 0 AND IsDeleted = 0
+                    GROUP BY ConsultantId
+                ) agg ON agg.ConsultantId = p.UserId;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserProfiles_ConsultantLowRatingFlagged",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ConsultantAverageRating",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ConsultantLowRatingFlaggedAt",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ConsultantRatingPenaltyFactor",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ConsultantReviewCount",
+                table: "UserProfiles");
+        }
+    }
+}

--- a/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
+++ b/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
@@ -130,6 +130,16 @@ public sealed class UserProfileConfiguration : IEntityTypeConfiguration<UserProf
         b.HasIndex(p => p.ScholarshipProviderLowRatingFlaggedAt)
             .HasFilter("[ScholarshipProviderLowRatingFlaggedAt] IS NOT NULL")
             .HasDatabaseName("IX_UserProfiles_ScholarshipProviderLowRatingFlagged");
+        // PB-006R: consultant rating snapshot + penalty factor. Average precision
+        // 3,2 fits 0.00..5.00; the factor needs 5,4 to hold compounded multipliers
+        // (e.g. 0.80*0.60 = 0.4800) without drift.
+        b.Property(p => p.ConsultantAverageRating).HasPrecision(3, 2);
+        // Default 1.0 (no penalty) so existing rows and any non-EF insert start
+        // un-penalized — a SQL default of 0 would zero out every rating.
+        b.Property(p => p.ConsultantRatingPenaltyFactor).HasPrecision(5, 4).HasDefaultValue(1.0m);
+        b.HasIndex(p => p.ConsultantLowRatingFlaggedAt)
+            .HasFilter("[ConsultantLowRatingFlaggedAt] IS NOT NULL")
+            .HasDatabaseName("IX_UserProfiles_ConsultantLowRatingFlagged");
         b.Property(p => p.AcademicLevel).HasConversion<string>().HasMaxLength(32);
         b.Property(p => p.StripeConnectAccountId).HasMaxLength(256);
         b.Property(p => p.StripeConnectStatus).HasConversion<string>().HasMaxLength(24);

--- a/server/src/ScholarPath.Infrastructure/Services/ConsultantReadService.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/ConsultantReadService.cs
@@ -407,24 +407,27 @@ public sealed class ConsultantReadService(
     private async Task<Dictionary<Guid, (int Count, double Average)>> LoadRatingAggregatesAsync(
         IReadOnlyCollection<Guid> consultantIds, CancellationToken ct)
     {
-        var rows = await db.ConsultantReviews
+        // PB-006R: read the persisted rating SNAPSHOT (penalized average + count)
+        // off UserProfile rather than live-aggregating the reviews. This is what
+        // makes reputation penalties (cancel −20% / no-show −40% / false report −70%)
+        // actually show — the deduction lives in ConsultantAverageRating, which a
+        // live AVG(Rating) would ignore. The snapshot is kept current by
+        // ConsultantRatingService on every rating submit and penalty event.
+        var rows = await db.UserProfiles
             .AsNoTracking()
-            .Where(rev => consultantIds.Contains(rev.ConsultantId)
-                          && !rev.IsHiddenByAdmin
-                          && !rev.IsDeleted)
-            .GroupBy(rev => rev.ConsultantId)
-            .Select(g => new
+            .Where(p => consultantIds.Contains(p.UserId) && p.ConsultantReviewCount > 0)
+            .Select(p => new
             {
-                ConsultantId = g.Key,
-                Count = g.Count(),
-                Average = g.Average(rev => (double)rev.Rating),
+                ConsultantId = p.UserId,
+                Count = p.ConsultantReviewCount,
+                Average = (double)(p.ConsultantAverageRating ?? 0m),
             })
             .ToListAsync(ct)
             .ConfigureAwait(false);
 
         return rows.ToDictionary(
             x => x.ConsultantId,
-            x => (x.Count, Math.Round(x.Average, 2)));
+            x => (x.Count, x.Average));
     }
 
     private async Task<Dictionary<Guid, int>> LoadCompletedCountsAsync(

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantRatingServiceTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantRatingServiceTests.cs
@@ -1,0 +1,155 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.ConsultantBookings.Services;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.ConsultantBookings;
+
+/// <summary>
+/// Unit-tests the PB-006R consultant rating snapshot + penalty-factor formula:
+/// penalized average = round(clamp(rawAvg * factor, 0, 5), 2), factor persists
+/// across recomputes, sticky low-rating flag on the penalized average.
+/// </summary>
+public sealed class ConsultantRatingServiceTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly INotificationDispatcher _notifications = Substitute.For<INotificationDispatcher>();
+    private readonly ConsultantRatingService _sut;
+    private readonly Guid _consultantId = Guid.NewGuid();
+
+    public ConsultantRatingServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new ApplicationDbContext(options);
+        _sut = new ConsultantRatingService(_db, _notifications, NullLogger<ConsultantRatingService>.Instance);
+    }
+
+    private async Task SeedProfileAsync(decimal factor = 1.0m)
+    {
+        _db.UserProfiles.Add(new UserProfile
+        {
+            UserId = _consultantId,
+            ConsultantRatingPenaltyFactor = factor,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private async Task AddReviewsAsync(params int[] ratings)
+    {
+        foreach (var r in ratings)
+        {
+            _db.ConsultantReviews.Add(new ConsultantReview
+            {
+                BookingId = Guid.NewGuid(),
+                StudentId = Guid.NewGuid(),
+                ConsultantId = _consultantId,
+                Rating = r,
+            });
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    private async Task<UserProfile> ReloadProfileAsync() =>
+        await _db.UserProfiles.AsNoTracking().FirstAsync(p => p.UserId == _consultantId);
+
+    [Fact]
+    public async Task Factor_one_gives_the_raw_average()
+    {
+        await SeedProfileAsync(factor: 1.0m);
+        await AddReviewsAsync(4, 5, 3); // avg 4.00
+
+        await _sut.RecalculateSnapshotAsync(_consultantId, default);
+
+        var profile = await ReloadProfileAsync();
+        profile.ConsultantAverageRating.Should().Be(4.00m);
+        profile.ConsultantReviewCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Penalty_factor_reduces_the_displayed_average()
+    {
+        await SeedProfileAsync(factor: 0.60m); // a validated no-show already applied −40%
+        await AddReviewsAsync(4, 5, 3); // raw avg 4.00 → 4.00 * 0.60 = 2.40
+
+        await _sut.RecalculateSnapshotAsync(_consultantId, default);
+
+        var profile = await ReloadProfileAsync();
+        profile.ConsultantAverageRating.Should().Be(2.40m);
+    }
+
+    [Fact]
+    public async Task Zero_reviews_yields_null_average_even_with_penalty()
+    {
+        await SeedProfileAsync(factor: 0.30m);
+
+        await _sut.RecalculateSnapshotAsync(_consultantId, default);
+
+        var profile = await ReloadProfileAsync();
+        profile.ConsultantAverageRating.Should().BeNull();
+        profile.ConsultantReviewCount.Should().Be(0);
+        // Factor is preserved so it applies once the first review lands.
+        profile.ConsultantRatingPenaltyFactor.Should().Be(0.30m);
+    }
+
+    [Fact]
+    public async Task Hidden_and_deleted_reviews_are_excluded()
+    {
+        await SeedProfileAsync();
+        await AddReviewsAsync(5, 5); // visible
+        _db.ConsultantReviews.Add(new ConsultantReview
+        {
+            BookingId = Guid.NewGuid(), StudentId = Guid.NewGuid(), ConsultantId = _consultantId,
+            Rating = 1, IsHiddenByAdmin = true,
+        });
+        _db.ConsultantReviews.Add(new ConsultantReview
+        {
+            BookingId = Guid.NewGuid(), StudentId = Guid.NewGuid(), ConsultantId = _consultantId,
+            Rating = 1, IsDeleted = true,
+        });
+        await _db.SaveChangesAsync();
+
+        await _sut.RecalculateSnapshotAsync(_consultantId, default);
+
+        var profile = await ReloadProfileAsync();
+        profile.ConsultantAverageRating.Should().Be(5.00m);
+        profile.ConsultantReviewCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Penalized_average_below_threshold_sets_sticky_flag()
+    {
+        await SeedProfileAsync(factor: 0.60m);
+        await AddReviewsAsync(4, 4, 4); // raw 4.00 → 2.40 penalized, < 2.5
+
+        await _sut.RecalculateSnapshotAsync(_consultantId, default);
+        var firstFlag = (await ReloadProfileAsync()).ConsultantLowRatingFlaggedAt;
+        firstFlag.Should().NotBeNull();
+
+        // A later recompute must NOT overwrite the original flag timestamp.
+        await AddReviewsAsync(1);
+        await _sut.RecalculateSnapshotAsync(_consultantId, default);
+        (await ReloadProfileAsync()).ConsultantLowRatingFlaggedAt.Should().Be(firstFlag);
+    }
+
+    [Fact]
+    public async Task ApplyPenaltyFactor_compounds_and_recomputes()
+    {
+        await SeedProfileAsync(factor: 1.0m);
+        await AddReviewsAsync(5, 5); // raw 5.00
+
+        await _sut.ApplyPenaltyFactorAsync(_consultantId, 0.80m, default); // consultant cancel <24h
+
+        var profile = await ReloadProfileAsync();
+        profile.ConsultantRatingPenaltyFactor.Should().Be(0.80m);
+        profile.ConsultantAverageRating.Should().Be(4.00m); // 5.00 * 0.80
+    }
+
+    public void Dispose() => _db.Dispose();
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantReadServiceTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantReadServiceTests.cs
@@ -128,6 +128,25 @@ public sealed class ConsultantReadServiceTests : IDisposable
             CreatedAt = Now.AddDays(-1),
         });
         _db.SaveChanges();
+        SyncRatingSnapshot(consultantId);
+    }
+
+    /// <summary>
+    /// PB-006R: the read service now reads the persisted rating snapshot, which
+    /// ConsultantRatingService keeps current in production. Mirror that invariant in
+    /// tests (penalty factor stays 1.0, so penalized average == raw average).
+    /// </summary>
+    private void SyncRatingSnapshot(Guid consultantId)
+    {
+        var visible = _db.ConsultantReviews
+            .Where(r => r.ConsultantId == consultantId && !r.IsHiddenByAdmin && !r.IsDeleted)
+            .ToList();
+        var profile = _db.UserProfiles.First(p => p.UserId == consultantId);
+        profile.ConsultantReviewCount = visible.Count;
+        profile.ConsultantAverageRating = visible.Count == 0
+            ? null
+            : Math.Round((decimal)visible.Average(r => r.Rating), 2, MidpointRounding.AwayFromZero);
+        _db.SaveChanges();
     }
 
     private void SeedBooking(
@@ -330,6 +349,7 @@ public sealed class ConsultantReadServiceTests : IDisposable
             CreatedAt = Now,
         });
         await _db.SaveChangesAsync();
+        SyncRatingSnapshot(consultant);
 
         var result = await _service.GetConsultantDetailAsync(consultant, CancellationToken.None);
 

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/GetMyReceivedConsultantReviewsQueryHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/GetMyReceivedConsultantReviewsQueryHandlerTests.cs
@@ -72,6 +72,30 @@ public sealed class GetMyReceivedConsultantReviewsQueryHandlerTests : IDisposabl
         await _db.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// PB-006R: the summary average now comes from the persisted rating snapshot
+    /// (ConsultantAverageRating), which ConsultantRatingService keeps current in
+    /// production. Mirror that invariant here (factor 1.0, penalized == raw).
+    /// </summary>
+    private async Task SyncSnapshotAsync(Guid? consultantId = null)
+    {
+        var cid = consultantId ?? _consultantId;
+        var visible = await _db.ConsultantReviews
+            .Where(r => r.ConsultantId == cid && !r.IsHiddenByAdmin && !r.IsDeleted)
+            .ToListAsync();
+        var profile = await _db.UserProfiles.FirstOrDefaultAsync(p => p.UserId == cid);
+        if (profile is null)
+        {
+            profile = new UserProfile { UserId = cid };
+            _db.UserProfiles.Add(profile);
+        }
+        profile.ConsultantReviewCount = visible.Count;
+        profile.ConsultantAverageRating = visible.Count == 0
+            ? null
+            : Math.Round((decimal)visible.Average(r => r.Rating), 2, MidpointRounding.AwayFromZero);
+        await _db.SaveChangesAsync();
+    }
+
     [Fact]
     public async Task Handle_NotAuthenticated_ThrowsForbidden()
     {
@@ -103,6 +127,7 @@ public sealed class GetMyReceivedConsultantReviewsQueryHandlerTests : IDisposabl
         await SeedReviewAsync(s1, 1, hidden: true);
         await SeedReviewAsync(s2, 1, deleted: true);
         await SeedReviewAsync(s1, 1, consultantId: Guid.NewGuid());
+        await SyncSnapshotAsync();
 
         var result = await Sut(User()).Handle(new GetMyReceivedConsultantReviewsQuery(), default);
 


### PR DESCRIPTION
**Batch 1 of 4** — the foundation for the Consultant penalty/enforcement system (FR-CBR-15..39), the missing half of PB-006 surfaced by the 2026-07 conformance audit.

### Why
The consultant average rating was a *live aggregate* recomputed on every read, so a reputation deduction (cancel −20% / validated no-show −40% / false report −70%) had nowhere to persist — the next review would erase it. This batch adds a durable snapshot + a compounding penalty factor.

### What
`UserProfile` gains `ConsultantAverageRating`, `ConsultantReviewCount`, `ConsultantLowRatingFlaggedAt` (sticky), `ConsultantRatingPenaltyFactor` (default 1.0). Displayed average = `round(clamp(rawAvg * factor, 0, 5), 2)`; the factor is only mutated by a penalty event and survives recomputes, so a deduction lingers proportionally.

- New `ConsultantRatingService` (single source of truth) + `ConsultantRatingThresholds`.
- `ConsultantLowRatingFlagged=208` notification + EN/AR catalog entry.
- Read-sites switched to the snapshot (browse, detail, received-reviews summary, consultant KPIs) so penalties actually show.
- Additive migration with factor SQL-default 1.0 + backfill from existing reviews.

### Verification
- Server build clean (0 warnings). **857 unit tests green** (6 new for the penalty formula: factor 1.0 == raw, 0.60 penalizes, zero-reviews→null, hidden/deleted excluded, sticky flag, factor compounding).

### Deploy note
No user-visible behaviour change yet (factor is 1.0 until batches 3–4 apply penalties). To avoid downtime for invisible foundations, batches 1–2 merge but **deploy is deferred until the feature is assembled** — the additive migrations then apply together on the next startup.

Follow-ups: B2 student booking-block fields + guard · B3 admin no-show validation flow + deductions · B4 cancel<24h penalties.