### PR TITLE
fix(client): stale-UI — enable prod WebSockets + fix cache invalidation

### DIFF
--- a/client/src/components/community/EditPostDialog.tsx
+++ b/client/src/components/community/EditPostDialog.tsx
@@ -71,7 +71,9 @@ export function EditPostDialog({
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["community", "thread"] });
       void qc.invalidateQueries({ queryKey: ["community", "posts"] });
-      void qc.invalidateQueries({ queryKey: ["community", "bookmarks"] });
+      // The bookmarks tab query key is "bookmarks-feed" — the old "bookmarks"
+      // key matched no query, so an edited bookmarked post stayed stale there.
+      void qc.invalidateQueries({ queryKey: ["community", "bookmarks-feed"] });
       toast.success(t("edit.success"));
       onSaved?.();
       onOpenChange(false);

--- a/client/src/pages/admin/AdminKnowledgeBase.tsx
+++ b/client/src/pages/admin/AdminKnowledgeBase.tsx
@@ -152,7 +152,10 @@ export function AdminKnowledgeBase() {
     mutationFn: () => adminApi.startFineTuningJob(),
     onSuccess: (r) => {
       toast.success(t("admin:knowledgeBase.ftStarted", { jobId: r.jobId }));
-      qc.invalidateQueries({ queryKey: FT_STATUS_KEY });
+      // The status query is enabled:false, so invalidate is a no-op (it never
+      // ran). Force a fetch so the status panel populates without the admin
+      // having to click "Check status".
+      void qc.refetchQueries({ queryKey: FT_STATUS_KEY });
     },
     onError: () => toast.error(t("admin:knowledgeBase.ftStartError")),
   });

--- a/client/src/pages/chat/Chat.tsx
+++ b/client/src/pages/chat/Chat.tsx
@@ -285,9 +285,14 @@ export function Chat() {
 
       // Refresh the list; for a pending conversation, swap the placeholder for
       // the real row the backend just created so the thread loads its messages.
+      // staleTime:0 forces a network read — otherwise fetchQuery returns the
+      // cached list (which predates the just-created conversation), the real row
+      // is never found, and the new thread stays stuck on the "pending" placeholder
+      // until a manual refresh.
       const fresh = await qc.fetchQuery({
         queryKey: ["chat", "conversations"],
         queryFn: () => chatApi.getConversations(),
+        staleTime: 0,
       });
       if (isPending) {
         const real = fresh.find((c) => c.otherParticipantId === selectedConv.otherParticipantId);
@@ -362,15 +367,22 @@ export function Chat() {
       }
 
       // Keep the thread open and refresh so the button reflects the new block
-      // state and the toggle stays reachable (UAT TC-006).
+      // state and the toggle stays reachable (UAT TC-006). staleTime:0 forces a
+      // network read — without it fetchQuery returns the cached (pre-block)
+      // conversations while they're still within the global staleTime window, so
+      // the button would keep showing the old state until a manual refresh.
       const fresh = await qc.fetchQuery({
         queryKey: ["chat", "conversations"],
         queryFn: () => chatApi.getConversations(),
+        staleTime: 0,
       });
       const updated = fresh.find(
         (c) => c.otherParticipantId === selectedConv.otherParticipantId,
       );
       setSelectedConv(updated ?? { ...selectedConv, isBlocked: !wasBlocked });
+      // A block/unblock changes who shows up in contact search (FR-MSG-23) —
+      // drop the cached contact lists so the next "new message" picker is correct.
+      void qc.invalidateQueries({ queryKey: ["chat", "contacts"] });
     } catch (error) {
       console.error("Failed to toggle block", error);
       toast.error(

--- a/client/src/pages/company/ApplicationsReview.tsx
+++ b/client/src/pages/company/ApplicationsReview.tsx
@@ -57,6 +57,10 @@ export function ApplicationsReview() {
     }) => applicationsApi.reviewApplication(id, status, reason),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["company", "applications"] });
+      // The detail modal uses ["company","application","detail",id] (singular) —
+      // a different prefix, so it needs its own invalidation or it shows the old
+      // status when re-opened right after a decision.
+      queryClient.invalidateQueries({ queryKey: ["company", "application", "detail"] });
       toast.success(t("scholarshipProviderReview.decision.success"));
       setDecisionTarget(null);
     },

