### PR TITLE
feat(consultant): student booking-access block + request guard (PB-006R B2)

### DIFF
--- a/server/src/ScholarPath.Application/Common/BookingOptions.cs
+++ b/server/src/ScholarPath.Application/Common/BookingOptions.cs
@@ -28,4 +28,15 @@ public sealed class BookingOptions
     /// small sample (1-4 reviews) is too noisy to auto-suspend on.
     /// </summary>
     public int LowRatingMinimumSampleSize { get; set; } = 5;
+
+    // ── Student booking-block durations (PB-006R, FR-CBR-15..32) ─────────────────
+
+    /// <summary>Days a student is blocked after cancelling a confirmed booking &lt;24h before start (FR-CBR-18).</summary>
+    public int LateCancellationBlockDays { get; set; } = 3;
+
+    /// <summary>Days a student is blocked after an admin-validated no-show (FR-CBR-28).</summary>
+    public int ValidatedNoShowBlockDays { get; set; } = 7;
+
+    /// <summary>Days a student is blocked after being falsely reported as a no-show (FR-CBR-31).</summary>
+    public int FalseNoShowReportBlockDays { get; set; } = 14;
 }

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/RequestBooking/RequestBookingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/RequestBooking/RequestBookingCommandHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using ScholarPath.Application.Common;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.ConsultantBookings.Services;
 using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Events;
@@ -47,6 +48,18 @@ public sealed class RequestBookingCommandHandler : IRequestHandler<RequestBookin
         if (studentId == request.ConsultantId)
         {
             throw new BookingDomainException("Student cannot book a session with themselves.");
+        }
+
+        // FR-CBR-21..24: a student under an active booking block cannot create new
+        // bookings. Checked before any Stripe payment-intent is created so a blocked
+        // student never reaches checkout.
+        var studentProfile = await _context.UserProfiles
+            .FirstOrDefaultAsync(p => p.UserId == studentId, cancellationToken);
+        if (studentProfile is not null
+            && BookingBlockService.IsCurrentlyBlocked(studentProfile, DateTimeOffset.UtcNow))
+        {
+            throw new BookingDomainException(
+                $"Your booking access is blocked until {studentProfile.BookingBlockUntil:yyyy-MM-dd HH:mm} UTC.");
         }
 
         var scheduledStartAtUtc = request.ScheduledStartAt.ToUniversalTime();

--- a/server/src/ScholarPath.Application/ConsultantBookings/Services/BookingBlockService.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Services/BookingBlockService.cs
@@ -1,0 +1,46 @@
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+
+namespace ScholarPath.Application.ConsultantBookings.Services;
+
+/// <summary>
+/// Pure helpers for the student booking-access block (PB-006R, FR-CBR-21..24).
+/// Operates on the tracked <see cref="UserProfile"/> so the caller keeps a single
+/// unit of work — no DB access of its own.
+/// </summary>
+public static class BookingBlockService
+{
+    /// <summary>
+    /// True when the student is currently blocked from creating new bookings.
+    /// A stale <c>BookingBlocked</c> status whose <c>BookingBlockUntil</c> has passed
+    /// reads as NOT blocked (lazy expiry) — the student can book again without an
+    /// explicit unblock step.
+    /// </summary>
+    public static bool IsCurrentlyBlocked(UserProfile profile, DateTimeOffset nowUtc) =>
+        profile.BookingAccessStatus == BookingAccessStatus.BookingBlocked
+        && profile.BookingBlockUntil is { } until
+        && until > nowUtc;
+
+    /// <summary>
+    /// Applies a booking block for <paramref name="days"/> days. Extend-never-shorten:
+    /// if an existing active block already runs longer, it is left untouched so a
+    /// shorter later penalty can't reduce a student's outstanding block.
+    /// </summary>
+    public static void ApplyBlock(
+        UserProfile profile, BookingBlockReason reason, int days, DateTimeOffset nowUtc)
+    {
+        var candidateUntil = nowUtc.AddDays(days);
+
+        if (IsCurrentlyBlocked(profile, nowUtc)
+            && profile.BookingBlockUntil is { } existing
+            && existing >= candidateUntil)
+        {
+            // The outstanding block is already longer — don't shorten it.
+            return;
+        }
+
+        profile.BookingAccessStatus = BookingAccessStatus.BookingBlocked;
+        profile.BookingBlockReason = reason;
+        profile.BookingBlockUntil = candidateUntil;
+    }
+}

--- a/server/src/ScholarPath.Domain/Entities/Identity.cs
+++ b/server/src/ScholarPath.Domain/Entities/Identity.cs
@@ -99,6 +99,14 @@ public class UserProfile : AuditableEntity
     public string? PreferredCountriesJson { get; set; }
     public string? PreferredFieldsJson { get; set; }
 
