### PR TITLE
feat(consultant): cancellation <24h penalties (PB-006R B4)

### DIFF
--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/CancelBooking/CancelBookingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/CancelBooking/CancelBookingCommandHandler.cs
@@ -1,8 +1,12 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using ScholarPath.Application.Common;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.ConsultantBookings;
 using ScholarPath.Application.ConsultantBookings.Services;
 using ScholarPath.Application.FinancialConfig;
+using ScholarPath.Domain.Entities;
 using ScholarPath.Domain.Enums;
 using ScholarPath.Domain.Events;
 using ScholarPath.Domain.Exceptions;
@@ -16,6 +20,8 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
     private readonly ICurrentUserService _currentUser;
     private readonly IStripeService _stripeService;
     private readonly RefundCalculatorService _refundCalculator;
+    private readonly ConsultantRatingService _ratingService;
+    private readonly BookingOptions _options;
     private readonly IPublisher _publisher;
 
     public CancelBookingCommandHandler(
@@ -23,12 +29,16 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
         ICurrentUserService currentUser,
         IStripeService stripeService,
         RefundCalculatorService refundCalculator,
+        ConsultantRatingService ratingService,
+        IOptions<BookingOptions> bookingOptions,
         IPublisher publisher)
     {
         _context = context;
         _currentUser = currentUser;
         _stripeService = stripeService;
         _refundCalculator = refundCalculator;
+        _ratingService = ratingService;
+        _options = bookingOptions.Value;
         _publisher = publisher;
     }
 
@@ -72,19 +82,19 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
             // reason check below always reads "Cancelled" and every free-booking
             // cancellation is mis-recorded as a consultant-side cancellation.
             var wasRequested = booking.Status == BookingStatus.Requested;
+            var nowUtcFree = DateTimeOffset.UtcNow;
 
             booking.Status = BookingStatus.Cancelled;
-            booking.CancelledAt = DateTimeOffset.UtcNow;
+            booking.CancelledAt = nowUtcFree;
             booking.CancelledByUserId = currentUserId;
-            // Mirror the paid-path reasoning: a Student cancelling a Requested
-            // booking is "before acceptance"; otherwise (Confirmed, or
-            // Consultant initiated) classify as the consultant-side reason so
-            // the booking's audit trail still shows a meaningful cause even
-            // though no money moved.
-            booking.CancellationReason = isStudent && wasRequested
-                ? CancellationReason.StudentCancelledBeforeAcceptance
-                : CancellationReason.ConsultantCancelledAfterAcceptance;
+            // Mirror the paid-path reasoning so free bookings incur the same
+            // reputational penalties (money is separate from reputation). A
+            // Requested cancel is "before acceptance" (no penalty); a Confirmed
+            // cancel <24h before start penalises the cancelling party.
+            booking.CancellationReason = ClassifyCancellation(
+                isStudent, wasRequested, booking.ScheduledStartAt, nowUtcFree);
 
+            await ApplyReputationPenaltyAsync(booking, cancellationToken);
             await _context.SaveChangesAsync(cancellationToken);
 
             await _publisher.Publish(
@@ -210,6 +220,7 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
         booking.CancelledByUserId = currentUserId;
         booking.CancellationReason = refund.CancellationReason;
 
+        await ApplyReputationPenaltyAsync(booking, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
 
         await _publisher.Publish(
@@ -220,5 +231,58 @@ public sealed class CancelBookingCommandHandler : IRequestHandler<CancelBookingC
                 currentUserId,
                 booking.CancellationReason?.ToString()),
             cancellationToken);
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="RefundCalculatorService"/> semantics for the free-booking
+    /// path so both paths record the same precise cancellation reason.
+    /// </summary>
+    private static CancellationReason ClassifyCancellation(
+        bool cancelledByStudent, bool wasRequested, DateTimeOffset scheduledStartAt, DateTimeOffset nowUtc)
+    {
+        if (wasRequested)
+        {
+            return cancelledByStudent
+                ? CancellationReason.StudentCancelledBeforeAcceptance
+                : CancellationReason.ConsultantCancelledAfterAcceptance;
+        }
+
+        var moreThan24HoursBefore = scheduledStartAt.ToUniversalTime() > nowUtc.AddHours(24);
+        return cancelledByStudent
+            ? (moreThan24HoursBefore
+                ? CancellationReason.StudentCancelledMoreThan24HoursBefore
+                : CancellationReason.StudentCancelledLessThan24HoursBefore)
+            : (moreThan24HoursBefore
+                ? CancellationReason.ConsultantCancelledAfterAcceptance
+                : CancellationReason.ConsultantCancelledLessThan24Hours);
+    }
+
+    /// <summary>
+    /// PB-006R (FR-CBR-15..20): a &lt;24h cancellation of a confirmed booking carries a
+    /// reputational penalty on the cancelling party — a 3-day booking block for the
+    /// student, a 20% rating deduction for the consultant. &gt;24h and before-acceptance
+    /// cancels carry no penalty. Keyed on the recorded reason so both the paid and
+    /// free paths behave identically.
+    /// </summary>
+    private async Task ApplyReputationPenaltyAsync(ConsultantBooking booking, CancellationToken ct)
+    {
+        switch (booking.CancellationReason)
+        {
+            case CancellationReason.StudentCancelledLessThan24HoursBefore:
+                var studentProfile = await _context.UserProfiles
+                    .FirstOrDefaultAsync(p => p.UserId == booking.StudentId, ct);
+                if (studentProfile is not null)
+                {
+                    BookingBlockService.ApplyBlock(
+                        studentProfile, BookingBlockReason.CancelledLessThan24Hours,
+                        _options.LateCancellationBlockDays, DateTimeOffset.UtcNow);
+                }
+                break;
+
+            case CancellationReason.ConsultantCancelledLessThan24Hours:
+                await _ratingService.ApplyPenaltyFactorAsync(
+                    booking.ConsultantId, ConsultantRatingThresholds.CancelLessThan24HoursFactor, ct);
+                break;
+        }
     }
 }

