### PR TITLE
fix: no-show atomicity + ScholarshipProviderReview refund integrity (audit C4/C2/C3)

### DIFF
--- a/docs/DEEP-AUDIT-2026-07-05.md
+++ b/docs/DEEP-AUDIT-2026-07-05.md
@@ -1,0 +1,135 @@
+# Deep System Audit — 2026-07-05 (business + code)
+
+6-agent parallel deep review (payments, consultant booking/penalties, applications/scholarships,
+auth/RBAC/data-protection, data-integrity/concurrency/jobs/perf, frontend). Each finding was
+verified against the actual code; confidence noted where relevant. The system is broadly solid
+and well-hardened — these are the real residual problems, prioritized by impact.
+
+---
+
+## 🔴 Critical — money, privacy/security, or data integrity
+
+### C1. Provider can read students' **unsubmitted Draft** applications (privacy / IDOR-class) — VERIFIED
+`GetScholarshipProviderApplicationsQueryHandler.cs:22` + `GetScholarshipProviderApplicationDetailsQueryHandler`
+filter only by scholarship ownership and never exclude `Status == Draft`. A `Draft` row is created the
+instant a student clicks "Apply" (before filling/paying) and keeps receiving `FormDataJson`/`AttachedDocumentsJson`.
+So the owning provider can list + open the in-progress form answers and uploaded documents of applications
+the student has **not submitted and may never submit**.
+**Fix:** add `a.Status != ApplicationStatus.Draft` (or `a.SubmittedAt != null`) to both provider queries.
+
+### C2. ScholarshipProviderReview fee can be **double-partial-refunded** (Withdraw + Cancel paths race)
+The one unified `Payment` row is mutated by two disjoint subsystems (request-lifecycle vs application-event/withdraw).
+`RefundScholarshipProviderReviewCommand.cs:98-100` computes a partial refund as `AmountCents / 2` **ignoring the
+prior `RefundedAmountCents`**, with a different Stripe idempotency key than the request-cancel path. Odd-cents case
+(e.g. 999¢: 500¢ then 499¢) passes the `>AmountCents` guard → **two Stripe refunds totalling the full charge** on a
+payment meant to be half-refunded.
+**Fix:** compute partial as `(AmountCents/2) - RefundedAmountCents`; refuse if already `PartiallyRefunded`; ideally
+route all ScholarshipProviderReview money through one authority/idempotency key.
+
+### C3. ScholarshipProviderReview money can **strand** — `Payment.RelatedApplicationId` is an optional client value
+`StartScholarshipProviderReviewRequestCommand.cs:270` sets `RelatedApplicationId = request.ApplicationTrackerId` (nullable —
+Apply-Now can run before the tracker exists). Every non-request-lifecycle money op (`CaptureScholarshipProviderReviewPayment`,
+`RejectScholarshipProviderReviewPayment`, `RefundScholarshipProviderReview`, `WithdrawApplication`, `ScholarshipProviderReviewTimeoutRefundJob`)
+finds the payment by `RelatedApplicationId == app.Id`. If it was null/mismatched, the **14-day timeout refund never
+fires** and the app-Rejected event never cancels the hold → the student's money sits Held/Captured forever
+(`IntegrityCheckJob` already counts these as orphan payments).
+**Fix:** make the Payment↔tracker link mandatory + server-derived, or drive all ScholarshipProviderReview money through the request lifecycle.
+
+### C4. No-show resolution (my PB-006R code) is **not atomic + penalty not idempotent + refund doesn't handle uncaptured/partial**
+`ResolveNoShowReportCommand.cs`: (a) it commits the report as resolved, then applies the rating deduction in a
+**separate** save — a failure between them leaves the report `Validated` with **no penalty applied** (and a manual
+retry is blocked by the `PendingReview` guard, so the penalty is permanently lost). `ApplyPenaltyFactorAsync`
+has no "already applied for this event" marker. (b) `RefundStudentAsync` refunds full `AmountCents` without
+checking `Payment.Status == Captured` (a `Held`/authorized intent → Stripe 400 → the report can never be resolved)
+and without netting `RefundedAmountCents`.
+**Fix:** wrap resolution (state + penalty + refund) in one transaction; stamp the report with an applied-penalty
+marker for idempotency; mirror `CancelBookingCommandHandler`'s captured-vs-authorized refund branching + net prior refunds.
+
+### C5. Notification idempotency is check-then-act with a **non-unique** index → duplicate notifications/emails
+`NotificationDispatcher.cs:29-33` does `if (!AnyAsync(key)) insert`; the `IdempotencyKey` index (`EntityConfigurations.cs:958`)
+is not unique. Two concurrent dispatches with the same key (overlapping job runs, sweep + manual mark, webhook re-delivery)
+both pass and both insert. The "exactly once" the whole job layer relies on is not enforced.
+**Fix:** `HasIndex(n => n.IdempotencyKey).IsUnique().HasFilter("[IdempotencyKey] IS NOT NULL")` + catch 2601/2627 as a no-op.
+
+### C6. `ChangeUserRole` has **no privilege-tier guard** — an Admin can self-escalate to SuperAdmin
+`ChangeUserRoleCommandHandler.cs` (gated only by controller `[Authorize(Roles="Admin,SuperAdmin")]`) lets an
+`active_role == Admin` account `POST /admin/users/{ownId}/roles {Role:"SuperAdmin", Add}` and vertically escalate,
+or grant Admin/SuperAdmin to anyone. No higher-tier-only or no-self-target rule.
+**Fix:** require `active_role == "SuperAdmin"` to add/remove Admin or SuperAdmin; forbid changing one's own roles.
+
+---
+
+## 🟠 High — correctness / consistency
+
+### H1. Country filter is an unbounded substring match (same class as the fixed field-of-study `&` bug)
+`GetScholarships` country filter uses raw `.Contains(request.Country)` → `"oman"` matches `["Romania"]`, `"United"`
+matches UK/US/UAE. **Fix:** mirror the field-of-study fix — `.Contains(JsonSerializer.Serialize(country.Trim()))`.
+
+### H2. `UpdateScholarship` has no deadline re-check
+Create/Approve/Reopen enforce the 7-day rule; `UpdateScholarshipCommand` sets `Deadline` with no validation → an
+admin-owned Open listing can be edited to a past deadline and stay Open. **Fix:** add the rule to the update validator.
+
+### H3. `PaymentCapturedEvent` is **never raised** → PB-018 analytics stream is dead
+Defined + a stream handler consumes it, but `grep "new PaymentCapturedEvent"` = 0. The webhook flips to `Captured`
+without raising it. Revenue analytics from that stream are incomplete. **Fix:** raise it from `payment_intent.succeeded`.
+
+### H4. `ScholarshipProviderReviewTimeoutRefundJob` — per-iteration Stripe refunds, single terminal `SaveChanges` (+ N+1)
+If the process dies mid-loop, Stripe refunded N payments but **zero** DB rows persisted → reprocessed next run.
+**Fix:** `SaveChanges` per application inside the loop; batch-load payments (one query, not per-app `FirstOrDefault`).
+
+### H5. `ConsultantLowRatingFlaggedAt` is set but **never cleared** anywhere
+No command sets it back to null (`ReinstateBookingIntake` clears only `BookingIntakeSuspendedAt`). The flag is
+permanent, and because re-notify requires it to be null, admins are alerted **once ever** — a recovered-then-dropped
+consultant never re-alerts. **Fix:** add an admin clear (or clear on reinstate / on recovery above threshold).
+
+### H6. Two low-rating mechanisms use inconsistent inputs
+Admin flag = penalized lifetime average, min 1 review; intake-suspend = raw last-20 average, min 5. They routinely
+disagree, and the flag can fire on a single noisy review. **Fix:** align both on the same basis + minimum sample.
+
+### H7. SuperAdmin RBAC seam — many handlers `IsInRole("Admin")` without `SuperAdmin`; refresh drops role claims
+Because `RoleClaimType = "active_role"`, a session acting as SuperAdmin fails handlers that check only `"Admin"`
+(GetPayment, RefundPayment, Approve/RejectScholarship, all Resources admin cmds, GetFlaggedPosts, DismissPostFlags,
+Hide*Review) → spurious 403 (safe-failing, but broken for a SuperAdmin operator). Separately, `TokenService.RotateRefreshTokenAsync`
+reissues with an empty role list, so after a refresh `DeletePostCommand.cs:29` (`currentUser.Roles.Contains("Admin")`)
+fails even for a legit Admin. **Fix:** standardise on an `IsAdminOrSuperAdmin()` helper everywhere; carry roles through the refresh rotation.
+
+### H8. `CompletionJob` can auto-complete a one-party-joined booking before the sweep files a no-show
+If the no-show sweep lags > 6h (deploy/outage), a one-sided-join booking crosses the 6h line and `CompletionJob`
+marks it `Completed` (full payment retained), permanently closing the no-show remedy. **Fix:** CompletionJob should
+skip/route one-party-joined bookings (require both-or-neither joined) or the sweep must run before completion age.
+
+### H9. Dead `ScholarshipProviderReviewPayment` table + its webhook branch (two payment models for one concept)
+`ProcessStripeWebhookCommand.ApplyToScholarshipProviderReviewPaymentAsync` operates on a legacy table the active flow no longer
+writes. **Fix:** delete the entity + branch (confirm no seed/migration writes it).
+
+---
+
+## 🟡 Medium / low
+
+- **Submit doc validation is positional parallel-array** (`SubmitApplicationCommand.cs:64-75`) — a client sending
+  documents in a different order can pass the wrong doc for a required slot. Use a keyed `{docType: fileName}` map.
+- **Chat SignalR stale-token closure** (`lib/signalr.ts:11`) — auto-reconnect re-auths with the captured (old) token
+  after rotation; use the live-store reader like `services/signalR/hubs.ts`.
+- **Soft-deleted `NoShowReport` blocks re-report** — unique index `UX_NoShowReports_Booking_Accused` isn't filtered on
+  `IsDeleted`; add `.HasFilter("[IsDeleted] = 0")` (latent — no delete path today).
+- **No-show refund notification** reuses `payment-refund:{id}` key → a 2nd refund on a payment sends no notice.
+- **PII encryption scope** — `OrganizationTaxNumber`/`OrganizationRegistrationNumber`/`ContactPhoneNumber` are plaintext-at-rest
+  (TDE only); extend the AES-GCM converter if defence-in-depth is intended.
+- **Redaction sampling job** scans `AiInteractions` with no `(Feature, StartedAt)` index (fine at current volume).
+- **Admin-notify fan-out** — O(admins) round-trips + 2 saves each per alert; batch into one `AddRange`+save.
+- **Frontend polish:** `text-error-600` is a non-existent token (asterisks render uncolored) → `text-danger-500`;
+  self-vote button on own root post not disabled (server-rejected → toast); free-path Submit button lacks a
+  double-click guard (409 toast); dead `ApplyConfirmation.tsx` has a hardcoded English disclaimer (delete);
+  no unsaved-changes navigation guard on draft/profile forms; `formatUsd` hardcodes `$`+Western digits.
+
+---
+
+## Verified sound (checked, no action) — so they're not re-audited
+Refund idempotency keys + rounding (remainder-to-payee, no leak); free-mode skips Stripe cleanly; webhook
+`StripeEventId` unique + re-query; `StripePayoutJob` pre-claim + RowVersion + DisableConcurrentExecution;
+`FlagPostCommand` RowVersion retry loop; soft-delete query filters + GDPR `IgnoreQueryFilters`; domain events
+dispatch after commit; all filtered unique indexes match their predicates; refresh reuse-detection (revoke-family);
+SSO external-link-first + signed state; login lockout 5/15→30; UpdateProfile mass-assignment defence; IDOR ownership
+on documents/recordings/bookings/payments/chat + ChatHub participant gate; prod-safe exception handler; RS256-only JWT;
+booking-overlap SERIALIZABLE re-check + unique slot index; client crash-guards + mutation onError coverage + Stripe
+double-charge guards.

