### PR TITLE
fix(messaging): SRS conformance — mutual block, canonical conversation, 2000-char cap

### DIFF
--- a/client/src/pages/chat/Chat.tsx
+++ b/client/src/pages/chat/Chat.tsx
@@ -800,6 +800,8 @@ export function Chat() {
                   value={messageBody}
                   onChange={handleTyping}
                   disabled={isBlocked}
+                  // FR-MSG-12: cap the body at 2000 chars (matches the server validator).
+                  maxLength={2000}
                   placeholder={
                     isBlocked
                       ? t("chat.input_disabled_blocked", "Conversation is blocked.")
@@ -810,13 +812,13 @@ export function Chat() {
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && !e.shiftKey) {
                       e.preventDefault();
-                      if (!isBlocked && !isSending) handleSendMessage(e);
+                      if (!isBlocked && !isSending && messageBody.length <= 2000) handleSendMessage(e);
                     }
                   }}
                 />
                 <button
                   type="submit"
-                  disabled={!messageBody.trim() || isBlocked || isSending}
+                  disabled={!messageBody.trim() || isBlocked || isSending || messageBody.length > 2000}
                   aria-label={t("chat.send", "Send")}
                   className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-brand-500 to-brand-700 text-white shadow-brand-sm transition-all hover:shadow-brand-md hover:from-brand-600 hover:to-brand-800 active:scale-95 disabled:bg-none disabled:bg-bg-subtle disabled:text-text-tertiary disabled:shadow-none disabled:cursor-not-allowed flex-shrink-0"
                 >
@@ -827,6 +829,15 @@ export function Chat() {
                   )}
                 </button>
               </form>