--- a/server/src/ScholarPath.Application/ConsultantBookings/Services/RefundCalculatorService.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Services/RefundCalculatorService.cs
@@ -57,17 +57,21 @@ public sealed class RefundCalculatorService
             throw new BookingDomainException("Only requested or confirmed bookings can be cancelled.");
         }
 
+        var moreThan24HoursBefore = scheduledStartAt.ToUniversalTime() > nowUtc.AddHours(24);
+
         if (cancelledByConsultant)
         {
+            // The student is always fully refunded when the consultant cancels; the
+            // <24h case additionally carries a rating penalty (applied by the handler).
             return new RefundCalculationResult
             {
                 RefundPercentage = 100,
                 RefundAmountCents = amountCents,
-                CancellationReason = CancellationReason.ConsultantCancelledAfterAcceptance
+                CancellationReason = moreThan24HoursBefore
+                    ? CancellationReason.ConsultantCancelledAfterAcceptance
+                    : CancellationReason.ConsultantCancelledLessThan24Hours
             };
         }
-
-        var moreThan24HoursBefore = scheduledStartAt.ToUniversalTime() > nowUtc.AddHours(24);
 
         if (moreThan24HoursBefore)
         {

--- a/server/src/ScholarPath.Domain/Enums/Enums.cs
+++ b/server/src/ScholarPath.Domain/Enums/Enums.cs
@@ -453,6 +453,10 @@ public enum CancellationReason
     StudentNoShow = 5,
     AutoExpiredNoResponse = 6,
     RejectedByConsultant = 7,
+    // PB-006R (FR-CBR-16/20): consultant cancels a confirmed booking <24h before
+    // start. Same 100% student refund as ConsultantCancelledAfterAcceptance, but
+    // additionally deducts 20% from the consultant's rating.
+    ConsultantCancelledLessThan24Hours = 8,
     Other = 99
 }
 

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingPaymentSyncTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/BookingPaymentSyncTests.cs
@@ -172,7 +172,10 @@ public sealed class BookingPaymentSyncTests : IDisposable
             .Returns(new StripePaymentIntentResult("pi_test", "canceled", null, null));
 
         var handler = new CancelBookingCommandHandler(
-            _db, _currentUser, _stripe, new RefundCalculatorService(), _publisher);
+            _db, _currentUser, _stripe, new RefundCalculatorService(),
+            new ConsultantRatingService(_db, Substitute.For<INotificationDispatcher>(),
+                Substitute.For<ILogger<ConsultantRatingService>>()),
+            Options.Create(new BookingOptions()), _publisher);
         await handler.Handle(new CancelBookingCommand(booking.Id), default);
 
         var payment = await PaymentForAsync(booking.Id);
