### PR TITLE
fix(security): SuperAdmin RBAC seam — admin gates accept SuperAdmin (audit H7)

### DIFF
--- a/server/src/ScholarPath.API/Program.cs
+++ b/server/src/ScholarPath.API/Program.cs
@@ -474,7 +474,8 @@ internal sealed class AdminDashboardAuthorizationFilter : Hangfire.Dashboard.IDa
 
         if (httpCtxProp?.GetValue(context) is Microsoft.AspNetCore.Http.HttpContext http)
         {
-            return http.User.Identity?.IsAuthenticated == true && http.User.IsInRole("Admin");
+            return http.User.Identity?.IsAuthenticated == true
+                && (http.User.IsInRole("Admin") || http.User.IsInRole("SuperAdmin"));
         }
 
         return false;

--- a/server/src/ScholarPath.Application/Admin/Commands/ClearScholarshipProviderLowRatingFlag/ClearScholarshipProviderLowRatingFlagCommand.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/ClearScholarshipProviderLowRatingFlag/ClearScholarshipProviderLowRatingFlagCommand.cs
@@ -44,7 +44,7 @@ public sealed class ClearScholarshipProviderLowRatingFlagCommandHandler(
     public async Task<bool> Handle(
         ClearScholarshipProviderLowRatingFlagCommand command, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException(
                 "Only an administrator can clear the low-rating flag.");

--- a/server/src/ScholarPath.Application/Admin/Commands/ResolveNoShowReport/ResolveNoShowReportCommand.cs
+++ b/server/src/ScholarPath.Application/Admin/Commands/ResolveNoShowReport/ResolveNoShowReportCommand.cs
@@ -55,7 +55,7 @@ public sealed class ResolveNoShowReportCommandHandler(
 
     public async Task Handle(ResolveNoShowReportCommand command, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException("Only an administrator can resolve a no-show report.");
         }

--- a/server/src/ScholarPath.Application/Admin/Queries/GetLowRatedCompanies/GetLowRatedCompaniesQuery.cs
+++ b/server/src/ScholarPath.Application/Admin/Queries/GetLowRatedCompanies/GetLowRatedCompaniesQuery.cs
@@ -37,7 +37,7 @@ public sealed class GetLowRatedCompaniesQueryHandler(
     public async Task<PagedResult<LowRatedScholarshipProviderRow>> Handle(
         GetLowRatedCompaniesQuery request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException();
         }

--- a/server/src/ScholarPath.Application/Admin/Queries/GetPendingNoShowReports/GetPendingNoShowReportsQuery.cs
+++ b/server/src/ScholarPath.Application/Admin/Queries/GetPendingNoShowReports/GetPendingNoShowReportsQuery.cs
@@ -36,7 +36,7 @@ public sealed class GetPendingNoShowReportsQueryHandler(
     public async Task<PagedResult<NoShowReportRow>> Handle(
         GetPendingNoShowReportsQuery request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException();
         }

--- a/server/src/ScholarPath.Application/Analytics/Queries/GetScholarshipProviderInsights/GetScholarshipProviderInsightsQuery.cs
+++ b/server/src/ScholarPath.Application/Analytics/Queries/GetScholarshipProviderInsights/GetScholarshipProviderInsightsQuery.cs
@@ -64,7 +64,7 @@ public sealed class GetScholarshipProviderInsightsQueryHandler(
         var userId = currentUser.UserId
             ?? throw new ForbiddenAccessException("Not authenticated.");
 
-        var isAdmin = currentUser.IsInRole("Admin") || currentUser.IsInRole("SuperAdmin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
 
         // Admins may supply a ScholarshipProviderId, owners default to themselves.
         var companyId = request.ScholarshipProviderId ?? userId;

--- a/server/src/ScholarPath.Application/Applications/Queries/GetApplicationDetail/GetApplicationDetailQuery.cs
+++ b/server/src/ScholarPath.Application/Applications/Queries/GetApplicationDetail/GetApplicationDetailQuery.cs
@@ -76,7 +76,7 @@ public sealed class GetApplicationDetailQueryHandler(
             return null;
 
         // Only the owning student or an administrator may view an application.
-        if (application.StudentId != userId && !currentUser.IsInRole("Admin"))
+        if (application.StudentId != userId && !currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException();
 
         var scholarship = application.Scholarship;

--- a/server/src/ScholarPath.Application/Community/Commands/DeletePost/DeletePostCommand.cs
+++ b/server/src/ScholarPath.Application/Community/Commands/DeletePost/DeletePostCommand.cs
@@ -25,8 +25,11 @@ public sealed class DeletePostCommandHandler(
             .FirstOrDefaultAsync(p => p.Id == request.PostId && !p.IsDeleted, ct)
             ?? throw new NotFoundException(nameof(ForumPost), request.PostId);
 
-        // Allow author or admin to delete
-        var isAdmin = currentUser.Roles?.Contains("Admin") == true;
+        // Allow author or admin to delete. Use IsInRole (the active_role claim) not
+        // the full Roles list — a refresh-rotated token carries active_role but not the
+        // ClaimTypes.Role set, so `currentUser.Roles.Contains("Admin")` wrongly failed
+        // for a legit admin after a token refresh.
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
         if (post.AuthorId != currentUser.UserId && !isAdmin)
             throw new ForbiddenAccessException();
 

--- a/server/src/ScholarPath.Application/Community/Commands/DismissPostFlags/DismissPostFlagsCommand.cs
+++ b/server/src/ScholarPath.Application/Community/Commands/DismissPostFlags/DismissPostFlagsCommand.cs
@@ -30,7 +30,7 @@ public sealed class DismissPostFlagsCommandHandler(
 {
     public async Task<bool> Handle(DismissPostFlagsCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can moderate the community.");
 
         var adminId = currentUser.UserId

--- a/server/src/ScholarPath.Application/Community/Queries/GetFlaggedPosts/GetFlaggedPostsQuery.cs
+++ b/server/src/ScholarPath.Application/Community/Queries/GetFlaggedPosts/GetFlaggedPostsQuery.cs
@@ -53,7 +53,7 @@ public sealed class GetFlaggedPostsQueryHandler(
 
     public async Task<PagedResult<FlaggedPostDto>> Handle(GetFlaggedPostsQuery request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can moderate the community.");
 
         var page = Math.Max(1, request.Page);

--- a/server/src/ScholarPath.Application/ConsultantBookings/Commands/HideConsultantReview/HideConsultantReviewCommand.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Commands/HideConsultantReview/HideConsultantReviewCommand.cs
@@ -49,7 +49,7 @@ public sealed class HideConsultantReviewCommandHandler(
 {
     public async Task<bool> Handle(HideConsultantReviewCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can moderate reviews.");
 
         var review = await db.ConsultantReviews

--- a/server/src/ScholarPath.Application/ConsultantBookings/Queries/DownloadSessionRecording/DownloadSessionRecordingQuery.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Queries/DownloadSessionRecording/DownloadSessionRecordingQuery.cs
@@ -39,7 +39,7 @@ public sealed class DownloadSessionRecordingQueryHandler(
             ?? throw new NotFoundException(nameof(ConsultantBooking), recording.BookingId);
 
         var isParticipant = booking.StudentId == userId || booking.ConsultantId == userId;
-        var isAdmin = currentUser.IsInRole("Admin") || currentUser.IsInRole("SuperAdmin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
         if (!isParticipant && !isAdmin)
         {
             throw new ForbiddenAccessException("You are not allowed to download this recording.");

--- a/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetAllBookings/GetAllBookingsQuery.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetAllBookings/GetAllBookingsQuery.cs
@@ -29,8 +29,7 @@ public sealed class GetAllBookingsQueryHandler(
         // SEC-03: only platform admins may list every booking. ScholarshipProvider
         // was previously allowed but has no ownership path to a booking, so it
         // leaked all students'/consultants' bookings platform-wide.
-        var isPrivileged = currentUser.IsInRole("Admin")
-            || currentUser.IsInRole("SuperAdmin");
+        var isPrivileged = currentUser.IsAdminOrSuperAdmin();
 
         if (!isPrivileged)
             throw new ForbiddenAccessException("Only admins can view all bookings.");

--- a/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetBookingById/GetBookingByIdQuery.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetBookingById/GetBookingByIdQuery.cs
@@ -83,8 +83,7 @@ public sealed class GetBookingByIdQueryHandler(
         // the entity), so it must not read arbitrary booking detail (payment
         // amounts, refund reason, Stripe intent id, student notes/email). Matches
         // the policy already used by GetBookingRecordings / DownloadSessionRecording.
-        var isAdmin = currentUser.IsInRole("Admin")
-            || currentUser.IsInRole("SuperAdmin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
 
         if (!isParticipant && !isAdmin)
         {

--- a/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetBookingRecordings/GetBookingRecordingsQuery.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Queries/GetBookingRecordings/GetBookingRecordingsQuery.cs
@@ -39,7 +39,7 @@ public sealed class GetBookingRecordingsQueryHandler(
             ?? throw new NotFoundException(nameof(ConsultantBooking), request.BookingId);
 
         var isParticipant = booking.StudentId == userId || booking.ConsultantId == userId;
-        var isAdmin = currentUser.IsInRole("Admin") || currentUser.IsInRole("SuperAdmin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
         if (!isParticipant && !isAdmin)
         {
             throw new ForbiddenAccessException(

--- a/server/src/ScholarPath.Application/Documents/Commands/DeleteDocument/DeleteDocumentCommand.cs
+++ b/server/src/ScholarPath.Application/Documents/Commands/DeleteDocument/DeleteDocumentCommand.cs
@@ -41,7 +41,7 @@ public sealed class DeleteDocumentCommandHandler(
             .ConfigureAwait(false)
             ?? throw new NotFoundException(nameof(Document), request.DocumentId);
 
-        var isAdmin = currentUser.IsInRole("Admin") || currentUser.IsInRole("SuperAdmin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
         if (document.OwnerUserId != userId && !isAdmin)
             throw new ForbiddenAccessException("You can only delete your own documents.");
 

--- a/server/src/ScholarPath.Application/Documents/Queries/DownloadDocument/DownloadDocumentQuery.cs
+++ b/server/src/ScholarPath.Application/Documents/Queries/DownloadDocument/DownloadDocumentQuery.cs
@@ -32,7 +32,7 @@ public sealed class DownloadDocumentQueryHandler(
             .ConfigureAwait(false)
             ?? throw new NotFoundException(nameof(Document), request.DocumentId);
 
-        var isAdmin = currentUser.IsInRole("Admin") || currentUser.IsInRole("SuperAdmin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
         if (document.OwnerUserId != userId && !isAdmin)
         {
             // A company reviewer may download documents that are attached to an

--- a/server/src/ScholarPath.Application/Payments/Commands/CapturePaymentIntent/CapturePaymentIntentCommand.cs
+++ b/server/src/ScholarPath.Application/Payments/Commands/CapturePaymentIntent/CapturePaymentIntentCommand.cs
@@ -59,7 +59,7 @@ public sealed class CapturePaymentIntentCommandHandler(
         // routes through this command, so this HTTP-facing command is an admin/ops
         // path. Without this gate any authenticated user could capture any Held
         // payment by guessing its id.
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can capture a payment.");
 
         // 1. Load Held payment — only Held can be captured

--- a/server/src/ScholarPath.Application/Payments/Commands/RefundPayment/RefundPaymentCommand.cs
+++ b/server/src/ScholarPath.Application/Payments/Commands/RefundPayment/RefundPaymentCommand.cs
@@ -60,7 +60,7 @@ public sealed class RefundPaymentCommandHandler(
         CancellationToken ct)
     {
         // Refunds move money — administrators only.
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can issue refunds.");
 
         // 1. Load payment — must be Held or Captured to be refundable

--- a/server/src/ScholarPath.Application/Payments/Queries/GetPayment/GetPaymentQuery.cs
+++ b/server/src/ScholarPath.Application/Payments/Queries/GetPayment/GetPaymentQuery.cs
@@ -57,7 +57,7 @@ public sealed class GetPaymentQueryHandler(
         // Only the payer, the payee, or an admin may read a payment.
         if (payment.PayerUserId != currentUser.UserId
             && payment.PayeeUserId != currentUser.UserId
-            && !currentUser.IsInRole("Admin"))
+            && !currentUser.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException("You can only view your own payments.");
         }

--- a/server/src/ScholarPath.Application/Payments/Queries/GetPayments/GetPaymentsQuery.cs
+++ b/server/src/ScholarPath.Application/Payments/Queries/GetPayments/GetPaymentsQuery.cs
@@ -41,7 +41,7 @@ public sealed class GetPaymentsQueryHandler(
         var query = db.Payments.AsNoTracking().Where(p => !p.IsDeleted);
 
         // Non-admins are scoped to payments they are a party to.
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             query = query.Where(p => p.PayerUserId == userId || p.PayeeUserId == userId);
 
         if (request.Status is { } status)

--- a/server/src/ScholarPath.Application/PlatformSettings/Commands/UpdatePlatformSetting/UpdatePlatformSettingCommand.cs
+++ b/server/src/ScholarPath.Application/PlatformSettings/Commands/UpdatePlatformSetting/UpdatePlatformSettingCommand.cs
@@ -55,7 +55,7 @@ public sealed class UpdatePlatformSettingCommandHandler(
         UpdatePlatformSettingCommand request, CancellationToken ct)
     {
         // Platform settings govern site-wide behaviour — administrators only.
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException(
                 "Only an administrator can change platform settings.");
 

--- a/server/src/ScholarPath.Application/ProfitShare/Commands/SetProfitShareConfig/SetProfitShareConfigCommand.cs
+++ b/server/src/ScholarPath.Application/ProfitShare/Commands/SetProfitShareConfig/SetProfitShareConfigCommand.cs
@@ -57,7 +57,7 @@ public sealed class SetProfitShareConfigCommandHandler(
         SetProfitShareConfigCommand request, CancellationToken ct)
     {
         // Profit-share config governs how money is split — administrators only.
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException(
                 "Only an administrator can change the profit-share configuration.");
 

--- a/server/src/ScholarPath.Application/Resources/Commands/ApproveResource/ApproveResourceCommand.cs
+++ b/server/src/ScholarPath.Application/Resources/Commands/ApproveResource/ApproveResourceCommand.cs
@@ -38,7 +38,7 @@ public sealed class ApproveResourceCommandHandler(
 {
     public async Task<bool> Handle(ApproveResourceCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can approve resources.");
 
         var adminId = currentUser.UserId

--- a/server/src/ScholarPath.Application/Resources/Commands/FeatureResource/FeatureResourceCommand.cs
+++ b/server/src/ScholarPath.Application/Resources/Commands/FeatureResource/FeatureResourceCommand.cs
@@ -38,7 +38,7 @@ public sealed class FeatureResourceCommandHandler(
 
     public async Task<bool> Handle(FeatureResourceCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can feature resources.");
 
         var resource = await db.Resources

--- a/server/src/ScholarPath.Application/Resources/Commands/RejectResource/RejectResourceCommand.cs
+++ b/server/src/ScholarPath.Application/Resources/Commands/RejectResource/RejectResourceCommand.cs
@@ -44,7 +44,7 @@ public sealed class RejectResourceCommandHandler(
 {
     public async Task<bool> Handle(RejectResourceCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can reject resources.");
 
         var adminId = currentUser.UserId

--- a/server/src/ScholarPath.Application/Resources/Commands/SetResourceVisibility/SetResourceVisibilityCommand.cs
+++ b/server/src/ScholarPath.Application/Resources/Commands/SetResourceVisibility/SetResourceVisibilityCommand.cs
@@ -49,7 +49,7 @@ public sealed class SetResourceVisibilityCommandHandler(
 {
     public async Task<bool> Handle(SetResourceVisibilityCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can moderate resources.");
 
         var resource = await db.Resources

--- a/server/src/ScholarPath.Application/Resources/Commands/SubmitResourceForReview/SubmitResourceForReviewCommand.cs
+++ b/server/src/ScholarPath.Application/Resources/Commands/SubmitResourceForReview/SubmitResourceForReviewCommand.cs
@@ -51,7 +51,7 @@ public sealed class SubmitResourceForReviewCommandHandler(
             .FirstOrDefaultAsync(r => r.Id == request.ResourceId, ct)
             ?? throw new NotFoundException(nameof(Resource), request.ResourceId);
 
-        var isAdmin = currentUser.IsInRole("Admin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
         if (resource.AuthorUserId != userId && !isAdmin)
             throw new ForbiddenAccessException("You can only submit your own resources.");
 

--- a/server/src/ScholarPath.Application/Resources/Commands/UpdateResource/UpdateResourceCommand.cs
+++ b/server/src/ScholarPath.Application/Resources/Commands/UpdateResource/UpdateResourceCommand.cs
@@ -77,7 +77,7 @@ public sealed class UpdateResourceCommandHandler(
             .FirstOrDefaultAsync(r => r.Id == request.ResourceId, ct)
             ?? throw new NotFoundException(nameof(Resource), request.ResourceId);
 
-        var isAdmin = currentUser.IsInRole("Admin");
+        var isAdmin = currentUser.IsAdminOrSuperAdmin();
         if (resource.AuthorUserId != userId && !isAdmin)
             throw new ForbiddenAccessException("You can only edit your own resources.");
 

--- a/server/src/ScholarPath.Application/Resources/Queries/GetPendingReviewResources/GetPendingReviewResourcesQuery.cs
+++ b/server/src/ScholarPath.Application/Resources/Queries/GetPendingReviewResources/GetPendingReviewResourcesQuery.cs
@@ -18,7 +18,7 @@ public sealed class GetPendingReviewResourcesQueryHandler(
     public async Task<IReadOnlyList<ResourceListItemDto>> Handle(
         GetPendingReviewResourcesQuery request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can view the review queue.");
 
         var entities = await db.Resources.AsNoTracking()

--- a/server/src/ScholarPath.Application/Resources/Queries/GetResourceDetail/GetResourceDetailQuery.cs
+++ b/server/src/ScholarPath.Application/Resources/Queries/GetResourceDetail/GetResourceDetailQuery.cs
@@ -31,7 +31,7 @@ public sealed class GetResourceDetailQueryHandler(
 
         if (resource.Status != ResourceStatus.Published)
         {
-            var canSeeDraft = currentUser.IsInRole("Admin")
+            var canSeeDraft = currentUser.IsAdminOrSuperAdmin()
                 || (currentUser.UserId is { } uid && uid == resource.AuthorUserId);
             if (!canSeeDraft) return null;
         }

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviewRequests/Commands/Expire/ExpireScholarshipProviderReviewRequestCommand.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviewRequests/Commands/Expire/ExpireScholarshipProviderReviewRequestCommand.cs
@@ -46,7 +46,7 @@ public sealed class ExpireScholarshipProviderReviewRequestCommandHandler(
         ExpireScholarshipProviderReviewRequestCommand command,
         CancellationToken ct)
     {
-        if (!command.SkipOwnerCheck && !currentUser.IsInRole("Admin"))
+        if (!command.SkipOwnerCheck && !currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can manually expire a request.");
 
         var entity = await db.ScholarshipProviderReviewRequests

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviewRequests/Queries/GetById/GetScholarshipProviderReviewRequestByIdQuery.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviewRequests/Queries/GetById/GetScholarshipProviderReviewRequestByIdQuery.cs
@@ -31,7 +31,7 @@ public sealed class GetScholarshipProviderReviewRequestByIdQueryHandler(
         // a confidentiality break.
         if (currentUser.UserId != dto.StudentId
             && currentUser.UserId != dto.ScholarshipProviderId
-            && !currentUser.IsInRole("Admin"))
+            && !currentUser.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException();
         }

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/HideScholarshipProviderReview/HideScholarshipProviderReviewCommand.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/HideScholarshipProviderReview/HideScholarshipProviderReviewCommand.cs
@@ -49,7 +49,7 @@ public sealed class HideScholarshipProviderReviewCommandHandler(
 {
     public async Task<bool> Handle(HideScholarshipProviderReviewCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can moderate reviews.");
 
         var review = await db.ScholarshipProviderReviews

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ApproveScholarship/ApproveScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ApproveScholarship/ApproveScholarshipCommand.cs
@@ -37,7 +37,7 @@ public sealed class ApproveScholarshipCommandHandler(
 {
     public async Task<bool> Handle(ApproveScholarshipCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can approve scholarships.");
 
         var adminId = currentUser.UserId

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ArchiveScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ArchiveScholarshipCommand.cs
@@ -28,7 +28,7 @@ public class ArchiveScholarshipCommandHandler(
         }
 
         // Only the owning company (or an admin) may archive a listing.
-        if (entity.OwnerScholarshipProviderId != user.UserId && !user.IsInRole("Admin"))
+        if (entity.OwnerScholarshipProviderId != user.UserId && !user.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException("You can only archive your own scholarship listings.");
         }

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ConfigureReviewFee/ConfigureReviewFeeCommandHandler.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ConfigureReviewFee/ConfigureReviewFeeCommandHandler.cs
@@ -20,7 +20,7 @@ public sealed class ConfigureReviewFeeCommandHandler(
             ?? throw new NotFoundException(nameof(Domain.Entities.Scholarship), request.ScholarshipId);
 
         // Verify the current user is the owner or an admin
-        if (scholarship.OwnerScholarshipProviderId != currentUser.UserId && !currentUser.IsInRole("Admin"))
+        if (scholarship.OwnerScholarshipProviderId != currentUser.UserId && !currentUser.IsAdminOrSuperAdmin())
         {
             throw new ForbiddenAccessException();
         }

--- a/server/src/ScholarPath.Application/Scholarships/Commands/RejectScholarship/RejectScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/RejectScholarship/RejectScholarshipCommand.cs
@@ -46,7 +46,7 @@ public sealed class RejectScholarshipCommandHandler(
 {
     public async Task<bool> Handle(RejectScholarshipCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can reject scholarships.");
 
         var adminId = currentUser.UserId

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ReopenScholarship/ReopenScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ReopenScholarship/ReopenScholarshipCommand.cs
@@ -49,7 +49,7 @@ public sealed class ReopenScholarshipCommandHandler(
         // Only the owning provider may reopen their listing; admins may reopen any
         // (they own the platform-created external listings).
         if (scholarship.OwnerScholarshipProviderId != userId
-            && !currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+            && !currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("You can only reopen your own scholarships.");
 
         if (scholarship.Status != ScholarshipStatus.Closed)

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ReorderFeaturedScholarships/ReorderFeaturedScholarshipsCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ReorderFeaturedScholarships/ReorderFeaturedScholarshipsCommand.cs
@@ -43,7 +43,7 @@ public sealed class ReorderFeaturedScholarshipsCommandHandler(
     public async Task<Unit> Handle(
         ReorderFeaturedScholarshipsCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can reorder featured scholarships.");
 
         // Load the full current featured set in one round-trip.

--- a/server/src/ScholarPath.Application/Scholarships/Commands/ToggleFeatureScholarship/ToggleFeatureScholarshipCommand.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Commands/ToggleFeatureScholarship/ToggleFeatureScholarshipCommand.cs
@@ -45,7 +45,7 @@ public sealed class ToggleFeatureScholarshipCommandHandler(
     public async Task<bool> Handle(
         ToggleFeatureScholarshipCommand request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin") && !currentUser.IsInRole("SuperAdmin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can feature scholarships.");
 
         var scholarship = await db.Scholarships

--- a/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsForModeration/GetScholarshipsForModerationQuery.cs
+++ b/server/src/ScholarPath.Application/Scholarships/Queries/GetScholarshipsForModeration/GetScholarshipsForModerationQuery.cs
@@ -30,7 +30,7 @@ public sealed class GetScholarshipsForModerationQueryHandler(
     public async Task<PaginatedList<MyScholarshipDto>> Handle(
         GetScholarshipsForModerationQuery request, CancellationToken ct)
     {
-        if (!currentUser.IsInRole("Admin"))
+        if (!currentUser.IsAdminOrSuperAdmin())
             throw new ForbiddenAccessException("Only an administrator can moderate scholarships.");
 
         var page = Math.Max(1, request.Page);

--- a/server/src/ScholarPath.Domain/Interfaces/CurrentUserExtensions.cs
+++ b/server/src/ScholarPath.Domain/Interfaces/CurrentUserExtensions.cs
@@ -1,0 +1,17 @@
+namespace ScholarPath.Domain.Interfaces;
+
+/// <summary>
+/// Role helpers on <see cref="ICurrentUserService"/>.
+/// </summary>
+public static class CurrentUserExtensions
+{
+    /// <summary>
+    /// True when the caller's ACTIVE role is Admin or SuperAdmin. SuperAdmin has every
+    /// Admin capability, so admin gates must accept both. Because the JWT
+    /// <c>RoleClaimType</c> is <c>active_role</c> (the single session role), a bare
+    /// <c>IsInRole("Admin")</c> spuriously 403s a session acting as SuperAdmin — use this
+    /// everywhere an admin capability is gated.
+    /// </summary>
+    public static bool IsAdminOrSuperAdmin(this ICurrentUserService user) =>
+        user.IsInRole("Admin") || user.IsInRole("SuperAdmin");
+}


### PR DESCRIPTION
Deep-audit **H7**. `RoleClaimType = active_role`, so a session acting as SuperAdmin failed every handler gating on a bare `IsInRole("Admin")` → spurious 403 for a SuperAdmin operator.

- Added `ICurrentUserService.IsAdminOrSuperAdmin()` and swept it across the Application layer (~15 Admin-only gates now accept SuperAdmin; collapsed the ~15 that already checked both). Hangfire dashboard filter too.
- **A-3/A-4**: `DeletePost` gated on `currentUser.Roles.Contains("Admin")` (the full ClaimTypes.Role set) — a refresh-rotated token **drops** that set, so a legit admin lost delete rights after a refresh. Switched to `IsAdminOrSuperAdmin()` (active_role). It was the **only** consumer of the full Roles set, so this also neutralises the refresh-drops-roles defect.

**884 unit tests green.** No migration. Deploy deferred to batch C.