### PR TITLE
fix(payments): raise PaymentCapturedEvent + timeout-job save timing (audit H3/H4)

### DIFF
--- a/docs/SRS-DIAGRAM-AUDIT-2026-07.md
+++ b/docs/SRS-DIAGRAM-AUDIT-2026-07.md
@@ -166,6 +166,45 @@ MediatR handlers — optionally fold those two into their triggering human use c
 - **Submit notifications (part3 SEQ-18):** the submit handler dispatches **two** — `ApplicationSubmittedConfirmation` to the
   **student** (FR-APP-17) + `ApplicationSubmitted` to the company. UC/DESC-18 omit the student confirmation — add it.
 
+## 7. Consultant Booking diagrams (v4) — documentation edits
+
+Reviewed the 43 v4 diagrams against the CURRENT code (incl. the new PB-006R penalty
+system). **The code is correct** (the penalty system was just built + shipped + audited);
+these are SRS/PlantUML edits for you. No `System`-actor violations (the machine-initiated
+UCs correctly use event-trigger actors: "Booking Status Change Event", "Booking Expiry
+Trigger", "Session End Trigger", "Reminder Time Trigger", etc.).
+
+### 7.1 Systemic (dominant root cause — fix globally across the write-path sequences)
+- **HTTP status codes:** every booking mutation returns **`204 No Content`** (accept/reject/
+  cancel/no-show/rate/availability), and every booking-rule failure throws `BookingDomainException`
+  → **`422`** (not 409/403). Booking creation returns **`200`** (not 201). Fix all the
+  `200/201/409/403` labels on SEQ-04/05/07/08/09/12/14 accordingly. (The admin-resolve's
+  already-resolved 409 is the one real 409.)
+
+### 7.2 Specific fixes
+- **SEQ-13 Admin Validate No-Show:** endpoint is `POST /api/admin/no-show-reports/{id}/resolve`
+  → **204** (not `/no-show/{id}/resolve` → 200). Command is `ResolveNoShowReportCommand(reportId,
+  IsValid, AdminNote)` (boolean verdict). Add the missing branches: validated consultant no-show
+  **also fully refunds the student** (diagram only shows −40%); false report sets the booking
+  back to **`Completed`**; already-resolved → **409**.
+- **SEQ-17 Reinstate Intake:** endpoint is `POST /api/admin/users/{userId}/reinstate-booking-intake`
+  → **204**; the command takes no decision arg and only clears `BookingIntakeSuspendedAt`. Delete
+  the fictional "keep restricted" else-branch.
+- **SEQ-16 / ACT-14 low-rating:** the low-rating FLAG (`ConsultantRatingService` → sticky
+  `ConsultantLowRatingFlaggedAt` + admin notify) does NOT stop new bookings. Intake suspension is a
+  **separate** field `BookingIntakeSuspendedAt`, set by the rating-submit handler over the last-20
+  window (min 5 samples) and checked in `RequestBooking`. Don't depict the flag as halting intake.
+- **SEQ-04 Availability:** it's `PATCH /api/bookings/me/availability` on **`BookingsController`**
+  → 204 (not `PUT /availability` on ConsultantsController → 200).
+- **State machine ACT-05 (biggest gap):** use the code enum names (`NoShowStudent`/`NoShowConsultant`)
+  and **add the new `NoShowReported` state**: `Confirmed → NoShowReported` (via report) and
+  `NoShowReported → {NoShowStudent | NoShowConsultant | Completed}` (via admin resolve).
+
+**Correct (no edit):** all 8 use-case diagrams; auto-expire (24h), reminders (24h+1h), complete,
+and cancel-penalty flows (3-day block / −20%) match the code. ~27 of 43 clean.
+
+---
+
 ### 6.4 ✅ Real code bug found & FIXED — withdrawal missing from the status timeline
 `WithdrawApplicationCommandHandler` set `Status=Withdrawn` but (unlike Submit/Review) **never raised
 `ApplicationStatusChangedEvent`**, so `ApplicationStatusHistoryEventHandler` never wrote a StatusHistory row —

--- a/server/src/ScholarPath.Application/Payments/Commands/ProcessStripeWebhook/ProcessStripeWebhookCommand.cs
+++ b/server/src/ScholarPath.Application/Payments/Commands/ProcessStripeWebhook/ProcessStripeWebhookCommand.cs
@@ -186,6 +186,14 @@ public sealed class ProcessStripeWebhookCommandHandler(
                 {
                     payment.StripeChargeId = request.ChargeId;
                 }
+                // PB-018: feed the analytics stream. A manual-capture intent always
+                // fires payment_intent.succeeded exactly once (webhook idempotency on
+                // StripeEventId guarantees single processing), so raise it here rather
+                // than at the various capture call sites — PaymentCapturedStreamHandler
+                // was previously dead because nothing ever raised this event.
+                payment.RaiseDomainEvent(new ScholarPath.Domain.Events.PaymentCapturedEvent(
+                    payment.Id, payment.Type, payment.AmountCents,
+                    payment.PayerUserId, payment.PayeeUserId));
                 await ConfirmBookingAsync(payment.StripePaymentIntentId, ct);
                 break;
 

--- a/server/src/ScholarPath.Infrastructure/Jobs/ScholarshipProviderReviewTimeoutRefundJob.cs
+++ b/server/src/ScholarPath.Infrastructure/Jobs/ScholarshipProviderReviewTimeoutRefundJob.cs
@@ -49,20 +49,26 @@ public sealed class ScholarshipProviderReviewTimeoutRefundJob(
             return;
         }
 
+        // Batch-load the refundable payments for all expired applications in ONE query
+        // (was an N+1 — one FirstOrDefault per application).
+        var appIds = expiredApplications.Select(a => a.Id).ToList();
+        var paymentsByApp = (await db.Payments
+                .Where(p => p.Type == PaymentType.ScholarshipProviderReview
+                            && p.RelatedApplicationId != null
+                            && appIds.Contains(p.RelatedApplicationId.Value)
+                            && (p.Status == PaymentStatus.Held
+                                || p.Status == PaymentStatus.Pending
+                                || p.Status == PaymentStatus.Captured))
+                .ToListAsync(ct)
+                .ConfigureAwait(false))
+            .GroupBy(p => p.RelatedApplicationId!.Value)
+            .ToDictionary(g => g.Key, g => g.First());
+
         int refunded = 0;
 
         foreach (var app in expiredApplications)
         {
-            var payment = await db.Payments
-                .FirstOrDefaultAsync(p =>
-                    p.Type == PaymentType.ScholarshipProviderReview
-                    && p.RelatedApplicationId == app.Id
-                    && (p.Status == PaymentStatus.Held
-                        || p.Status == PaymentStatus.Pending
-                        || p.Status == PaymentStatus.Captured),
-                    ct);
-
-            if (payment is null) continue;
+            if (!paymentsByApp.TryGetValue(app.Id, out var payment)) continue;
             if (string.IsNullOrWhiteSpace(payment.StripePaymentIntentId)) continue;
 
             try
@@ -115,6 +121,13 @@ public sealed class ScholarshipProviderReviewTimeoutRefundJob(
                     payment.PayeeAmountCents = retainedSplit.PayeeNetCents;
                 }
 
+                // Persist THIS application's refund immediately — each refund is its own
+                // unit of work. Previously a single SaveChanges after the whole loop meant
+                // a mid-loop crash left Stripe having refunded N payments while zero DB rows
+                // were saved (they'd be reprocessed next run — safe via the Stripe idempotency
+                // key, but fragile). Saving per iteration bounds that window to one row.
+                await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
                 await notifications.DispatchAsync(
                     app.StudentId,
                     NotificationType.ScholarshipProviderReviewRefunded,
@@ -133,7 +146,6 @@ public sealed class ScholarshipProviderReviewTimeoutRefundJob(
             }
         }
 
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
         logger.LogInformation(
             "ScholarshipProviderReviewTimeoutRefundJob — scanned {Scanned} expired applications, refunded {Refunded}.",
             expiredApplications.Count, refunded);


### PR DESCRIPTION
Backend-only hardening of the deferred payments feature (money UI stays fully hidden in free mode — this fixes internals per "solve its problems, don't show it").

- **H3** — `PaymentCapturedEvent` had a stream handler (PB-018 analytics) but was **never raised** → dead pipeline. Now raised from the `payment_intent.succeeded` webhook (fires exactly once per capture; payment is tracked so it dispatches on SaveChanges).
- **H4** — `ScholarshipProviderReviewTimeoutRefundJob` refunded per-application on Stripe but SaveChanged **once after the whole loop** (crash → Stripe refunded N, 0 DB rows saved) + N+1 lookup. Now **batch-loads** payments in one query and **saves per application**.
- **H9 deferred** (documented): the legacy `ScholarshipProviderReviewPayment` webhook branch — the seeder still writes that table, so removal needs a dedicated cleanup + table-drop.

Also appends the **Consultant-Booking v4 diagram** corrections to `docs/SRS-DIAGRAM-AUDIT-2026-07.md` (204/422 status codes, admin resolve/reinstate endpoints, missing `NoShowReported` state).

**882 unit tests green.** No migration, no UI change.