### PR TITLE
fix(audit): scholarship/consultant HIGH items (H1/H5/H6/H8 + indexes)

### DIFF
--- a/server/src/ScholarPath.Application/Admin/Commands/ReinstateBookingIntake/ReinstateBookingIntakeCommand.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/ReinstateBookingIntake/ReinstateBookingIntakeCommand.cs
@@ -35,9 +35,15 @@ public sealed class ReinstateBookingIntakeCommandHandler(IApplicationDbContext d
             .FirstOrDefaultAsync(u => u.Id == request.ConsultantId, ct)
             ?? throw new NotFoundException("User", request.ConsultantId);
 
-        if (consultant.Profile?.BookingIntakeSuspendedAt is not null)
+        // Clear BOTH the intake suspension AND the sticky low-rating admin flag —
+        // an admin reinstating a consultant has reviewed them, so the flag (which
+        // otherwise is never cleared anywhere, keeping the consultant permanently in
+        // the low-rated queue and suppressing all future re-alerts) is resolved here too.
+        if (consultant.Profile is { } profile
+            && (profile.BookingIntakeSuspendedAt is not null || profile.ConsultantLowRatingFlaggedAt is not null))
         {
-            consultant.Profile.BookingIntakeSuspendedAt = null;
+            profile.BookingIntakeSuspendedAt = null;
+            profile.ConsultantLowRatingFlaggedAt = null;
             await db.SaveChangesAsync(ct);
         }
     }

--- a/server/src/ScholarPath.Application/ConsultantBookings/ConsultantRatingThresholds.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/ConsultantRatingThresholds.cs
@@ -20,10 +20,12 @@ public static class ConsultantRatingThresholds
 
     /// <summary>
     /// Minimum number of visible reviews required before the penalized-average
-    /// flag check fires. A penalized average needs at least one review to be
-    /// non-null, so 1 matches the literal spec.
+    /// admin flag fires. Set to 5 to match the booking-intake auto-suspend sample
+    /// floor (BookingOptions.LowRatingMinimumSampleSize) — a single noisy 2-star (or
+    /// a penalty on a 1-review consultant) should not put a consultant in the admin
+    /// low-rated queue.
     /// </summary>
-    public const int MinimumReviewsForFlagging = 1;
+    public const int MinimumReviewsForFlagging = 5;
 
     // ── Penalty factors (compounding multipliers on the rating average) ──────────
 

--- a/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsQuery.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsQuery.cs
@@ -95,7 +95,14 @@ public class GetScholarshipsQueryHandler(IApplicationDbContext db, ICurrentUserS
         if (request.DeadlineTo.HasValue) query = query.Where(s => s.Deadline <= request.DeadlineTo);
 
         if (!string.IsNullOrEmpty(request.Country))
-            query = query.Where(s => s.TargetCountriesJson!.Contains(request.Country));
+        {
+            // FR-SCH-14: match the country as a whole JSON-array element (same fix as
+            // the field-of-study filter below) — a raw substring made "oman" match
+            // ["Romania"] and "United" match UK/US/UAE indiscriminately. Serialize the
+            // needle with the same serializer the array was stored with.
+            var countryNeedle = JsonSerializer.Serialize(request.Country);
+            query = query.Where(s => s.TargetCountriesJson!.Contains(countryNeedle));
+        }
 
         if (!string.IsNullOrEmpty(request.FieldOfStudy))
         {

--- a/server/src/ScholarPath.Infrastructure/Jobs/CompletionJob.cs
+++ b/server/src/ScholarPath.Infrastructure/Jobs/CompletionJob.cs
@@ -32,7 +32,14 @@ public sealed class CompletionJob : ICompletionJob
                 b.Status == BookingStatus.Confirmed &&
                 b.ScheduledEndAt <= completionThreshold &&
                 !b.IsNoShowStudent &&
-                !b.IsNoShowConsultant)
+                !b.IsNoShowConsultant &&
+                // Never auto-complete a booking where exactly ONE party joined — that's
+                // a no-show and belongs to MeetingNoShowSweepJob (which files a report).
+                // Completing it here would silently erase the present party's no-show
+                // remedy if the sweep lagged past this 6h threshold. Both-joined or
+                // neither-joined bookings still complete normally.
+                !((b.StudentJoinedAt != null && b.ConsultantJoinedAt == null) ||
+                  (b.StudentJoinedAt == null && b.ConsultantJoinedAt != null)))
             .ToListAsync(cancellationToken);
 
         if (bookings.Count == 0)

--- a/server/src/ScholarPath.Infrastructure/Jobs/MeetingNoShowSweepJob.cs
+++ b/server/src/ScholarPath.Infrastructure/Jobs/MeetingNoShowSweepJob.cs
@@ -31,10 +31,6 @@ public sealed class MeetingNoShowSweepJob : IMeetingNoShowSweepJob
     // still recorded for up to 15 min after end, so 20 min is safely clear.
     private static readonly TimeSpan PostSessionGrace = TimeSpan.FromMinutes(20);
 