+    // Student consultant-booking access (PB-006R, FR-CBR-21..24). A student who
+    // late-cancels, no-shows (admin-validated), or falsely reports a consultant
+    // no-show is temporarily blocked from creating NEW bookings. BookingBlockUntil
+    // is the expiry; a lazy check flips the status back to Active once it passes.
+    public BookingAccessStatus BookingAccessStatus { get; set; } = BookingAccessStatus.Active;
+    public BookingBlockReason? BookingBlockReason { get; set; }
+    public DateTimeOffset? BookingBlockUntil { get; set; }
+
     // ScholarshipProvider fields
     public string? OrganizationLegalName { get; set; }
     public string? OrganizationRegistrationNumber { get; set; }

--- a/server/src/ScholarPath.Domain/Enums/Enums.cs
+++ b/server/src/ScholarPath.Domain/Enums/Enums.cs
@@ -89,6 +89,33 @@ public enum BookingStatus
     Completed = 5,
     NoShowStudent = 6,
     NoShowConsultant = 7,
+    // PB-006R: a party reported a no-show; the booking is frozen pending admin
+    // validation (FR-CBR-25). Excluded from auto-completion until resolved.
+    NoShowReported = 8,
+}
+
+/// <summary>
+/// A student's access to CREATE consultant bookings (PB-006R, FR-CBR-21..24).
+/// Independent of the account status — a blocked student keeps full access to
+/// everything except starting a new booking, until <c>BookingBlockUntil</c> passes.
+/// </summary>
+public enum BookingAccessStatus
+{
+    Active = 0,
+    BookingBlocked = 1,
+}
+
+/// <summary>Why a student's booking access was blocked (PB-006R).</summary>
+public enum BookingBlockReason
+{
+    /// <summary>Student cancelled a confirmed booking &lt;24h before start — 3-day block (FR-CBR-18).</summary>
+    CancelledLessThan24Hours = 0,
+
+    /// <summary>Admin-validated student no-show — 7-day block (FR-CBR-28).</summary>
+    ValidatedNoShow = 1,
+
+    /// <summary>Student was falsely reported as a no-show by the consultant — 14-day block (FR-CBR-31).</summary>
+    FalseNoShowReport = 2,
 }
 
 public enum PaymentType

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704124122_AddStudentBookingAccessBlock_PB006R.Designer.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704124122_AddStudentBookingAccessBlock_PB006R.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScholarPath.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using ScholarPath.Infrastructure.Persistence;
 namespace ScholarPath.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704124122_AddStudentBookingAccessBlock_PB006R")]
+    partial class AddStudentBookingAccessBlock_PB006R
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704124122_AddStudentBookingAccessBlock_PB006R.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704124122_AddStudentBookingAccessBlock_PB006R.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScholarPath.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStudentBookingAccessBlock_PB006R : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BookingAccessStatus",
+                table: "UserProfiles",
+                type: "nvarchar(24)",
+                maxLength: 24,
+                nullable: false,
+                defaultValue: "Active");
+
+            migrationBuilder.AddColumn<string>(
+                name: "BookingBlockReason",
+                table: "UserProfiles",
+                type: "nvarchar(32)",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "BookingBlockUntil",
+                table: "UserProfiles",
+                type: "datetimeoffset",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_BookingBlockUntil",
+                table: "UserProfiles",
+                column: "BookingBlockUntil",
+                filter: "[BookingBlockUntil] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserProfiles_BookingBlockUntil",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "BookingAccessStatus",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "BookingBlockReason",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "BookingBlockUntil",
+                table: "UserProfiles");
+        }
+    }
+}

--- a/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
+++ b/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
@@ -140,6 +140,14 @@ public sealed class UserProfileConfiguration : IEntityTypeConfiguration<UserProf
         b.HasIndex(p => p.ConsultantLowRatingFlaggedAt)
             .HasFilter("[ConsultantLowRatingFlaggedAt] IS NOT NULL")
             .HasDatabaseName("IX_UserProfiles_ConsultantLowRatingFlagged");