--- a/client/src/pages/student/Applications.tsx
+++ b/client/src/pages/student/Applications.tsx
@@ -127,6 +127,10 @@ export function Applications() {
     comment: string,
   ) => {
     await applicationsApi.submitReview(applicationId, scholarshipProviderId, rating, comment);
+    // Refresh the board so `hasReview` flips and the "Rate provider" affordance
+    // disappears — without this the button lingers and a re-click hits a
+    // duplicate-review error until reload.
+    await queryClient.invalidateQueries({ queryKey: queryKeys.applications.mine });
   };
 
   return (

--- a/client/src/pages/student/ResourceDetail.tsx
+++ b/client/src/pages/student/ResourceDetail.tsx
@@ -187,6 +187,9 @@ export function ResourceDetail() {
     mutationFn: (id: string) => resourcesApi.toggleBookmark(id),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["resources", "bookmarks"] });
+      // Also refresh THIS page's detail query so the bookmark button flips
+      // immediately instead of only the separate bookmarks list.
+      void qc.invalidateQueries({ queryKey: ["resources", "detail", idOrSlug] });
     },
     onError: (err) => toast.error(apiErrorMessage(err, t("common:status.error"))),
   });
@@ -202,6 +205,9 @@ export function ResourceDetail() {
         toast.success(t("resources:detail.chapterMarked"));
       }
       void qc.invalidateQueries({ queryKey: ["resources", "progress"] });
+      // Also refresh THIS page's detail query so the per-chapter checkmarks
+      // update immediately.
+      void qc.invalidateQueries({ queryKey: ["resources", "detail", idOrSlug] });
     },
     onError: (err) => toast.error(apiErrorMessage(err, t("common:status.error"))),
   });

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -355,6 +355,11 @@ resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
       http20Enabled: true
+      // Required for SignalR real-time (chat messages, typing, presence,
+      // notifications). Without this the WebSocket transport is rejected and the
+      // client falls back to slow/flaky polling, so live updates never arrive and
+      // users have to refresh manually.
+      webSocketsEnabled: true
       healthCheckPath: '/health'
       cors: {
         allowedOrigins: empty(clientCorsOrigin) ? [] : [clientCorsOrigin]


### PR DESCRIPTION
Fixes the widespread "I have to refresh to see my change" bug the user reported (block/unblock, messages, user-selection, and more).

### Root cause 1 — SignalR real-time was dead in prod 🔴
The App Service had `webSocketsEnabled=false`, so the WebSocket transport was rejected and live chat messages, typing, presence, and notifications never arrived. **Enabled live** (`az webapp config set --web-sockets-enabled true`) and pinned in `infra/main.bicep` so it survives reprovision.

### Root cause 2 — client cache not refreshed after mutations
- **chat** (`Chat.tsx`): block/unblock + new-conversation send used `qc.fetchQuery` **without `staleTime:0`**, so within the 30s global `staleTime` they returned the *cached pre-action* conversations — the block button never flipped and a new thread stayed stuck on its "pending" placeholder. Added `staleTime:0`; also invalidate `["chat","contacts"]` on block/unblock.
- **community** `EditPostDialog`: invalidated `["community","bookmarks"]` (no query uses it) → `bookmarks-feed`.
- **student `Applications`**: rating from the board never invalidated `applications.mine` → the "Rate" button lingered and a re-click 409'd.
- **student `ResourceDetail`**: bookmark + chapter-complete didn't invalidate the page's own `["resources","detail",id]`.
- **company `ApplicationsReview`**: accept/reject invalidated the plural list key, not the singular detail-modal key.
- **admin `KnowledgeBase`**: "Start fine-tuning" invalidated an `enabled:false` query (no-op) → `refetchQueries`.

A read-only sweep of every client mutation confirmed no other `fetchQuery`-staleTime or key-mismatch defects remain. Client tsc + eslint + build clean.

> Note: the WebSockets platform setting is already applied in prod (live). This PR ships the client cache fixes + makes the setting durable in IaC.