### PR TITLE
fix(security): Draft-app leak, role self-escalation, notification dup (audit C1/C5/C6)

### DIFF
--- a/server/src/ScholarPath.Application/Admin/Commands/ChangeUserRole/ChangeUserRoleCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/ChangeUserRole/ChangeUserRoleCommandHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Common.Exceptions;
@@ -7,11 +8,34 @@ namespace ScholarPath.Application.Admin.Commands.ChangeUserRole;
 
 public sealed class ChangeUserRoleCommandHandler(
     IUserAdministration admin,
+    ICurrentUserService currentUser,
     ILogger<ChangeUserRoleCommandHandler> logger)
     : IRequestHandler<ChangeUserRoleCommand, bool>
 {
     public async Task<bool> Handle(ChangeUserRoleCommand request, CancellationToken ct)
     {
+        // Privilege-tier guard (prevents self-escalation): the controller only
+        // requires Admin OR SuperAdmin, but granting/revoking the privileged roles
+        // (Admin, SuperAdmin) must be SuperAdmin-only — otherwise a plain Admin could
+        // mint itself (or a confederate) SuperAdmin. And no admin may change their OWN roles.
+        var currentUserId = currentUser.UserId
+            ?? throw new ForbiddenAccessException("Authenticated admin id is missing.");
+
+        var isPrivilegedRole =
+            string.Equals(request.Role, "Admin", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(request.Role, "SuperAdmin", StringComparison.OrdinalIgnoreCase);
+
+        if (isPrivilegedRole && !currentUser.IsInRole("SuperAdmin"))
+        {
+            throw new ForbiddenAccessException(
+                "Only a SuperAdmin can grant or revoke the Admin or SuperAdmin role.");
+        }
+
+        if (request.UserId == currentUserId)
+        {
+            throw new ForbiddenAccessException("You cannot change your own roles.");
+        }
+
         var ok = request.Operation switch
         {
             RoleOp.Add    => await admin.AddRoleAsync(request.UserId, request.Role, ct).ConfigureAwait(false),

--- a/server/src/ScholarPath.Application/Applications/Queries/GetScholarshipProviderApplicationDetails/GetScholarshipProviderApplicationDetailsQueryHandler.cs
+++ b/server/src/ScholarPath.Application/Applications/Queries/GetScholarshipProviderApplicationDetails/GetScholarshipProviderApplicationDetailsQueryHandler.cs
@@ -26,6 +26,13 @@ public sealed class GetScholarshipProviderApplicationDetailsQueryHandler(
             throw new ForbiddenAccessException();
         }
 
+        // A provider must never see a student's unsubmitted Draft (in-progress form
+        // + uploaded documents). Treat it as not-found to avoid confirming it exists.
+        if (application.Status == Domain.Enums.ApplicationStatus.Draft)
+        {
+            throw new NotFoundException(nameof(Domain.Entities.ApplicationTracker), request.ApplicationId);
+        }
+
         var documents = await db.Documents
             .AsNoTracking()
             .Where(d => d.ApplicationTrackerId == application.Id && !d.IsDeleted)

--- a/server/src/ScholarPath.Application/Applications/Queries/GetScholarshipProviderApplications/GetScholarshipProviderApplicationsQueryHandler.cs
+++ b/server/src/ScholarPath.Application/Applications/Queries/GetScholarshipProviderApplications/GetScholarshipProviderApplicationsQueryHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using ScholarPath.Application.Applications.DTOs;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Enums;
 
 namespace ScholarPath.Application.Applications.Queries.GetScholarshipProviderApplications;
 
@@ -19,7 +20,12 @@ public sealed class GetScholarshipProviderApplicationsQueryHandler(
             .AsNoTracking()
             .Include(a => a.Student)
             .Include(a => a.Scholarship)
-            .Where(a => a.Scholarship != null && a.Scholarship.OwnerScholarshipProviderId == currentUser.UserId);
+            // A Draft is created the instant a student clicks Apply (before filling
+            // in / submitting). Providers must only see SUBMITTED applications —
+            // never a student's unsubmitted in-progress form + documents.
+            .Where(a => a.Scholarship != null
+                        && a.Scholarship.OwnerScholarshipProviderId == currentUser.UserId
+                        && a.Status != ApplicationStatus.Draft);
 
         if (request.ScholarshipId.HasValue)
         {

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704221536_UniqueNotificationIdempotencyKey_Audit.Designer.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704221536_UniqueNotificationIdempotencyKey_Audit.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScholarPath.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using ScholarPath.Infrastructure.Persistence;
 namespace ScholarPath.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704221536_UniqueNotificationIdempotencyKey_Audit")]
+    partial class UniqueNotificationIdempotencyKey_Audit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704221536_UniqueNotificationIdempotencyKey_Audit.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704221536_UniqueNotificationIdempotencyKey_Audit.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScholarPath.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UniqueNotificationIdempotencyKey_Audit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Notifications_IdempotencyKey",
+                table: "Notifications");
+
+            // Remove any duplicate (IdempotencyKey, Channel) rows that the old
+            // check-then-act race may already have created, keeping the earliest —
+            // otherwise the new UNIQUE index below cannot be built.
+            migrationBuilder.Sql(@"
+                WITH dups AS (
+                    SELECT Id,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY [IdempotencyKey], [Channel]
+                               ORDER BY [CreatedAt], [Id]) AS rn
+                    FROM [Notifications]
+                    WHERE [IdempotencyKey] IS NOT NULL
+                )
+                DELETE FROM [Notifications] WHERE [Id] IN (SELECT [Id] FROM dups WHERE rn > 1);");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_Notifications_IdempotencyKey_Channel",
+                table: "Notifications",
+                columns: new[] { "IdempotencyKey", "Channel" },
+                unique: true,
+                filter: "[IdempotencyKey] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_Notifications_IdempotencyKey_Channel",
+                table: "Notifications");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_IdempotencyKey",
+                table: "Notifications",
+                column: "IdempotencyKey");
+        }
+    }
+}

