### PR TITLE
fix(rating): compute average + low-rating flag from the latest 20 reviews

### DIFF
--- a/server/src/ScholarPath.Application/ConsultantBookings/ConsultantRatingThresholds.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/ConsultantRatingThresholds.cs
@@ -19,6 +19,15 @@ public static class ConsultantRatingThresholds
     public const decimal LowRatingThreshold = 2.5m;
 
     /// <summary>
+    /// FR-CBR-38: the displayed rating and the low-rating flag are both computed
+    /// from the most recent N reviews only ("latest 20 reviews", newest first) —
+    /// not the all-time set and not a calendar window. A consultant who recently
+    /// improved is not held back by old ratings, and a recent decline is caught
+    /// even if the all-time average is still healthy.
+    /// </summary>
+    public const int RatingWindowSize = 20;
+
+    /// <summary>
     /// Minimum number of visible reviews required before the penalized-average
     /// admin flag fires. Set to 5 to match the booking-intake auto-suspend sample
     /// floor (BookingOptions.LowRatingMinimumSampleSize) — a single noisy 2-star (or

--- a/server/src/ScholarPath.Application/ConsultantBookings/Services/ConsultantRatingService.cs
+++ b/server/src/ScholarPath.Application/ConsultantBookings/Services/ConsultantRatingService.cs
@@ -67,10 +67,22 @@ public sealed class ConsultantRatingService(
             .AsNoTracking()
             .Where(r => r.ConsultantId == consultantId && !r.IsHiddenByAdmin && !r.IsDeleted);
 
-        var reviewCount = await visibleReviews.CountAsync(ct).ConfigureAwait(false);
-        decimal? rawAverage = reviewCount == 0
+        // Total visible reviews — the "N reviews" figure shown to users.
+        var totalReviewCount = await visibleReviews.CountAsync(ct).ConfigureAwait(false);
+
+        // FR-CBR-38: the rating + flag are computed from the most recent
+        // RatingWindowSize reviews only ("latest 20 reviews"), newest first.
+        var windowRatings = await visibleReviews
+            .OrderByDescending(r => r.CreatedAt)
+            .Take(ConsultantRatingThresholds.RatingWindowSize)
+            .Select(r => (decimal)r.Rating)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var sampleCount = windowRatings.Count;
+        decimal? rawAverage = sampleCount == 0
             ? null
-            : await visibleReviews.AverageAsync(r => (decimal)r.Rating, ct).ConfigureAwait(false);
+            : windowRatings.Average();
 
         var profile = await db.UserProfiles
             .FirstOrDefaultAsync(p => p.UserId == consultantId, ct)
@@ -93,10 +105,10 @@ public sealed class ConsultantRatingService(
             : decimal.Round(Math.Clamp(rawAverage.Value * factor, 0m, 5m), 2, MidpointRounding.AwayFromZero);
 
         profile.ConsultantAverageRating = penalized;
-        profile.ConsultantReviewCount = reviewCount;
+        profile.ConsultantReviewCount = totalReviewCount;
 
         var shouldFlag = penalized is { } avg
-            && reviewCount >= ConsultantRatingThresholds.MinimumReviewsForFlagging
+            && sampleCount >= ConsultantRatingThresholds.MinimumReviewsForFlagging
             && avg < ConsultantRatingThresholds.LowRatingThreshold;
 
         // Sticky flag: the original flag time is what the admin queue surfaces; a
@@ -111,7 +123,7 @@ public sealed class ConsultantRatingService(
 
         if (firstFlagging)
         {
-            await NotifyAdminsAsync(consultantId, penalized!.Value, reviewCount, ct).ConfigureAwait(false);
+            await NotifyAdminsAsync(consultantId, penalized!.Value, sampleCount, ct).ConfigureAwait(false);
         }
     }
 

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/SubmitScholarshipProviderRating/SubmitScholarshipProviderRatingCommandHandler.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviews/Commands/SubmitScholarshipProviderRating/SubmitScholarshipProviderRatingCommandHandler.cs
@@ -89,17 +89,24 @@ public sealed class SubmitScholarshipProviderRatingCommandHandler(
             .AsNoTracking()
             .Where(r => r.ScholarshipProviderId == companyId && !r.IsHiddenByAdmin);
 
-        var reviewCount = await visibleReviews.CountAsync(ct);
-        // Math.Round on the decimal average — server-side aggregation already
-        // returns decimal, but a CLR Math.Round at write time keeps the
-        // persisted snapshot at 2-decimal precision matching the column.
-        decimal? averageRating = reviewCount == 0
+        // Total visible reviews — the "N reviews" figure shown to users.
+        var totalReviewCount = await visibleReviews.CountAsync(ct);
+
+        // FR-APP-35 (updated): the rating + low-rating flag are both computed
+        // from the most recent RatingWindowSize reviews only ("latest 20
+        // reviews"), newest first — not all-time and not a 3-month window.
+        var windowRatings = await visibleReviews
+            .OrderByDescending(r => r.CreatedAt)
+            .Take(ScholarshipProviderRatingThresholds.RatingWindowSize)
+            .Select(r => (decimal)r.Rating)
+            .ToListAsync(ct);
+
+        var sampleCount = windowRatings.Count;
+        decimal? averageRating = sampleCount == 0
             ? null
-            : await visibleReviews.AverageAsync(r => (decimal)r.Rating, ct);
-        if (averageRating is not null)
-        {
-            averageRating = Math.Round(averageRating.Value, 2, MidpointRounding.AwayFromZero);
-        }
+            // Math.Round keeps the persisted snapshot at 2-decimal precision
+            // matching the column.
+            : Math.Round(windowRatings.Average(), 2, MidpointRounding.AwayFromZero);
 
         var profile = await db.UserProfiles
             .FirstOrDefaultAsync(p => p.UserId == companyId, ct);
@@ -115,34 +122,12 @@ public sealed class SubmitScholarshipProviderRatingCommandHandler(
             return;
         }
 
-        // The displayed reputation snapshot stays ALL-TIME (overall standing).
+        // Both the displayed snapshot and the flag use the latest-20 window.
         profile.ScholarshipProviderAverageRating = averageRating;
-        profile.ScholarshipProviderReviewCount = reviewCount;
+        profile.ScholarshipProviderReviewCount = totalReviewCount;
 
-        // FR-APP-35: the low-rating FLAG decision is scoped to the trailing
-        // 3 months only — "if the ScholarshipProvider average rating during the last 3
-        // months falls below 2.5, flag for Admin assessment." A provider that
-        // has recently improved should not stay flagged on old ratings, and a
-        // provider that recently declined should be caught even if its all-time
-        // average is still healthy.
-        var windowStart = DateTimeOffset.UtcNow.AddMonths(-ScholarshipProviderRatingThresholds.FlaggingWindowMonths);
-        var recentReviews = db.ScholarshipProviderReviews
-            .AsNoTracking()
-            .Where(r => r.ScholarshipProviderId == companyId
-                        && !r.IsHiddenByAdmin
-                        && r.CreatedAt >= windowStart);
-
-        var recentCount = await recentReviews.CountAsync(ct);
-        decimal? recentAverage = recentCount == 0
-            ? null
-            : await recentReviews.AverageAsync(r => (decimal)r.Rating, ct);
-        if (recentAverage is not null)
-        {
-            recentAverage = Math.Round(recentAverage.Value, 2, MidpointRounding.AwayFromZero);
-        }
-
-        var shouldFlag = recentAverage is { } avg
-            && recentCount >= ScholarshipProviderRatingThresholds.MinimumReviewsForFlagging
+        var shouldFlag = averageRating is { } avg
+            && sampleCount >= ScholarshipProviderRatingThresholds.MinimumReviewsForFlagging
             && avg < ScholarshipProviderRatingThresholds.LowRatingThreshold;
 
         // Sticky flag: don't overwrite an existing FlaggedAt timestamp on
@@ -158,9 +143,8 @@ public sealed class SubmitScholarshipProviderRatingCommandHandler(
 
         if (firstFlagging)
         {
-            // Notify with the trailing-window figures that actually triggered
-            // the flag, not the all-time snapshot.
-            await NotifyAdminsAsync(companyId, recentAverage!.Value, recentCount, ct);
+            // Notify with the latest-20-window figures that actually triggered the flag.
+            await NotifyAdminsAsync(companyId, averageRating!.Value, sampleCount, ct);
         }
     }
 

--- a/server/src/ScholarPath.Application/ScholarshipProviderReviews/ScholarshipProviderRatingThresholds.cs
+++ b/server/src/ScholarPath.Application/ScholarshipProviderReviews/ScholarshipProviderRatingThresholds.cs
@@ -5,10 +5,11 @@ namespace ScholarPath.Application.ScholarshipProviderReviews;
 ///
 /// <para>
 /// When a Student submits a ScholarshipProviderReview, the handler recomputes the
-/// ScholarshipProvider's average rating across its visible reviews (not soft-deleted, not
-/// admin-hidden). If the average falls below <see cref="LowRatingThreshold"/>
-/// and the ScholarshipProvider has at least <see cref="MinimumReviewsForFlagging"/> visible
-/// review(s), the ScholarshipProvider's <c>UserProfile.ScholarshipProviderLowRatingFlaggedAt</c> is
+/// ScholarshipProvider's average rating from the most recent <see cref="RatingWindowSize"/>
+/// visible reviews (not soft-deleted, not admin-hidden), newest first. If that average
+/// falls below <see cref="LowRatingThreshold"/> and the ScholarshipProvider has at least
+/// <see cref="MinimumReviewsForFlagging"/> visible review(s) in that window, the
+/// ScholarshipProvider's <c>UserProfile.ScholarshipProviderLowRatingFlaggedAt</c> is
 /// stamped and the admins are notified — they triage the queue and either
 /// clear the flag or suspend the account via the existing
 /// <c>SetUserStatusCommand</c>.
@@ -36,9 +37,9 @@ public static class ScholarshipProviderRatingThresholds
     public const int MinimumReviewsForFlagging = 1;
 
     /// <summary>
-    /// FR-APP-35: the flag decision considers only reviews created within this
-    /// trailing window (in months). The displayed all-time average is unaffected
-    /// — only the flag trigger is time-scoped.
+    /// FR-APP-35 (updated): both the displayed rating and the low-rating flag are
+    /// computed from the most recent N reviews only ("latest 20 reviews", newest
+    /// first) — not the all-time set and not a calendar window.
     /// </summary>
-    public const int FlaggingWindowMonths = 3;
+    public const int RatingWindowSize = 20;
 }

--- a/server/tests/ScholarPath.UnitTests/ScholarshipProviderReviews/SubmitScholarshipProviderRatingCommandHandlerTests.cs
+++ b/server/tests/ScholarPath.UnitTests/ScholarshipProviderReviews/SubmitScholarshipProviderRatingCommandHandlerTests.cs
@@ -348,33 +348,41 @@ public sealed class SubmitScholarshipProviderRatingCommandHandlerTests : IDispos
     }
 
     [Fact]
-    public async Task Handle_OldLowRatingsOutsideWindow_DoNotFlag()
+    public async Task Handle_ReviewsBeyondLatest20_ExcludedFromRatingAndFlag()
     {
-        // FR-APP-35: the flag decision is scoped to the trailing 3 months. Two
-        // old 1-star reviews (4 months ago) drag the ALL-TIME average below 2.5,
-        // but a recent good rating means the 3-month window average is healthy —
-        // so the company must NOT be flagged.
+        // FR-APP-35 (updated): the rating + flag use the latest 20 reviews only.
+        // A pile of OLD 5-star reviews keeps the ALL-TIME average healthy, but a
+        // run of RECENT 1-stars fills the latest-20 window → the company IS
+        // flagged on its recent decline, and the displayed average reflects the
+        // window (not all-time).
         var studentId = Guid.NewGuid();
         _currentUser.UserId.Returns(studentId);
         var (appId, companyId) = await SeedApplicationAsync(studentId, ApplicationStatus.Accepted);
         await SeedAdminAsync();
 
-        var fourMonthsAgo = DateTimeOffset.UtcNow.AddMonths(-4);
-        await SeedExistingReviewAsync(companyId, rating: 1, createdAt: fourMonthsAgo);
-        await SeedExistingReviewAsync(companyId, rating: 1, createdAt: fourMonthsAgo);
+        var now = DateTimeOffset.UtcNow;
+        // 25 old 5-star reviews (a year ago) — pushed out of the latest-20 window.
+        for (var i = 0; i < 25; i++)
+        {
+            await SeedExistingReviewAsync(companyId, rating: 5, createdAt: now.AddYears(-1).AddMinutes(i));
+        }
+        // 19 recent 1-star reviews (last half hour) — inside the window.
+        for (var i = 0; i < 19; i++)
+        {
+            await SeedExistingReviewAsync(companyId, rating: 1, createdAt: now.AddMinutes(-30 + i));
+        }
 
-        // Recent 5-star. All-time avg = (1+1+5)/3 = 2.33 (< 2.5), but the last
-        // 3 months hold only the 5-star → window avg 5.0 → no flag.
+        // The submitted 1-star (newest) makes twenty recent 1-stars in the window → avg 1.00.
         await _handler.Handle(
-            new SubmitScholarshipProviderRatingCommand(appId, 5, null), CancellationToken.None);
+            new SubmitScholarshipProviderRatingCommand(appId, 1, null), CancellationToken.None);
 
         var profile = await _db.UserProfiles.SingleAsync(p => p.UserId == companyId);
-        profile.ScholarshipProviderLowRatingFlaggedAt.Should().BeNull();
-        // The displayed snapshot stays all-time.
-        profile.ScholarshipProviderReviewCount.Should().Be(3);
-        profile.ScholarshipProviderAverageRating.Should().Be(2.33m);
+        // Displayed count is all-time (25 + 19 + 1); the average is the latest-20 window.
+        profile.ScholarshipProviderReviewCount.Should().Be(45);
+        profile.ScholarshipProviderAverageRating.Should().Be(1.00m);
+        profile.ScholarshipProviderLowRatingFlaggedAt.Should().NotBeNull();
 
-        await _notif.DidNotReceive().DispatchAsync(
+        await _notif.Received().DispatchAsync(
             Arg.Any<Guid>(),
             NotificationType.ScholarshipProviderLowRatingFlagged,
             Arg.Any<NotificationParams>(),


### PR DESCRIPTION
## What

Aligns the rating logic with the updated SRS / testing chapter (**TC-28** provider, **TC-39** consultant). Both sides now compute the displayed rating **and** the low-rating flag from the **most recent 20 visible reviews** (newest first).

## Why
The testing chapter states the rating uses "latest 20 reviews, not last 3 months". The code did NOT:
- **Consultant**: averaged **all** visible reviews (min 5).
- **Provider**: displayed **all-time** average + flagged on a **3-month** trailing window (min 1).

Neither implemented "latest 20". Per the team-lead decision, the code is updated to match.

## Changes
- `ConsultantRatingService.RecalculateSnapshotAsync`: rating/flag over the latest 20 (penalty factor still applies to the windowed raw average); displayed **review count stays all-time**.
- `SubmitScholarshipProviderRatingCommandHandler`: rating/flag over the latest 20; count stays all-time; **3-month window removed**.
- `RatingWindowSize = 20` added to both threshold classes; unused `FlaggingWindowMonths` dropped.
- Replaced the 3-month-window provider test with a **latest-20-window** test (25 old 5★ excluded, 20 recent 1★ → flagged).

## Verify
- **884 unit tests green** (34 rating-specific).
- No schema/migration — query logic only. No client copy referenced the window.