### PR TITLE
fix(community): block voting on your own posts

### DIFF
--- a/client/src/pages/community/Community.tsx
+++ b/client/src/pages/community/Community.tsx
@@ -44,6 +44,7 @@ export function Community() {
 
   const activeRole = useAuthStore((state) => state.user?.activeRole);
   const roles = useAuthStore((state) => state.user?.roles ?? []);
+  const currentUserId = useAuthStore((state) => state.user?.id);
   const isStudent = activeRole === "Student" || roles.includes("Student");
 
   const { data: categories = [] } = useQuery<ForumCategory[]>({
@@ -452,12 +453,17 @@ export function Community() {
                     >
                       <div className="flex gap-4">
                         {/* Vote Side */}
-                        {isStudent && (
+                        {isStudent && (() => {
+                          const isOwnPost = post.authorId === currentUserId;
+                          const voteTitle = isOwnPost ? t("actions.voteOwnPost") : undefined;
+                          return (
                           <div className="hidden sm:flex flex-col items-center gap-0.5 bg-bg-subtle rounded-xl px-1.5 py-2 h-fit border border-border-subtle">
                             <button
                               type="button"
                               aria-label={t("thread.upvote")}
                               onClick={(e) => handleVote(e, post.id, "Up")}
+                              disabled={isOwnPost}
+                              title={voteTitle}
                               className="p-1.5 rounded-md text-text-tertiary hover:text-brand-600 hover:bg-brand-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                             >
                               <ArrowUp size={18} aria-hidden strokeWidth={2.5} />
@@ -471,12 +477,15 @@ export function Community() {
                               type="button"
                               aria-label={t("thread.downvote")}
                               onClick={(e) => handleVote(e, post.id, "Down")}
+                              disabled={isOwnPost}
+                              title={voteTitle}
                               className="p-1.5 rounded-md text-text-tertiary hover:text-danger-500 hover:bg-danger-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                             >
                               <ArrowDown size={18} aria-hidden strokeWidth={2.5} />
                             </button>
                           </div>
-                        )}
+                          );
+                        })()}
 
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 mb-2 flex-wrap">

--- a/client/src/pages/community/CommunityThread.tsx
+++ b/client/src/pages/community/CommunityThread.tsx
@@ -243,6 +243,8 @@ export function CommunityThread() {
                   <button
                     type="button"
                     onClick={() => handleVote(thread.post.id, "Up")}
+                    disabled={isRootOwn}
+                    title={isRootOwn ? t("actions.voteOwnPost") : undefined}
                     aria-label={t("thread.upvote")}
                     className="p-1.5 rounded-md text-text-tertiary hover:text-brand-600 hover:bg-brand-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                   >
@@ -256,6 +258,8 @@ export function CommunityThread() {
                   <button
                     type="button"
                     onClick={() => handleVote(thread.post.id, "Down")}
+                    disabled={isRootOwn}
+                    title={isRootOwn ? t("actions.voteOwnPost") : undefined}
                     aria-label={t("thread.downvote")}
                     className="p-1.5 rounded-md text-text-tertiary hover:text-danger-500 hover:bg-danger-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-tertiary"
                   >

--- a/docs/SRS-DIAGRAM-AUDIT-2026-07.md
+++ b/docs/SRS-DIAGRAM-AUDIT-2026-07.md
@@ -212,12 +212,14 @@ correct** (recently audited: bilingual posts, mutual block, auto-hide 3-distinct
 moderation stamping). All edits below are SRS/PlantUML. No `System`-actor violations (auto
 behaviours use event actors: PostAutoHiddenEvent, reply/report events). No code bug found.
 
-### 8.1 🔴 Self-vote — the diagrams still forbid it, but the code REMOVED that rule
-The code intentionally allows an author to vote on their own content (`ToggleVoteCommand.cs:43-45`:
-"the self-vote block was removed on request" — only the Student-role + one-vote-per-item rules remain).
-Delete the "cannot vote on own content / Own content? → reject" wording from **UC-03 note, UC-COM-12
-table (step 2 + ext 2a), ACT-04, and SEQ-04's guard**. (This also confirms the client's self-vote
-button being enabled is CORRECT — not a bug.)
+### 8.1 ✅ Self-vote — code now BLOCKS it, matching the diagrams (no edit needed)
+The diagrams' "cannot vote on own content / Own content? → reject" guard is CORRECT. On request
+(2026-07-05) the self-vote block was **re-added** to the code: `ToggleVoteCommand.cs:43-46` now throws
+`ConflictException("You can't vote on your own content.")` when `post.AuthorId == currentUser.UserId`
+(mirrors the self-report block on `FlagPost`). The client also disables the up/down vote buttons on the
+author's own posts in both the feed (`Community.tsx`) and the thread (`CommunityThread.tsx`), with a
+`voteOwnPost` tooltip. So UC-03 note, UC-COM-12 table (step 2 + ext 2a), ACT-04 and SEQ-04's guard all
+match the code — **keep them as-is**. (SEQ-04's reject branch is a **409 Conflict**.)
 
 ### 8.2 🟠 HTTP status codes (systemic)
 - Mutations return **`204 No Content`**, not 200: SEQ-04 (vote), SEQ-05 (flag), SEQ-08 (edit),
@@ -241,3 +243,41 @@ posts, auto-hide-at-3-distinct, moderation stamping, self-reply-notify suppressi
 a withdrawal never appeared in the student's timeline (FR-APP-18/19). Fixed: it now raises the event
 (`statusBeforeWithdrawal → Withdrawn`); the payment-outcome handler only acts on Accepted/Rejected, so it's
 side-effect-safe. Shipped separately.
+
+---
+
+## 9. Messaging / Direct Chat diagrams — documentation edits
+
+Reviewed all 24 Messaging diagrams (6 UC + 8 ACT + 10 SEQ) against the current code. **The code is
+correct** (audited: mutual block, canonical conversation, 2000-char cap, presence ref-counting). 19 clean;
+5 sequence diagrams need edits — all SRS/PlantUML, no code bug. No `System`-actor violations (real-time
+delivery + offline notification are correctly initiated by `ChatMessageReceivedEvent`, not a System actor).
+
+### 9.1 🔴 SEQ-07 "Block User" — remove the fabricated "reject duplicate" branch; fix status
+A duplicate block is **idempotent** (`BlockUserCommand.cs:40-41` → `return true`, no error), not rejected.
+Self-block throws `ConflictException` → **409** (`:34-35`); success returns **204 No Content**
+(`ChatController.cs:50-56`), not 200. Model as: `alt blocking self → 409` / `else new-or-already-blocked →
+create if none → 204`. Delete the "reject duplicate" else-branch.
+
+### 9.2 🔴 SEQ-08 "Unblock User" — remove the fabricated 404 branch; fix status
+Unblock is a silent **no-op** when no block exists (`UnblockUserCommand.cs:23-32` always `return true`), not
+a 404. Success returns **204** (`ChatController.cs:58-64`). Model as: `find block → opt exists → remove` →
+**204**. Drop the `else no removable block / 404` branch.
+
+### 9.3 🟠 SEQ-02 & SEQ-03 — Send returns **200**, not 201
+Both show `201 Created`; the controller returns `Ok(result)` (**200**) carrying the new message Guid
+(`ChatController.cs:41-48`). Change both to 200.
+
+### 9.4 🟠 SEQ-03 "Send Message" — event publish/save ordering is misplaced
+Actual order (`SendMessageCommand.cs:94,96,102-109`): **save first** → realtime `NotifyNewMessageAsync` →
+`publisher.Publish(ChatMessageReceivedEvent)` — all **synchronously before** returning to the controller.
+Reorder the diagram so the HANDLER fan-out sits above the `CTRL → API` return arrows, not after the response.
+
+### 9.5 🟡 Minor
+- **SEQ-04** note `load messages (ReadAt updated)` is wrong — `GetMessagesQuery` is read-only `AsNoTracking`
+  and never writes `ReadAt` (read receipts are out of scope). Change to `load messages (read-only)`.
+  Optionally add the unmodeled 404 (conversation-not-found) branch before the participant 403.
+- **SEQ-05** lifeline `ChatHubClient` should be `chatHub` (real client module `services/signalR/chatHub.ts`).
+
+**Correct (no edit):** UC-01..06, ACT-01..08, SEQ-01/06/09/10; canonical conversation reuse, block gating on
+send + community, presence ref-counted connect/disconnect, offline-only notification all match the code.

--- a/server/src/ScholarPath.Application/Community/Commands/ToggleVote/ToggleVoteCommand.cs
+++ b/server/src/ScholarPath.Application/Community/Commands/ToggleVote/ToggleVoteCommand.cs
@@ -40,8 +40,11 @@ public sealed class ToggleVoteCommandHandler(
             .FirstOrDefaultAsync(p => p.Id == request.PostId && !p.IsDeleted, ct)
             ?? throw new NotFoundException(nameof(ForumPost), request.PostId);
 
-        // Authors may upvote their own posts (the self-vote block was removed on
-        // request); the unique (post, user) vote guarantees one vote per user.
+        // A user cannot vote on their own content (mirrors the self-report block on
+        // FlagPost). The unique (post, user) vote still guarantees one vote per user.
+        if (post.AuthorId == currentUser.UserId)
+            throw new ConflictException("You can't vote on your own content.");
+
         var existingVote = post.Votes.FirstOrDefault(v => v.UserId == currentUser.UserId);
 
         if (existingVote != null)

--- a/server/tests/ScholarPath.UnitTests/Community/ToggleVoteCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/Community/ToggleVoteCommandHandlerTests.cs
@@ -10,17 +10,18 @@ public sealed class ToggleVoteCommandHandlerTests : IDisposable
     public void Dispose() => _h.Dispose();
 
     [Fact]
-    public async Task Author_can_vote_on_own_post()
+    public async Task Author_cannot_vote_on_own_post()
     {
-        // The self-vote block was removed on request — authors may upvote their
-        // own posts, and the unique (post, user) vote still caps it at one.
+        // A user cannot vote on their own content (mirrors the self-report block
+        // on FlagPost) — the handler rejects it with a ConflictException.
         var post = await _h.SeedPostAsync(_h.StudentA);
         _h.AsStudent(_h.StudentA);
         var handler = new ToggleVoteCommandHandler(_h.Db, _h.CurrentUser);
 
-        await handler.Handle(new ToggleVoteCommand(post.Id, VoteType.Up), CancellationToken.None);
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            handler.Handle(new ToggleVoteCommand(post.Id, VoteType.Up), CancellationToken.None));
 
-        _h.Db.ForumPosts.Single(p => p.Id == post.Id).UpvoteCount.Should().Be(1);
+        _h.Db.ForumPosts.Single(p => p.Id == post.Id).UpvoteCount.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Re-adds the self-vote guard so an author **cannot** upvote/downvote their own posts — mirrors the existing self-report (FlagPost) block. Requested by the team lead.

## Changes
- **Server** `ToggleVoteCommand`: `ConflictException` (409) when `post.AuthorId == currentUser.UserId`. The unique (post, user) vote still caps one vote per user.
- **Client**: disable up/down vote buttons on own posts (with a `voteOwnPost` tooltip) in both the feed (`Community.tsx`) and thread (`CommunityThread.tsx`). Self-report/flag was already blocked server-side and hidden client-side.
- **Test**: flipped `Author_can_vote_on_own_post` → `Author_cannot_vote_on_own_post` (asserts `ConflictException`). 6/6 vote+flag tests green; full client build green.
- **Docs**: reversed SRS-DIAGRAM-AUDIT §8.1 (code now matches the diagrams) and added **§9 — Messaging/Direct Chat diagram review** (SEQ-07/08 fabricated branches, SEQ-02/03 201→200, SEQ-03 event ordering, SEQ-04/05 minor).

## Verify
- `dotnet test` vote+flag filter: Passed 6/6
- `tsc` + `eslint --max-warnings 0` + `npm run build`: green