+        // PB-006R: student booking-access block (FR-CBR-21..24). Enums stored as
+        // strings for readability; filtered index drives any "expire blocks" sweep.
+        b.Property(p => p.BookingAccessStatus).HasConversion<string>().HasMaxLength(24)
+            .HasDefaultValue(BookingAccessStatus.Active);
+        b.Property(p => p.BookingBlockReason).HasConversion<string>().HasMaxLength(32);
+        b.HasIndex(p => p.BookingBlockUntil)
+            .HasFilter("[BookingBlockUntil] IS NOT NULL")
+            .HasDatabaseName("IX_UserProfiles_BookingBlockUntil");
         b.Property(p => p.AcademicLevel).HasConversion<string>().HasMaxLength(32);
         b.Property(p => p.StripeConnectAccountId).HasMaxLength(256);
         b.Property(p => p.StripeConnectStatus).HasConversion<string>().HasMaxLength(24);

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingBlockServiceTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingBlockServiceTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.ConsultantBookings.Commands.RequestBooking;
+using ScholarPath.Application.ConsultantBookings.Services;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Exceptions;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.ConsultantBookings;
+
+/// <summary>
+/// PB-006R student booking-access block (FR-CBR-21..24): the pure
+/// <see cref="BookingBlockService"/> logic plus the RequestBooking guard.
+/// </summary>
+public sealed class BookingBlockServiceTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 4, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Default_profile_is_not_blocked()
+    {
+        var p = new UserProfile { UserId = Guid.NewGuid() };
+        BookingBlockService.IsCurrentlyBlocked(p, Now).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyBlock_sets_status_reason_and_expiry()
+    {
+        var p = new UserProfile { UserId = Guid.NewGuid() };
+
+        BookingBlockService.ApplyBlock(p, BookingBlockReason.ValidatedNoShow, 7, Now);
+
+        p.BookingAccessStatus.Should().Be(BookingAccessStatus.BookingBlocked);
+        p.BookingBlockReason.Should().Be(BookingBlockReason.ValidatedNoShow);
+        p.BookingBlockUntil.Should().Be(Now.AddDays(7));
+        BookingBlockService.IsCurrentlyBlocked(p, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Block_reads_as_expired_once_BlockUntil_passes()
+    {
+        var p = new UserProfile { UserId = Guid.NewGuid() };
+        BookingBlockService.ApplyBlock(p, BookingBlockReason.CancelledLessThan24Hours, 3, Now);
+
+        BookingBlockService.IsCurrentlyBlocked(p, Now.AddDays(3).AddSeconds(1)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyBlock_extends_never_shortens()
+    {
+        var p = new UserProfile { UserId = Guid.NewGuid() };
+        BookingBlockService.ApplyBlock(p, BookingBlockReason.ValidatedNoShow, 7, Now); // until +7d
+
+        // A shorter later penalty must not reduce the outstanding block.
+        BookingBlockService.ApplyBlock(p, BookingBlockReason.CancelledLessThan24Hours, 3, Now);
+        p.BookingBlockUntil.Should().Be(Now.AddDays(7));
+        p.BookingBlockReason.Should().Be(BookingBlockReason.ValidatedNoShow);
+
+        // A longer later penalty extends it.
+        BookingBlockService.ApplyBlock(p, BookingBlockReason.FalseNoShowReport, 14, Now);
+        p.BookingBlockUntil.Should().Be(Now.AddDays(14));
+        p.BookingBlockReason.Should().Be(BookingBlockReason.FalseNoShowReport);
+    }
+
+    [Fact]
+    public async Task RequestBooking_is_rejected_for_a_blocked_student_without_touching_Stripe()
+    {
+        var db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+        var studentId = Guid.NewGuid();
+
+        db.UserProfiles.Add(new UserProfile
+        {
+            UserId = studentId,
+            BookingAccessStatus = BookingAccessStatus.BookingBlocked,
+            BookingBlockReason = BookingBlockReason.ValidatedNoShow,
+            BookingBlockUntil = DateTimeOffset.UtcNow.AddDays(5),
+        });
+        await db.SaveChangesAsync();
+
+        var currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.IsAuthenticated.Returns(true);
+        currentUser.IsInRole("Student").Returns(true);
+        currentUser.UserId.Returns(studentId);
+        var stripe = Substitute.For<IStripeService>();
+        var publisher = Substitute.For<IPublisher>();
+
+        var handler = new RequestBookingCommandHandler(db, currentUser, stripe, publisher);
+        var start = DateTimeOffset.UtcNow.AddDays(2);
+        var command = new RequestBookingCommand(
+            Guid.NewGuid(), null, start, start.AddMinutes(45), "UTC", null);
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<BookingDomainException>()
+            .WithMessage("*blocked*");
+        await stripe.DidNotReceiveWithAnyArgs().CreatePaymentIntentAsync(
+            default, default!, default!, default!, default!, default);
+
+        db.Dispose();
+    }
+}


### PR DESCRIPTION
**Batch 2 of 4** — student booking-access block (FR-CBR-21..24), the enforcement mechanism the penalty flows in batches 3–4 trigger.

### What
- `UserProfile` gains `BookingAccessStatus {Active, BookingBlocked}`, `BookingBlockReason {CancelledLessThan24Hours, ValidatedNoShow, FalseNoShowReport}`, `BookingBlockUntil`.
- `BookingBlockService` (pure): `IsCurrentlyBlocked` (lazy expiry) + `ApplyBlock` (extend-never-shorten so a shorter later penalty can't reduce an outstanding block).
- `RequestBookingCommandHandler` guard: a currently-blocked student is rejected **before** any Stripe intent is created; the block message + expiry surfaces at booking time.
- Block durations are policy knobs in `BookingOptions` (3 / 7 / 14 days).
- Additive migration (string-enum columns, `BookingAccessStatus` SQL-default `Active`, filtered index).

### Verification
- Build clean. **862 unit tests green** (5 new: pure block logic — default not-blocked, apply sets fields, lazy expiry, extend-never-shorten; + a RequestBooking guard test asserting a blocked student throws and never touches Stripe).

### Deploy note
Same as B1 — no user-visible change until batches 3–4 create blocks. Deploy deferred until the feature is assembled; migrations then apply together.