--- a/server/src/ScholarPath.Application/Admin/Commands/ResolveNoShowReport/ResolveNoShowReportCommand.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/ResolveNoShowReport/ResolveNoShowReportCommand.cs
@@ -78,6 +78,43 @@ public sealed class ResolveNoShowReportCommandHandler(
             ?? throw new NotFoundException(nameof(ConsultantBooking), report.BookingId);
 
         var nowUtc = DateTimeOffset.UtcNow;
+
+        // Apply the whole resolution ATOMICALLY: report status + booking status +
+        // student block + Stripe refund/ledger + consultant rating deduction must all
+        // commit together or all roll back. Without this, a mid-way DB failure could
+        // leave the report Validated but the −40%/−70% penalty unapplied — and the
+        // PendingReview guard would then block any retry, losing the penalty forever.
+        // The transaction also makes the compounding rating factor idempotent under an
+        // execution-strategy retry: a rollback undoes the factor multiply, and the
+        // Stripe refund is idempotency-keyed, so a retry never double-charges.
+        if (db.Database.IsRelational())
+        {
+            var strategy = db.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
+            {
+                await using var tx = await db.Database.BeginTransactionAsync(ct);
+                await ApplyResolutionAsync(report, booking, command, adminId, nowUtc, ct);
+                await tx.CommitAsync(ct);
+            });
+        }
+        else
+        {
+            // InMemory (unit tests) has no transaction support — apply directly.
+            await ApplyResolutionAsync(report, booking, command, adminId, nowUtc, ct);
+        }
+
+        logger.LogInformation(
+            "Admin {AdminId} resolved no-show report {ReportId} as {Verdict} (accused {Role}).",
+            adminId, report.Id, report.Status, report.AccusedRole);
+
+        // Party notifications are a post-commit side effect (never rolled back).
+        await NotifyPartiesAsync(report, ct);
+    }
+
+    private async Task ApplyResolutionAsync(
+        NoShowReport report, ConsultantBooking booking, ResolveNoShowReportCommand command,
+        Guid adminId, DateTimeOffset nowUtc, CancellationToken ct)
+    {
         Guid? consultantToDeduct = null;
         decimal deductionFactor = 1m;
 
@@ -129,18 +166,12 @@ public sealed class ResolveNoShowReportCommandHandler(
 
         await db.SaveChangesAsync(ct);
 
-        // Apply the rating deduction last — ApplyPenaltyFactorAsync recomputes the
-        // snapshot and commits, so all prior tracked changes persist with it.
+        // Rating deduction runs inside the same transaction (ApplyPenaltyFactorAsync
+        // recomputes the snapshot and commits) — so it rolls back with everything else.
         if (consultantToDeduct is { } consultantId)
         {
             await ratingService.ApplyPenaltyFactorAsync(consultantId, deductionFactor, ct);
         }
-
-        logger.LogInformation(
-            "Admin {AdminId} resolved no-show report {ReportId} as {Verdict} (accused {Role}).",
-            adminId, report.Id, report.Status, report.AccusedRole);
-
-        await NotifyPartiesAsync(report, ct);
     }
 
     private async Task BlockStudentAsync(
@@ -169,20 +200,52 @@ public sealed class ResolveNoShowReportCommandHandler(
             throw new ConflictException("Booking has no Stripe payment intent to refund.");
         }
 
-        // Refund the amount actually captured (the Payment row is authoritative).
-        var amountCents = booking.Payment is { } capturedPayment
-            ? capturedPayment.AmountCents
-            : (long)decimal.Round(booking.PriceUsd * 100m, 0, MidpointRounding.AwayFromZero);
+        var payment = booking.Payment;
+        var reason = CancellationReason.ConsultantNoShow.ToString();
+        var nowUtc = DateTimeOffset.UtcNow;
 
-        if (amountCents < 0)
+        // Already terminal (a prior path fully refunded/cancelled) — nothing to do.
+        if (payment is { Status: PaymentStatus.Refunded or PaymentStatus.Cancelled })
         {
-            throw new ConflictException("Booking amount cannot be negative.");
+            return;
+        }
+
+        // Held/authorized-but-not-captured → cancel the intent (Stripe rejects a
+        // Refund on an un-captured charge). Mirrors CancelBookingCommandHandler.
+        if (payment is { Status: PaymentStatus.Held or PaymentStatus.Pending })
+        {
+            var cancelResult = await stripe.CancelPaymentIntentAsync(
+                paymentIntentId: booking.StripePaymentIntentId,
+                cancellationReason: reason,
+                idempotencyKey: $"booking-noshow-cancel:{booking.Id:N}",
+                ct: ct);
+
+            if (string.IsNullOrWhiteSpace(cancelResult.Id))
+            {
+                throw new ConflictException("Stripe payment-intent cancellation failed.");
+            }
+
+            payment.Status = PaymentStatus.Cancelled;
+            payment.FailureReason = "consultant_no_show_before_capture";
+            return;
+        }
+
+        // Captured (or a payment-less priced booking) → refund the OUTSTANDING amount,
+        // net of any prior partial refund, so we never over-refund on Stripe.
+        var gross = payment?.AmountCents
+            ?? (long)decimal.Round(booking.PriceUsd * 100m, 0, MidpointRounding.AwayFromZero);
+        var alreadyRefunded = payment?.RefundedAmountCents ?? 0;
+        var refundable = gross - alreadyRefunded;
+
+        if (refundable <= 0)
+        {
+            return; // already fully refunded — idempotent
         }
 
         var refundResult = await stripe.RefundPaymentAsync(
             paymentIntentId: booking.StripePaymentIntentId,
-            amountCents: amountCents,
-            reason: CancellationReason.ConsultantNoShow.ToString(),
+            amountCents: refundable,
+            reason: reason,
             idempotencyKey: $"booking-noshow-refund:{booking.Id:N}",
             ct: ct);
 
@@ -191,12 +254,12 @@ public sealed class ResolveNoShowReportCommandHandler(
             throw new ConflictException("Stripe refund failed.");
         }
 
-        if (booking.Payment is { } payment)
+        if (payment is not null)
         {
             payment.Status = PaymentStatus.Refunded;
-            payment.RefundedAmountCents = payment.AmountCents;
-            payment.RefundedAt = DateTimeOffset.UtcNow;
-            payment.RefundReason = CancellationReason.ConsultantNoShow.ToString();
+            payment.RefundedAmountCents = gross; // fully refunded now
+            payment.RefundedAt = nowUtc;
+            payment.RefundReason = reason;
             payment.ProfitShareAmountCents = 0;
             payment.PayeeAmountCents = 0;
         }

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviewRequests/Commands/Start/StartScholarshipProviderReviewRequestCommand.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviewRequests/Commands/Start/StartScholarshipProviderReviewRequestCommand.cs
@@ -103,6 +103,26 @@ public sealed class StartScholarshipProviderReviewRequestCommandHandler(
         if (scholarship.OwnerScholarshipProviderId == studentId)
             throw new ConflictException("A ScholarshipProvider cannot start a paid review request for its own scholarship.");
 
+        // Server-derive the application link — never trust the optional client-supplied
+        // ApplicationTrackerId blindly. The payment's RelatedApplicationId is how the
+        // timeout-refund job and the capture/refund event handlers locate the money, so
+        // a null/wrong link strands a held/captured fee (it can never be released).
+        // Validate a provided id belongs to this student + scholarship, else fall back
+        // to the student's own most-recent application for this scholarship.
+        Guid? applicationTrackerId = request.ApplicationTrackerId;
+        if (applicationTrackerId is { } clientTracker)
+        {
+            var belongsToStudent = await db.Applications.AnyAsync(
+                a => a.Id == clientTracker && a.StudentId == studentId
+                     && a.ScholarshipId == request.ScholarshipId && !a.IsDeleted, ct);
+            if (!belongsToStudent) applicationTrackerId = null;
+        }
+        applicationTrackerId ??= await db.Applications
+            .Where(a => a.StudentId == studentId && a.ScholarshipId == request.ScholarshipId && !a.IsDeleted)
+            .OrderByDescending(a => a.CreatedAt)
+            .Select(a => (Guid?)a.Id)
+            .FirstOrDefaultAsync(ct);
+
         // Master switch: when payments are off, treat every request as free
         // regardless of the stored fee — money never moves on this platform
         // until the admin re-enables payments. This also lets legacy listings
@@ -189,7 +209,7 @@ public sealed class StartScholarshipProviderReviewRequestCommandHandler(
                 StudentId = studentId,
                 ScholarshipProviderId = companyId,
                 ScholarshipId = scholarship.Id,
-                ApplicationTrackerId = request.ApplicationTrackerId,
+                ApplicationTrackerId = applicationTrackerId,
                 PaymentId = null,
                 Status = ScholarshipProviderReviewRequestStatus.Pending,
                 ReviewFeeUsdSnapshot = 0m,
@@ -267,7 +287,7 @@ public sealed class StartScholarshipProviderReviewRequestCommandHandler(
             StripePaymentIntentId = stripeResult.Id,
             StripeChargeId = stripeResult.LatestChargeId,
             IdempotencyKey = idempotencyKey,
-            RelatedApplicationId = request.ApplicationTrackerId,
+            RelatedApplicationId = applicationTrackerId,
         };
 
         var entity = new ScholarshipProviderReviewRequest

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/RefundScholarshipProviderReview/RefundScholarshipProviderReviewCommand.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/RefundScholarshipProviderReview/RefundScholarshipProviderReviewCommand.cs
@@ -94,10 +94,23 @@ public sealed class RefundScholarshipProviderReviewCommandHandler(
             }
             else
             {
-                // PATH B — Captured / PartiallyRefunded: Stripe Refund.
+                // PATH B — Captured / PartiallyRefunded: Stripe Refund. BOTH the full
+                // and the 50% target NET OUT any refund a different path already issued
+                // (e.g. CancelScholarshipProviderReviewRequest's 50%) — a "50% refund" means "refund
+                // up to 50% total", not "an additional 50%". Without this, a Cancel (50%)
+                // followed by a Withdraw (partial) double-refunds toward the full charge.
                 var refundAmountCents = request.IsFullRefund
                     ? payment.AmountCents - payment.RefundedAmountCents
-                    : payment.AmountCents / 2;
+                    : Math.Max(0, payment.AmountCents / 2 - payment.RefundedAmountCents);
+
+                if (refundAmountCents <= 0)
+                {
+                    // Already refunded to (at least) the target amount — idempotent no-op.
+                    logger.LogInformation(
+                        "ScholarshipProviderReview payment {PaymentId} already refunded to target; no further refund.",
+                        payment.Id);
+                    return true;
+                }
 
                 if (payment.RefundedAmountCents + refundAmountCents > payment.AmountCents)
                 {

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/ResolveNoShowReportTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/ResolveNoShowReportTests.cs
@@ -39,6 +39,9 @@ public sealed class ResolveNoShowReportTests : IDisposable
         _stripe.RefundPaymentAsync(Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<string?>(),
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new StripeRefundResult("re_test", "succeeded", 10000));
+        _stripe.CancelPaymentIntentAsync(Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new StripePaymentIntentResult("pi_test", "canceled", null, null));
     }
 
     private ResolveNoShowReportCommandHandler Sut()
@@ -51,7 +54,9 @@ public sealed class ResolveNoShowReportTests : IDisposable
             Options.Create(new BookingOptions()), NullLogger<ResolveNoShowReportCommandHandler>.Instance);
     }
 
-    private async Task<Guid> SeedAsync(NoShowAccusedRole accusedRole, bool withPayment = false)
+    private async Task<Guid> SeedAsync(
+        NoShowAccusedRole accusedRole, bool withPayment = false,
+        PaymentStatus paymentStatus = PaymentStatus.Captured)
     {
         _db.UserProfiles.Add(new UserProfile { UserId = _studentId });
         _db.UserProfiles.Add(new UserProfile { UserId = _consultantId });
@@ -74,7 +79,7 @@ public sealed class ResolveNoShowReportTests : IDisposable
             {
                 Id = Guid.NewGuid(),
                 Type = PaymentType.ConsultantBooking,
-                Status = PaymentStatus.Captured,
+                Status = paymentStatus,
                 AmountCents = 10000,
                 Currency = "USD",
                 IdempotencyKey = "ik-" + Guid.NewGuid().ToString("N"),
@@ -170,6 +175,26 @@ public sealed class ResolveNoShowReportTests : IDisposable
         var consultant = await ProfileAsync(_consultantId);
         consultant.ConsultantRatingPenaltyFactor.Should().Be(0.30m); // −70%
         (await _db.Bookings.AsNoTracking().FirstAsync()).Status.Should().Be(BookingStatus.Completed);
+    }
+
+    [Fact]
+    public async Task Validated_consultant_no_show_on_an_uncaptured_payment_cancels_the_intent()
+    {
+        // Webhook lag: the booking is Confirmed but the payment is still Held (not
+        // captured). Refunding an un-captured intent would 400 on Stripe and block the
+        // admin from ever resolving — instead we must cancel the intent.
+        var reportId = await SeedAsync(NoShowAccusedRole.Consultant, withPayment: true,
+            paymentStatus: PaymentStatus.Held);
+
+        await Sut().Handle(new ResolveNoShowReportCommand(reportId, IsValid: true, null), default);
+
+        var payment = await _db.Payments.AsNoTracking().FirstAsync();
+        payment.Status.Should().Be(PaymentStatus.Cancelled);
+        (await _db.Bookings.AsNoTracking().FirstAsync()).Status.Should().Be(BookingStatus.NoShowConsultant);
+        await _stripe.Received(1).CancelPaymentIntentAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _stripe.DidNotReceiveWithAnyArgs().RefundPaymentAsync(
+            default!, default, default!, default!, default);
     }
 
     [Fact]

--- a/server/tests/ScholarPath.UnitTests/ScholarshipProviderReviews/RefundScholarshipProviderReviewCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ScholarshipProviderReviews/RefundScholarshipProviderReviewCommandHandlerTests.cs
@@ -155,6 +155,32 @@ public sealed class RefundScholarshipProviderReviewCommandHandlerTests : IDispos
     }
 
     [Fact]
+    public async Task Partial_refund_is_a_noop_when_already_refunded_to_target()
+    {
+        // Audit C2: a prior path (e.g. CancelScholarshipProviderReviewRequest's 50%) already
+        // refunded half. A subsequent Withdraw-triggered partial refund must NOT issue
+        // another 50% (which would double-refund toward the full charge) — the 50%
+        // target is "refund up to 50% total", so this is a no-op.
+        var appId = Guid.NewGuid();
+        var payment = SeedCapturedPayment(appId, 10_000);
+        payment.Status = PaymentStatus.PartiallyRefunded;
+        payment.RefundedAmountCents = 5_000;
+        _db.Applications.Add(new ApplicationTracker
+        {
+            Id = appId, StudentId = Guid.NewGuid(), Status = ApplicationStatus.UnderReview,
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _handler.Handle(
+            new RefundScholarshipProviderReviewCommand(appId, IsFullRefund: false), default);
+
+        result.Should().BeTrue();
+        payment.RefundedAmountCents.Should().Be(5_000); // unchanged — no second refund
+        await _stripe.DidNotReceiveWithAnyArgs()
+            .RefundPaymentAsync(default!, default, default, default!, default);
+    }
+
+    [Fact]
     public async Task Returns_false_when_no_companyreview_payment_exists()
     {
         var result = await _handler.Handle(


### PR DESCRIPTION
Deep-audit criticals **batch 2/2** — C4 + C2 + C3 (see `docs/DEEP-AUDIT-2026-07-05.md`, added here).

### C4 — no-show resolution atomicity
`ResolveNoShowReport` committed the report then applied the penalty in a separate save → penalty could be lost + retry blocked. Now runs in **one execution-strategy transaction** (rating factor idempotent via rollback; Stripe refund idempotency-keyed). `RefundStudentAsync` now handles **Held** (cancel intent — a refund on an un-captured charge 400'd and made the report unresolvable) vs **Captured** (refund outstanding, net of prior refund).

### C2 — ScholarshipProviderReview double partial-refund
The 50% path computed `AmountCents/2` **without** netting a refund another path already issued → Cancel-then-Withdraw could refund toward the full charge. Both paths now net `RefundedAmountCents` ("refund up to 50% total"); already-met target = idempotent no-op.

### C3 — ScholarshipProviderReview stranded money
`Payment.RelatedApplicationId` (how the timeout-refund job + capture/refund handlers find the money) came from the **optional client** `ApplicationTrackerId` → null/wrong stranded held/captured fees. `Start` now **server-derives** the link (validate a provided id against student+scholarship, else fall back to the student's most-recent application).

### Verification
**882 unit tests green** (+3 across C4/C2 for Held-cancel, partial-net-noop). No migration. This completes all 6 critical deep-audit findings (C1/C5/C6 shipped in #94).