@@ -193,7 +196,10 @@ public sealed class BookingPaymentSyncTests : IDisposable
             .Returns(new StripeRefundResult("re_test", "succeeded", 10_000));
 
         var handler = new CancelBookingCommandHandler(
-            _db, _currentUser, _stripe, new RefundCalculatorService(), _publisher);
+            _db, _currentUser, _stripe, new RefundCalculatorService(),
+            new ConsultantRatingService(_db, Substitute.For<INotificationDispatcher>(),
+                Substitute.For<ILogger<ConsultantRatingService>>()),
+            Options.Create(new BookingOptions()), _publisher);
         await handler.Handle(new CancelBookingCommand(booking.Id), default);
 
         var payment = await PaymentForAsync(booking.Id);
@@ -254,7 +260,10 @@ public sealed class BookingPaymentSyncTests : IDisposable
             .Returns(new StripeRefundResult("re_50", "succeeded", 5_000));
 
         var handler = new CancelBookingCommandHandler(
-            _db, _currentUser, _stripe, new RefundCalculatorService(), _publisher);
+            _db, _currentUser, _stripe, new RefundCalculatorService(),
+            new ConsultantRatingService(_db, Substitute.For<INotificationDispatcher>(),
+                Substitute.For<ILogger<ConsultantRatingService>>()),
+            Options.Create(new BookingOptions()), _publisher);
         await handler.Handle(new CancelBookingCommand(booking.Id), default);
 
         var payment = await PaymentForAsync(booking.Id);

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/CancelBookingPenaltyTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/CancelBookingPenaltyTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using ScholarPath.Application.Common;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Application.ConsultantBookings.Commands.CancelBooking;
+using ScholarPath.Application.ConsultantBookings.Services;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Domain.Interfaces;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.ConsultantBookings;
+
+/// <summary>
+/// PB-006R (FR-CBR-15..20): a &lt;24h cancellation of a confirmed booking penalises
+/// the cancelling party — 3-day student block / 20% consultant rating deduction.
+/// Exercised via the free-booking path (no Stripe / financial config needed).
+/// </summary>
+public sealed class CancelBookingPenaltyTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly Guid _studentId = Guid.NewGuid();
+    private readonly Guid _consultantId = Guid.NewGuid();
+
+    public CancelBookingPenaltyTests()
+    {
+        _db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+        _currentUser.IsAuthenticated.Returns(true);
+    }
+
+    private CancelBookingCommandHandler Sut()
+    {
+        var rating = new ConsultantRatingService(
+            _db, Substitute.For<INotificationDispatcher>(),
+            NullLogger<ConsultantRatingService>.Instance);
+        return new CancelBookingCommandHandler(
+            _db, _currentUser, Substitute.For<IStripeService>(), new RefundCalculatorService(),
+            rating, Options.Create(new BookingOptions()), Substitute.For<IPublisher>());
+    }
+
+    private async Task<Guid> SeedConfirmedFreeBookingAsync(int startInHours)
+    {
+        _db.UserProfiles.Add(new UserProfile { UserId = _studentId });
+        _db.UserProfiles.Add(new UserProfile { UserId = _consultantId });
+        var booking = new ConsultantBooking
+        {
+            Id = Guid.NewGuid(),
+            StudentId = _studentId,
+            ConsultantId = _consultantId,
+            Status = BookingStatus.Confirmed,
+            ScheduledStartAt = DateTimeOffset.UtcNow.AddHours(startInHours),
+            ScheduledEndAt = DateTimeOffset.UtcNow.AddHours(startInHours + 1),
+            DurationMinutes = 45,
+            PriceUsd = 0m,
+        };
+        _db.Bookings.Add(booking);
+        await _db.SaveChangesAsync();
+        return booking.Id;
+    }
+
+    private async Task<UserProfile> ProfileAsync(Guid userId) =>
+        await _db.UserProfiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+
+    [Fact]
+    public async Task Student_cancel_within_24h_blocks_the_student_for_3_days()
+    {
+        var bookingId = await SeedConfirmedFreeBookingAsync(startInHours: 12);
+        _currentUser.UserId.Returns(_studentId);
+
+        await Sut().Handle(new CancelBookingCommand(bookingId), default);
+
+        var student = await ProfileAsync(_studentId);
+        student.BookingAccessStatus.Should().Be(BookingAccessStatus.BookingBlocked);
+        student.BookingBlockReason.Should().Be(BookingBlockReason.CancelledLessThan24Hours);
+        student.BookingBlockUntil.Should().BeCloseTo(DateTimeOffset.UtcNow.AddDays(3), TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
+    public async Task Student_cancel_more_than_24h_does_not_block()
+    {
+        var bookingId = await SeedConfirmedFreeBookingAsync(startInHours: 48);
+        _currentUser.UserId.Returns(_studentId);
+
+        await Sut().Handle(new CancelBookingCommand(bookingId), default);
+
+        (await ProfileAsync(_studentId)).BookingAccessStatus.Should().Be(BookingAccessStatus.Active);
+    }
+
+    [Fact]
+    public async Task Consultant_cancel_within_24h_deducts_20_percent_from_rating()
+    {
+        var bookingId = await SeedConfirmedFreeBookingAsync(startInHours: 12);
+        _currentUser.UserId.Returns(_consultantId);
+
+        await Sut().Handle(new CancelBookingCommand(bookingId), default);
+
+        (await ProfileAsync(_consultantId)).ConsultantRatingPenaltyFactor.Should().Be(0.80m);
+    }
+
+    [Fact]
+    public async Task Consultant_cancel_more_than_24h_does_not_deduct()
+    {
+        var bookingId = await SeedConfirmedFreeBookingAsync(startInHours: 48);
+        _currentUser.UserId.Returns(_consultantId);
+
+        await Sut().Handle(new CancelBookingCommand(bookingId), default);
+
+        (await ProfileAsync(_consultantId)).ConsultantRatingPenaltyFactor.Should().Be(1.0m);
+    }
+
+    public void Dispose() => _db.Dispose();
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/Services/RefundCalculatorServiceTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/Services/RefundCalculatorServiceTests.cs
@@ -90,7 +90,7 @@ public sealed class RefundCalculatorServiceTests
     }
 
     [Fact]
-    public void Calculate_WhenConsultantCancelsConfirmedBooking_ReturnsFullRefund()
+    public void Calculate_WhenConsultantCancelsConfirmedBookingWithin24h_FullRefundButLessThan24hReason()
     {
         var nowUtc = new DateTimeOffset(2026, 4, 25, 10, 0, 0, TimeSpan.Zero);
 
@@ -99,12 +99,32 @@ public sealed class RefundCalculatorServiceTests
             cancelledByUserId: ConsultantId,
             studentId: StudentId,
             consultantId: ConsultantId,
-            scheduledStartAt: nowUtc.AddHours(12),
+            scheduledStartAt: nowUtc.AddHours(12), // <24h → rating penalty (handler)
+            amountCents: 10_000,
+            nowUtc: nowUtc);
+
+        // Student is always fully refunded when the consultant cancels; the <24h
+        // reason drives the 20% consultant rating deduction in the handler (PB-006R).
+        Assert.Equal(100, result.RefundPercentage);
+        Assert.Equal(10_000, result.RefundAmountCents);
+        Assert.Equal(CancellationReason.ConsultantCancelledLessThan24Hours, result.CancellationReason);
+    }
+
+    [Fact]
+    public void Calculate_WhenConsultantCancelsConfirmedBookingMoreThan24h_FullRefundNoPenaltyReason()
+    {
+        var nowUtc = new DateTimeOffset(2026, 4, 25, 10, 0, 0, TimeSpan.Zero);
+
+        var result = _sut.Calculate(
+            bookingStatus: BookingStatus.Confirmed,
+            cancelledByUserId: ConsultantId,
+            studentId: StudentId,
+            consultantId: ConsultantId,
+            scheduledStartAt: nowUtc.AddHours(48), // >24h → no penalty
             amountCents: 10_000,
             nowUtc: nowUtc);
 
         Assert.Equal(100, result.RefundPercentage);
-        Assert.Equal(10_000, result.RefundAmountCents);
         Assert.Equal(CancellationReason.ConsultantCancelledAfterAcceptance, result.CancellationReason);
     }
 


### PR DESCRIPTION
**Batch 4 of 4 — final piece** of the consultant enforcement system (FR-CBR-15..20). Cancelling a **confirmed** booking <24h before start now penalises the cancelling party. Refunds are unchanged; only the reputational penalty is added.

- Student cancels <24h → **3-day booking block**.
- Consultant cancels <24h → **−20% rating** (new `ConsultantCancelledLessThan24Hours` reason; the calculator now branches the consultant path on the 24h boundary).
- >24h / before-acceptance → no penalty.

`CancelBookingCommandHandler` gets a shared `ApplyReputationPenaltyAsync` keyed on the recorded reason so paid and free paths behave identically; the free path also now records the precise reason (fixing a pre-existing mislabel of student confirmed-cancels).

### Verification
- **872 unit tests green** (4 new cancel-penalty tests + calculator <24h/>24h consultant cases).

### Completes PB-006R
Batches 1–4: persisted rating snapshot + penalty factor → student booking blocks → admin no-show validation → cancellation penalties. **After this merges I'll deploy — all four PB-006R migrations apply together on the next startup.**