-    // Aligns with MarkNoShowCommandHandler's 6-hour manual window and
-    // CompletionJob's 6-hour auto-completion threshold.
-    private static readonly TimeSpan NoShowWindow = TimeSpan.FromHours(6);
-
     public MeetingNoShowSweepJob(
         IApplicationDbContext context,
         INotificationDispatcher notifications,
@@ -49,15 +45,19 @@ public sealed class MeetingNoShowSweepJob : IMeetingNoShowSweepJob
     {
         var nowUtc = DateTimeOffset.UtcNow;
         var endedBefore = nowUtc - PostSessionGrace;
-        var endedAfter = nowUtc - NoShowWindow;
 
+        // No lower age bound: the sweep is the SOLE authority for one-party-joined
+        // bookings (CompletionJob now skips them). Without covering any age, a sweep
+        // outage longer than the old 6h window would strand a one-party-joined booking
+        // in Confirmed forever — CompletionJob won't complete it and the old window
+        // wouldn't re-catch it. The filter (Confirmed + exactly-one-joined) is naturally
+        // small, so scanning older rows is cheap.
         var bookings = await _context.Bookings
             .Where(b =>
                 b.Status == BookingStatus.Confirmed &&
                 !b.IsNoShowStudent &&
                 !b.IsNoShowConsultant &&
                 b.ScheduledEndAt <= endedBefore &&
-                b.ScheduledEndAt > endedAfter &&
                 // exactly one party joined the room
                 ((b.StudentJoinedAt != null && b.ConsultantJoinedAt == null) ||
                  (b.StudentJoinedAt == null && b.ConsultantJoinedAt != null)))

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704232013_AuditHardening_Indexes_H8.Designer.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704232013_AuditHardening_Indexes_H8.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScholarPath.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using ScholarPath.Infrastructure.Persistence;
 namespace ScholarPath.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704232013_AuditHardening_Indexes_H8")]
+    partial class AuditHardening_Indexes_H8
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/ScholarPath.Infrastructure/Migrations/20260704232013_AuditHardening_Indexes_H8.cs
+++ b/server/src/ScholarPath.Infrastructure/Migrations/20260704232013_AuditHardening_Indexes_H8.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScholarPath.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AuditHardening_Indexes_H8 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_NoShowReports_Booking_Accused",
+                table: "NoShowReports");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_NoShowReports_Booking_Accused",
+                table: "NoShowReports",
+                columns: new[] { "BookingId", "AccusedUserId" },
+                unique: true,
+                filter: "[IsDeleted] = 0");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AiInteractions_Feature_StartedAt",
+                table: "AiInteractions",
+                columns: new[] { "Feature", "StartedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_NoShowReports_Booking_Accused",
+                table: "NoShowReports");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AiInteractions_Feature_StartedAt",
+                table: "AiInteractions");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_NoShowReports_Booking_Accused",
+                table: "NoShowReports",
+                columns: new[] { "BookingId", "AccusedUserId" },
+                unique: true);
+        }
+    }
+}

--- a/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
+++ b/server/src/ScholarPath.Infrastructure/Persistence/Configurations/EntityConfigurations.cs
@@ -504,9 +504,14 @@ public sealed class NoShowReportConfiguration : IEntityTypeConfiguration<NoShowR
         b.HasIndex(r => r.Status)
             .HasFilter("[Status] = 'PendingReview'")
             .HasDatabaseName("IX_NoShowReports_PendingReview");
-        // At most one report per (booking, accused party) — prevents duplicates.
+        // At most one LIVE report per (booking, accused party) — prevents duplicates.
+        // Filtered on IsDeleted so it matches the HasQueryFilter above: a soft-deleted
+        // report must not occupy the slot (otherwise the app-level AnyAsync check, which
+        // honours the query filter, would say "no report" while the unfiltered index
+        // still throws a 2601 on re-report).
         b.HasIndex(r => new { r.BookingId, r.AccusedUserId })
             .IsUnique()
+            .HasFilter("[IsDeleted] = 0")
             .HasDatabaseName("UX_NoShowReports_Booking_Accused");
 
         // Two FKs to Users (Reporter + Accused) + one to Booking — explicit
@@ -819,6 +824,9 @@ public sealed class AiInteractionConfiguration : IEntityTypeConfiguration<AiInte
         b.Property(a => a.RowVersion).IsRowVersion();
         b.HasIndex(a => new { a.UserId, a.StartedAt });
         b.HasIndex(a => a.SessionId);