--- a/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
+++ b/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
@@ -955,7 +955,15 @@ public sealed class NotificationConfiguration : IEntityTypeConfiguration<Notific
         b.Property(n => n.DispatchError).HasMaxLength(2000);
         b.Property(n => n.RowVersion).IsRowVersion();
         b.HasIndex(n => new { n.RecipientUserId, n.IsRead, n.CreatedAt });
-        b.HasIndex(n => n.IdempotencyKey);
+        // Idempotency is enforced at the DB, not just check-then-act: a concurrent
+        // duplicate dispatch (overlapping jobs, webhook re-delivery) can't insert a
+        // second row. Composite with Channel because one dispatch legitimately writes
+        // one row per channel (InApp + Email) under the same key; filtered so the many
+        // key-less notifications aren't collapsed by SQL Server's NULL-equality.
+        b.HasIndex(n => new { n.IdempotencyKey, n.Channel })
+            .IsUnique()
+            .HasFilter("[IdempotencyKey] IS NOT NULL")
+            .HasDatabaseName("UX_Notifications_IdempotencyKey_Channel");
         b.HasQueryFilter(n => !n.IsDeleted);
     }
 }

--- a/server/src/ScholarPath.Infrastructure/Services/NotificationDispatcher.cs
+++ b/server/src/ScholarPath.Infrastructure/Services/NotificationDispatcher.cs
@@ -57,7 +57,19 @@ public sealed class NotificationDispatcher(
             rows.Add(row);
         }
 
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (ScholarPath.Application.Common.Exceptions.ConflictException)
+            when (!string.IsNullOrEmpty(idempotencyKey))
+        {
+            // A concurrent dispatch with the same idempotency key won the race and
+            // inserted these rows first — the unique (IdempotencyKey, Channel) index
+            // rejected ours. Detach our rejected rows and no-op (idempotent).
+            db.Notifications.RemoveRange(rows);
+            return;
+        }
 
         foreach (var row in rows)
             await DeliverAsync(row, content, ct);

--- a/server/tests/ScholarPath.UnitTests/Admin/ChangeUserRoleCommandTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Admin/ChangeUserRoleCommandTests.cs
@@ -2,13 +2,24 @@ using Microsoft.Extensions.Logging;
 using ScholarPath.Application.Admin.Commands.ChangeUserRole;
 using ScholarPath.Application.Common.Exceptions;
 using ScholarPath.Application.Common.Interfaces;