+              {messageBody.length > 1800 && (
+                <p
+                  className={`mt-1 text-end text-xs ${
+                    messageBody.length >= 2000 ? "text-danger-500" : "text-text-tertiary"
+                  }`}
+                >
+                  {messageBody.length}/2000
+                </p>
+              )}
             </div>
           </>
         ) : (

--- a/server/src/ScholarPath.Application/Chat/Commands/SendMessage/SendMessageCommand.cs
+++ b/server/src/ScholarPath.Application/Chat/Commands/SendMessage/SendMessageCommand.cs
@@ -43,10 +43,18 @@ public sealed class SendMessageCommandHandler(
 
         if (conversation == null)
         {
+            // FR-MSG-11: store the pair in a CANONICAL order (smaller GUID first) so
+            // the unique index on (ParticipantOneId, ParticipantTwoId) actually
+            // enforces one-conversation-per-pair — otherwise a concurrent first
+            // message from each side races two rows in with swapped columns. Reads
+            // map participant→user by id, so the order carries no other meaning.
+            var (participantOne, participantTwo) = senderId.CompareTo(request.RecipientId) <= 0
+                ? (senderId, request.RecipientId)
+                : (request.RecipientId, senderId);
             conversation = new ChatConversation
             {
-                ParticipantOneId = senderId,
-                ParticipantTwoId = request.RecipientId,
+                ParticipantOneId = participantOne,
+                ParticipantTwoId = participantTwo,
             };
             db.Conversations.Add(conversation);
         }

--- a/server/src/ScholarPath.Application/Community/Commands/CreateReply/CreateReplyCommand.cs
+++ b/server/src/ScholarPath.Application/Community/Commands/CreateReply/CreateReplyCommand.cs
@@ -45,6 +45,13 @@ public sealed class CreateReplyCommandHandler(
             .ConfigureAwait(false)
             ?? throw new NotFoundException(nameof(ForumPost), request.ParentPostId);
 
+        // FR-MSG-29: a mutual block prevents either party from replying to the
+        // other's community posts.
+        if (await CommunityBlockFilter.AreBlockedAsync(db, authorId, parent.AuthorId, ct).ConfigureAwait(false))
+        {
+            throw new ConflictException("You cannot reply to this post because a block is in place.");
+        }
+
         var sanitizer = new Ganss.Xss.HtmlSanitizer();
 
         var body = sanitizer.Sanitize(request.BodyMarkdown);

--- a/server/src/ScholarPath.Application/Community/CommunityBlockFilter.cs
+++ b/server/src/ScholarPath.Application/Community/CommunityBlockFilter.cs
@@ -1,0 +1,32 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Entities;
+
+namespace ScholarPath.Application.Community;
+
+/// <summary>
+/// FR-MSG-29: a block is MUTUAL. When two users are in a block relationship (in
+/// either direction), neither may view or reply to the other's community content.
+/// This is the single predicate every community query + the reply command uses so
+/// the block semantics never drift (an earlier version filtered blocker-only, which
+/// contradicted the chat side that was already bidirectional).
+/// </summary>
+public static class CommunityBlockFilter
+{
+    /// <summary>
+    /// A <see cref="ForumPost"/> predicate: true when the post's author is NOT in a
+    /// block relationship (either direction) with <paramref name="viewerId"/>.
+    /// </summary>
+    public static Expression<Func<ForumPost, bool>> NotBlockedWith(IApplicationDbContext db, Guid viewerId) =>
+        p => !db.UserBlocks.Any(b =>
+            (b.BlockerId == viewerId && b.BlockedUserId == p.AuthorId) ||
+            (b.BlockerId == p.AuthorId && b.BlockedUserId == viewerId));
+
+    /// <summary>True when <paramref name="a"/> and <paramref name="b"/> are in a block
+    /// relationship in either direction.</summary>
+    public static Task<bool> AreBlockedAsync(IApplicationDbContext db, Guid a, Guid b, CancellationToken ct) =>
+        db.UserBlocks.AnyAsync(x =>
+            (x.BlockerId == a && x.BlockedUserId == b) ||
+            (x.BlockerId == b && x.BlockedUserId == a), ct);
+}

--- a/server/src/ScholarPath.Application/Community/Queries/GetMyBookmarks/GetMyBookmarksQuery.cs
+++ b/server/src/ScholarPath.Application/Community/Queries/GetMyBookmarks/GetMyBookmarksQuery.cs
@@ -38,10 +38,11 @@ public sealed class GetMyBookmarksQueryHandler(
                         && b.ForumPost != null
                         && !b.ForumPost.IsDeleted
                         && !b.ForumPost.IsAutoHidden
-                        // Personal block: a post whose author the user later blocked
-                        // drops out of their bookmarks too.
+                        // FR-MSG-29: a post whose author is in a block relationship
+                        // (either direction) with the user drops out of their bookmarks.
                         && !db.UserBlocks.Any(
-                            ub => ub.BlockerId == userId && ub.BlockedUserId == b.ForumPost.AuthorId));
+                            ub => (ub.BlockerId == userId && ub.BlockedUserId == b.ForumPost.AuthorId)
+                               || (ub.BlockerId == b.ForumPost.AuthorId && ub.BlockedUserId == userId)));
 
         var total = await baseQuery.CountAsync(ct).ConfigureAwait(false);
 

--- a/server/src/ScholarPath.Application/Community/Queries/GetPostDetails/GetPostDetailsQuery.cs
+++ b/server/src/ScholarPath.Application/Community/Queries/GetPostDetails/GetPostDetailsQuery.cs
@@ -46,16 +46,23 @@ public sealed class GetPostDetailsQueryHandler(
             .ConfigureAwait(false)
             ?? throw new NotFoundException(nameof(ForumPost), request.Id);
 
+        // FR-MSG-29: mutual block — the thread of a user in a block relationship
+        // (either direction) with the viewer is hidden entirely (not just its replies).
+        if (currentUserId is Guid viewerId
+            && await CommunityBlockFilter.AreBlockedAsync(db, viewerId, post.AuthorId, ct).ConfigureAwait(false))
+        {
+            throw new NotFoundException(nameof(ForumPost), request.Id);
+        }
+
         var repliesQuery = db.ForumPosts
             .AsNoTracking()
             .Include(p => p.Author)
             .Where(p => p.ParentPostId == request.Id && !p.IsDeleted && !p.IsAutoHidden);
 
-        // Personal block: drop replies authored by anyone the current user blocked.
+        // FR-MSG-29: drop replies authored by anyone in a block relationship with the viewer.
         if (currentUserId is Guid blockerId)
         {
-            repliesQuery = repliesQuery.Where(p => !db.UserBlocks.Any(
-                b => b.BlockerId == blockerId && b.BlockedUserId == p.AuthorId));
+            repliesQuery = repliesQuery.Where(CommunityBlockFilter.NotBlockedWith(db, blockerId));
         }
 
         var replyRows = await repliesQuery

--- a/server/src/ScholarPath.Application/Community/Queries/GetPosts/GetPostsQuery.cs
+++ b/server/src/ScholarPath.Application/Community/Queries/GetPosts/GetPostsQuery.cs
@@ -67,12 +67,11 @@ public sealed class GetPostsQueryHandler(
             return new PagedResult<ForumPostDto>(Array.Empty<ForumPostDto>(), request.Page, request.PageSize, 0);
         }
 
-        // Personal block: hide posts authored by anyone the current user has
-        // blocked (blocker-only — the block never affects other viewers).
+        // FR-MSG-29: mutual block — hide posts authored by anyone in a block
+        // relationship (either direction) with the current user.
         if (currentUserId is Guid blockerId)
         {
-            query = query.Where(p => !db.UserBlocks.Any(
-                b => b.BlockerId == blockerId && b.BlockedUserId == p.AuthorId));
+            query = query.Where(CommunityBlockFilter.NotBlockedWith(db, blockerId));
         }
 
         // "Trending" = recent + high engagement (last 30 days, scored by net votes

--- a/server/tests/ScholarPath.UnitTests/Community/CreateReplyCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Community/CreateReplyCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Community.Commands.CreateReply;
+using ScholarPath.Domain.Entities;
 
 namespace ScholarPath.UnitTests.Community;
 
@@ -47,5 +48,36 @@ public sealed class CreateReplyCommandHandlerTests : IDisposable
 
         await Assert.ThrowsAsync<ForbiddenAccessException>(() =>
             handler.Handle(new CreateReplyCommand(root.Id, "no"), CancellationToken.None));
+    }
+
+    // FR-MSG-29: a mutual block prevents either party from replying to the other.
+
+    [Fact]
+    public async Task Reply_is_blocked_when_the_replier_blocked_the_post_author()
+    {
+        var root = await _h.SeedPostAsync(_h.StudentA);
+        _h.Db.UserBlocks.Add(new UserBlock { BlockerId = _h.StudentB.Id, BlockedUserId = _h.StudentA.Id });
+        await _h.Db.SaveChangesAsync();
+
+        _h.AsStudent(_h.StudentB);
+        var handler = new CreateReplyCommandHandler(_h.Db, _h.CurrentUser);
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            handler.Handle(new CreateReplyCommand(root.Id, "blocked reply"), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Reply_is_blocked_when_the_post_author_blocked_the_replier()
+    {
+        // Reverse direction: A blocked B, B still cannot reply to A's post (mutual).
+        var root = await _h.SeedPostAsync(_h.StudentA);
+        _h.Db.UserBlocks.Add(new UserBlock { BlockerId = _h.StudentA.Id, BlockedUserId = _h.StudentB.Id });
+        await _h.Db.SaveChangesAsync();
+
+        _h.AsStudent(_h.StudentB);
+        var handler = new CreateReplyCommandHandler(_h.Db, _h.CurrentUser);
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            handler.Handle(new CreateReplyCommand(root.Id, "blocked reply"), CancellationToken.None));
     }
 }

--- a/server/tests/ScholarPath.UnitTests/Community/GetPostDetailsBlockTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Community/GetPostDetailsBlockTests.cs
@@ -1,0 +1,52 @@
+using ScholarPath.Application.Common.Exceptions;
+using ScholarPath.Application.Community.Queries.GetPostDetails;
+using ScholarPath.Domain.Entities;
+
+namespace ScholarPath.UnitTests.Community;
+
+/// <summary>
+/// FR-MSG-29: a mutual block hides the blocked author's whole community thread from
+/// the viewer — in EITHER block direction — while leaving unrelated threads visible.
+/// </summary>
+public sealed class GetPostDetailsBlockTests : IDisposable
+{
+    private readonly CommunityTestHarness _h = new();
+    public void Dispose() => _h.Dispose();
+
+    private GetPostDetailsQueryHandler Sut() => new(_h.Db, _h.CurrentUser);
+
+    [Fact]
+    public async Task Thread_is_hidden_when_viewer_blocked_the_author()
+    {
+        var post = await _h.SeedPostAsync(_h.StudentA);
+        _h.Db.UserBlocks.Add(new UserBlock { BlockerId = _h.StudentB.Id, BlockedUserId = _h.StudentA.Id });
+        await _h.Db.SaveChangesAsync();
+        _h.AsStudent(_h.StudentB);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            Sut().Handle(new GetPostDetailsQuery(post.Id), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Thread_is_hidden_when_the_author_blocked_the_viewer()
+    {
+        var post = await _h.SeedPostAsync(_h.StudentA);
+        _h.Db.UserBlocks.Add(new UserBlock { BlockerId = _h.StudentA.Id, BlockedUserId = _h.StudentB.Id });
+        await _h.Db.SaveChangesAsync();
+        _h.AsStudent(_h.StudentB);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            Sut().Handle(new GetPostDetailsQuery(post.Id), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Thread_is_visible_when_there_is_no_block()
+    {
+        var post = await _h.SeedPostAsync(_h.StudentA);
+        _h.AsStudent(_h.StudentB);
+
+        var result = await Sut().Handle(new GetPostDetailsQuery(post.Id), CancellationToken.None);
+
+        result.Post.Id.Should().Be(post.Id);
+    }
+}


### PR DESCRIPTION
Messaging / Direct-Chat SRS audit (FR-MSG-01..34) — **32/34 already conformant**; this fixes the 3 gaps. No user story uses "System" as the actor (verified). No diagrams in this module.

### FR-MSG-29 🔴 — Community block is now MUTUAL/bidirectional
Per the new SRS (reverses the earlier "personal block" call, so chat + community agree — chat was already bidirectional). New `CommunityBlockFilter` is the single predicate for `GetPosts`, `GetPostDetails` (replies **and** the top-level thread, now hidden as NotFound), and `GetMyBookmarks`. `CreateReply` now rejects a reply when either party blocked the other. Previously: reply-block absent, `GetPostDetails` top-level post unfiltered, view filter blocker-only.

### FR-MSG-11 🟠 — Canonical conversation ordering
Conversations store the pair smaller-GUID-first so the unique `(ParticipantOneId, ParticipantTwoId)` index actually prevents duplicate conversations under a concurrent first-message race. Reads map participant→user by id, so order carries no other meaning.

### FR-MSG-12 🟡 — Client 2000-char cap
Chat composer caps at 2000 (`maxLength`), disables send past the limit, shows a counter near the cap. Server validator already enforced 2000.

### Verification
- **Adversarially verified** (separate agent): EF translatability confirmed, complete for view+reply scope, self-safe, chat-consistent — verdict "ship it".
- **877 unit tests green** (5 new: reply-block both directions + GetPostDetails hide both directions + no-block visible). Client tsc + eslint + build clean.