+        // Supports the monthly RedactionAuditSamplingJob's (Feature, StartedAt) scan,
+        // which otherwise full-scans AiInteractions as the table grows.
+        b.HasIndex(a => new { a.Feature, a.StartedAt });
     }
 }
 

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/CompletionJobTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/CompletionJobTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ScholarPath.Domain.Entities;
+using ScholarPath.Domain.Enums;
+using ScholarPath.Infrastructure.Jobs;
+using ScholarPath.Infrastructure.Persistence;
+using Xunit;
+
+namespace ScholarPath.UnitTests.ConsultantBookings;
+
+/// <summary>
+/// Audit H8: CompletionJob must NOT auto-complete a booking where exactly one party
+/// joined — that's a no-show and belongs to MeetingNoShowSweepJob. Completing it here
+/// would silently erase the present party's no-show remedy.
+/// </summary>
+public sealed class CompletionJobTests : IDisposable
+{
+    private readonly ApplicationDbContext _db = new(
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+
+    private CompletionJob Sut() =>
+        new(_db, NullLogger<CompletionJob>.Instance, Substitute.For<IPublisher>());
+
+    private ConsultantBooking Booking(DateTimeOffset? studentJoined, DateTimeOffset? consultantJoined)
+    {
+        var ended = DateTimeOffset.UtcNow.AddHours(-7); // past the 6h completion threshold
+        return new ConsultantBooking
+        {
+            Id = Guid.NewGuid(),
+            StudentId = Guid.NewGuid(),
+            ConsultantId = Guid.NewGuid(),
+            Status = BookingStatus.Confirmed,
+            ScheduledStartAt = ended.AddMinutes(-45),
+            ScheduledEndAt = ended,
+            DurationMinutes = 45,
+            StudentJoinedAt = studentJoined,
+            ConsultantJoinedAt = consultantJoined,
+        };
+    }
+
+    [Fact]
+    public async Task Does_not_complete_a_one_party_joined_booking()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var b = Booking(studentJoined: now.AddHours(-8), consultantJoined: null);
+        _db.Bookings.Add(b);
+        await _db.SaveChangesAsync();
+
+        await Sut().RunAsync(default);
+
+        (await _db.Bookings.AsNoTracking().FirstAsync()).Status
+            .Should().Be(BookingStatus.Confirmed); // left for the no-show sweep
+    }
+
+    [Fact]
+    public async Task Completes_a_both_parties_joined_booking()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var b = Booking(studentJoined: now.AddHours(-8), consultantJoined: now.AddHours(-8));
+        _db.Bookings.Add(b);
+        await _db.SaveChangesAsync();
+
+        await Sut().RunAsync(default);
+
+        (await _db.Bookings.AsNoTracking().FirstAsync()).Status
+            .Should().Be(BookingStatus.Completed);
+    }
+
+    public void Dispose() => _db.Dispose();
+}

--- a/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantRatingServiceTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ConsultantBookings/ConsultantRatingServiceTests.cs
@@ -126,7 +126,9 @@ public sealed class ConsultantRatingServiceTests : IDisposable
     public async Task Penalized_average_below_threshold_sets_sticky_flag()
     {
         await SeedProfileAsync(factor: 0.60m);
-        await AddReviewsAsync(4, 4, 4); // raw 4.00 → 2.40 penalized, < 2.5
+        // ≥5 reviews (MinimumReviewsForFlagging) so a real sample, not a single noisy
+        // one, drives the flag. raw 4.00 → 2.40 penalized, < 2.5.
+        await AddReviewsAsync(4, 4, 4, 4, 4);
 
         await _sut.RecalculateSnapshotAsync(_consultantId, default);
         var firstFlag = (await ReloadProfileAsync()).ConsultantLowRatingFlaggedAt;


### PR DESCRIPTION
Deep-audit HIGH batch A (`docs/DEEP-AUDIT-2026-07-05.md`). *(H2 was already fixed — the Update validator re-checks the 7-day deadline.)*

- **H1** — country filter used a raw substring (`"oman"`→`["Romania"]`); now serializes the needle like the field-of-study filter.
- **H5** — `ConsultantLowRatingFlaggedAt` was **never cleared** → permanent flag, admins re-alerted once ever. `ReinstateBookingIntake` now clears it too.
- **H6** — admin flag fired at **1 review** (noisy); raised `MinimumReviewsForFlagging` 1→5 to match the intake-suspend floor.
- **H8** — `CompletionJob` could auto-complete a **one-party-joined** booking (erasing the no-show remedy) if the sweep lagged >6h. CompletionJob now **skips** one-party-joined; the sweep drops its 6h lower bound to be their sole authority at any age. +2 tests.
- 🟡 — `NoShowReport` unique index filtered on `[IsDeleted]=0`; added `(Feature,StartedAt)` index for the redaction job. Migration.

**884 unit tests green.** Deploy deferred until batch B/C land.