+using ScholarPath.Domain.Interfaces;
 
 namespace ScholarPath.UnitTests.Admin;
 
 public class ChangeUserRoleCommandTests
 {
     private readonly IUserAdministration _admin = Substitute.For<IUserAdministration>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
     private readonly ILogger<ChangeUserRoleCommandHandler> _log = Substitute.For<ILogger<ChangeUserRoleCommandHandler>>();
+    private readonly Guid _actorId = Guid.NewGuid();
+
+    public ChangeUserRoleCommandTests()
+    {
+        _currentUser.UserId.Returns(_actorId);
+        _currentUser.IsInRole("SuperAdmin").Returns(true); // default: acting as SuperAdmin
+    }
+
+    private ChangeUserRoleCommandHandler Sut() => new(_admin, _currentUser, _log);
 
     [Fact]
     public async Task Add_role_delegates_to_admin()
@@ -16,8 +27,7 @@ public class ChangeUserRoleCommandTests
         var uid = Guid.NewGuid();
         _admin.AddRoleAsync(uid, "Consultant", Arg.Any<CancellationToken>()).Returns(true);
 
-        var sut = new ChangeUserRoleCommandHandler(_admin, _log);
-        var result = await sut.Handle(new ChangeUserRoleCommand(uid, "Consultant", RoleOp.Add), default);
+        var result = await Sut().Handle(new ChangeUserRoleCommand(uid, "Consultant", RoleOp.Add), default);
 
         result.Should().BeTrue();
         await _admin.Received(1).AddRoleAsync(uid, "Consultant", Arg.Any<CancellationToken>());
@@ -29,8 +39,7 @@ public class ChangeUserRoleCommandTests
         var uid = Guid.NewGuid();
         _admin.RemoveRoleAsync(uid, "ScholarshipProvider", Arg.Any<CancellationToken>()).Returns(true);
 
-        var sut = new ChangeUserRoleCommandHandler(_admin, _log);
-        await sut.Handle(new ChangeUserRoleCommand(uid, "ScholarshipProvider", RoleOp.Remove), default);
+        await Sut().Handle(new ChangeUserRoleCommand(uid, "ScholarshipProvider", RoleOp.Remove), default);
 
         await _admin.Received(1).RemoveRoleAsync(uid, "ScholarshipProvider", Arg.Any<CancellationToken>());
     }
@@ -41,10 +50,31 @@ public class ChangeUserRoleCommandTests
         var uid = Guid.NewGuid();
         _admin.AddRoleAsync(uid, "Admin", Arg.Any<CancellationToken>()).Returns(false);
 
-        var sut = new ChangeUserRoleCommandHandler(_admin, _log);
-        var act = () => sut.Handle(new ChangeUserRoleCommand(uid, "Admin", RoleOp.Add), default);
+        var act = () => Sut().Handle(new ChangeUserRoleCommand(uid, "Admin", RoleOp.Add), default);
 
         await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Theory]
+    [InlineData("Admin")]
+    [InlineData("SuperAdmin")]
+    public async Task Non_superadmin_cannot_grant_privileged_role(string role)
+    {
+        _currentUser.IsInRole("SuperAdmin").Returns(false); // acting as plain Admin
+
+        var act = () => Sut().Handle(new ChangeUserRoleCommand(Guid.NewGuid(), role, RoleOp.Add), default);
+
+        await act.Should().ThrowAsync<ForbiddenAccessException>();
+        await _admin.DidNotReceiveWithAnyArgs().AddRoleAsync(default, default!, default);
+    }
+
+    [Fact]
+    public async Task Cannot_change_own_roles()
+    {
+        var act = () => Sut().Handle(new ChangeUserRoleCommand(_actorId, "Consultant", RoleOp.Add), default);
+
+        await act.Should().ThrowAsync<ForbiddenAccessException>();
+        await _admin.DidNotReceiveWithAnyArgs().AddRoleAsync(default, default!, default);
     }
 }
 


### PR DESCRIPTION
Deep-audit criticals batch 1/3 (see `docs/DEEP-AUDIT-2026-07-05.md`).

- **C1 (privacy/IDOR)** — providers could read students' **unsubmitted Draft** applications (in-progress form + uploaded docs). Provider list/detail queries now exclude `Draft` (detail → NotFound to hide existence).
- **C6 (priv-esc)** — `ChangeUserRole` had no tier guard: a plain Admin could grant itself SuperAdmin. Now SuperAdmin-only for granting/revoking Admin/SuperAdmin, and no self-role-change. +3 tests.
- **C5 (dup notifications)** — idempotency was check-then-act on a non-unique index. Added a composite **UNIQUE filtered** index `(IdempotencyKey, Channel)` (migration de-dups existing rows first); dispatcher no-ops on the resulting conflict.

**880 unit tests green.** Deploy deferred until batches 2–3 land (the migration applies with them).