### PR TITLE
test(client): expand unit coverage for core pure logic (18 → 65 tests)

### DIFF
--- a/client/src/test/auth.test.ts
+++ b/client/src/test/auth.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { switchableRoles, postAuthPath } from "@/services/api/auth";
+import type { CurrentUser } from "@/stores/authStore";
+
+/** Minimal valid CurrentUser with overridable fields for focused assertions. */
+function makeUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
+  return {
+    id: "u1",
+    email: "u@example.com",
+    firstName: "Test",
+    lastName: "User",
+    fullName: "Test User",
+    profileImageUrl: null,
+    accountStatus: "Active",
+    isOnboardingComplete: true,
+    emailConfirmed: true,
+    roles: ["Student"],
+    activeRole: "Student",
+    preferredLanguage: null,
+    ...overrides,
+  };
+}
+
+describe("switchableRoles", () => {
+  it("returns the plain switchable roles a user holds", () => {
+    const user = makeUser({ roles: ["Student", "ScholarshipProvider"] });
+    expect(switchableRoles(user)).toEqual(["Student", "ScholarshipProvider"]);
+  });
+
+  it("hides Consultant when the backend has NOT confirmed eligibility", () => {
+    // A raw/stale Consultant role row must not expose the switch target.
+    const noFlag = makeUser({ roles: ["Student", "Consultant"] });
+    expect(switchableRoles(noFlag)).toEqual(["Student"]);
+
+    const falseFlag = makeUser({
+      roles: ["Student", "Consultant"],
+      canActAsConsultant: false,
+    });
+    expect(switchableRoles(falseFlag)).toEqual(["Student"]);
+  });
+
+  it("shows Consultant only when canActAsConsultant is true", () => {
+    const user = makeUser({
+      roles: ["Student", "Consultant"],
+      canActAsConsultant: true,
+    });
+    expect(switchableRoles(user)).toEqual(["Student", "Consultant"]);
+  });
+
+  it("excludes non-switchable roles (SuperAdmin, Moderator)", () => {
+    const user = makeUser({ roles: ["Admin", "SuperAdmin", "Moderator"] });
+    expect(switchableRoles(user)).toEqual(["Admin"]);
+  });
+
+  it("excludes the pre-rename 'Company' role literal", () => {
+    // Regression guard for the Company→ScholarshipProvider rename: a stale
+    // "Company" role string is not offered as a switch target.
+    const user = makeUser({ roles: ["Student", "Company"] });
+    expect(switchableRoles(user)).toEqual(["Student"]);
+  });
+});
+
+describe("postAuthPath", () => {
+  it("routes an incomplete onboarding to /onboarding regardless of role", () => {
+    const user = makeUser({ isOnboardingComplete: false, activeRole: "Student" });
+    expect(postAuthPath(user)).toBe("/onboarding");
+  });
+
+  it.each([
+    ["Student", "/student"],
+    ["ScholarshipProvider", "/company"],
+    ["Consultant", "/consultant"],
+    ["Admin", "/admin"],
+    ["SuperAdmin", "/admin"],
+  ])("routes an onboarded %s to %s", (activeRole, expected) => {
+    expect(postAuthPath(makeUser({ activeRole }))).toBe(expected);
+  });
+
+  it("falls back to /onboarding for an unknown or null active role", () => {
+    expect(postAuthPath(makeUser({ activeRole: null }))).toBe("/onboarding");
+    expect(postAuthPath(makeUser({ activeRole: "Wat" }))).toBe("/onboarding");
+  });
+});

--- a/client/src/test/bookingFormat.test.ts
+++ b/client/src/test/bookingFormat.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  statusBucket,
+  statusBadgeClass,
+  statusLabelKey,
+  formatUsd,
+  formatDate,
+  formatTime,
+} from "@/lib/bookingFormat";
+import type { BookingStatus } from "@/services/api/bookings";
+
+describe("statusBucket", () => {
+  it.each<[BookingStatus, string]>([
+    ["Requested", "pending"],
+    ["NoShowReported", "pending"], // frozen pending admin validation
+    ["Confirmed", "confirmed"],
+    ["Completed", "completed"],
+    ["Rejected", "closed"],
+    ["Expired", "closed"],
+    ["Cancelled", "closed"],
+    ["NoShowStudent", "closed"],
+    ["NoShowConsultant", "closed"],
+  ])("maps %s → %s bucket", (status, bucket) => {
+    expect(statusBucket(status)).toBe(bucket);
+  });
+});
+
+describe("statusBadgeClass", () => {
+  it("uses the danger palette for the punitive no-show / rejected statuses", () => {
+    for (const s of ["Rejected", "NoShowStudent", "NoShowConsultant"] as BookingStatus[]) {
+      expect(statusBadgeClass(s)).toContain("danger");
+    }
+  });
+
+  it("uses the success palette for a completed booking", () => {
+    expect(statusBadgeClass("Completed")).toContain("success");
+  });
+
+  it("uses the muted palette for expired / cancelled", () => {
+    expect(statusBadgeClass("Cancelled")).toContain("text-text-secondary");
+    expect(statusBadgeClass("Expired")).toContain("text-text-secondary");
+  });
+});
+
+describe("statusLabelKey", () => {
+  it("namespaces the status under statusLabels", () => {
+    expect(statusLabelKey("Confirmed")).toBe("statusLabels.Confirmed");
+  });
+});
+
+describe("formatUsd", () => {
+  it("formats whole and fractional amounts to two decimals", () => {
+    expect(formatUsd(35)).toBe("$35.00");
+    expect(formatUsd(35.5)).toBe("$35.50");
+    expect(formatUsd(0)).toBe("$0.00");
+  });
+});
+
+describe("formatDate / formatTime null-safety", () => {
+  it("returns an empty string for a missing timestamp instead of crashing", () => {
+    expect(formatDate(null, "en")).toBe("");
+    expect(formatDate(undefined, "en")).toBe("");
+    expect(formatTime(null, "en")).toBe("");
+  });
+
+  it("echoes an unparseable string back rather than rendering 'Invalid Date'", () => {
+    expect(formatDate("not-a-date", "en")).toBe("not-a-date");
+  });
+
+  it("formats a valid ISO instant to a day-level label", () => {
+    // Assert on stable parts (locale/runtime can vary the exact separators).
+    const out = formatDate("2026-04-25T18:30:00Z", "en");
+    expect(out).toContain("2026");
+    expect(out).toContain("Apr");
+    expect(out).toContain("25");
+  });
+});

--- a/client/src/test/expertiseTagLabel.test.ts
+++ b/client/src/test/expertiseTagLabel.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  expertiseTagLabelByLang,
+  languageNameByLang,
+} from "@/lib/expertiseTagLabel";
+
+describe("expertiseTagLabelByLang", () => {
+  it("returns the Arabic label for a canonical English key in Arabic mode", () => {
+    expect(expertiseTagLabelByLang("Interview Prep", "ar")).toBe("التحضير للمقابلة");
+  });
+
+  it("returns the canonical English key unchanged in English mode", () => {
+    expect(expertiseTagLabelByLang("Interview Prep", "en")).toBe("Interview Prep");
+  });
+
+  it("normalises an Arabic-stored value back to English for the English UI", () => {
+    // A consultant who typed their specialisation in Arabic must not surface a
+    // stray Arabic chip among English ones.
+    expect(expertiseTagLabelByLang("التحضير للمقابلة", "en")).toBe("Interview Prep");
+  });
+
+  it("keeps an Arabic-stored value Arabic in the Arabic UI", () => {
+    expect(expertiseTagLabelByLang("التحضير للمقابلة", "ar")).toBe("التحضير للمقابلة");
+  });
+
+  it("maps known free-text Arabic aliases to their canonical English key", () => {
+    // "التحضير للمقابلات" (plural) is not an exact map value but is pinned.
+    expect(expertiseTagLabelByLang("التحضير للمقابلات", "en")).toBe("Interview Prep");
+    expect(expertiseTagLabelByLang("التحضير للمقابلات", "ar")).toBe("التحضير للمقابلة");
+  });
+
+  it("falls back to the raw key when no translation is known", () => {
+    expect(expertiseTagLabelByLang("Quantum Basketry", "ar")).toBe("Quantum Basketry");
+    expect(expertiseTagLabelByLang("Quantum Basketry", "en")).toBe("Quantum Basketry");
+  });
+
+  it("treats an undefined language as English", () => {
+    expect(expertiseTagLabelByLang("Interview Prep", undefined)).toBe("Interview Prep");
+  });
+
+  it("handles slug-style resource tags", () => {
+    expect(expertiseTagLabelByLang("pre-departure", "ar")).toBe("ما قبل السفر");
+    expect(expertiseTagLabelByLang("checklist", "ar")).toBe("قائمة تحقق");
+  });
+});
+
+describe("languageNameByLang", () => {
+  it("renders an ISO code as a localized full name", () => {
+    expect(languageNameByLang("en", "ar")).toBe("الإنجليزية");
+    expect(languageNameByLang("ar", "en")).toBe("Arabic");
+  });
+
+  it("is case-insensitive on the code", () => {
+    expect(languageNameByLang("EN", "en")).toBe("English");
+  });
+
+  it("falls back to the upper-cased code when unknown", () => {
+    expect(languageNameByLang("xx", "en")).toBe("XX");
+    expect(languageNameByLang("xx", "ar")).toBe("XX");
+  });
+});

--- a/client/src/test/flagReasons.test.ts
+++ b/client/src/test/flagReasons.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { FLAG_REASONS, flagReasonLabel } from "@/lib/flagReasons";
+
+describe("flagReasonLabel", () => {
+  it("localizes every canonical reason key in both languages", () => {
+    for (const reason of FLAG_REASONS) {
+      const en = flagReasonLabel(reason, "en");
+      const ar = flagReasonLabel(reason, "ar");
+      // A localized label must differ from the raw key (except where a key is
+      // its own word) and never be empty.
+      expect(en).toBeTruthy();
+      expect(ar).toBeTruthy();
+      expect(ar).not.toBe(en);
+    }
+  });
+
+  it("picks Arabic labels for an Arabic language code", () => {
+    expect(flagReasonLabel("spam", "ar")).toBe("إعلانات أو محتوى مزعج");
+  });
+
+  it("defaults to English for a non-Arabic (or undefined) language", () => {
+    expect(flagReasonLabel("harassment", "en")).toBe("Harassment or abuse");
+    expect(flagReasonLabel("harassment", undefined)).toBe("Harassment or abuse");
+  });
+
+  it("renders known free-text seed reasons readably in Arabic", () => {
+    expect(flagReasonLabel("Advertising", "ar")).toBe("إعلانات");
+    expect(flagReasonLabel("Academic dishonesty", "ar")).toBe("غش أكاديمي");
+  });
+
+  it("falls back to the raw value for an unknown legacy reason", () => {
+    expect(flagReasonLabel("something-custom", "en")).toBe("something-custom");
+    expect(flagReasonLabel("something-custom", "ar")).toBe("something-custom");
+  });
+});

--- a/client/src/test/userPhoto.test.ts
+++ b/client/src/test/userPhoto.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { userPhotoUrl, userPhotoUrlWithVersion } from "@/lib/userPhoto";
+
+describe("userPhotoUrl", () => {
+  it("builds the stable per-user photo endpoint path", () => {
+    // VITE_API_BASE_URL is unset in tests, so the base collapses to a
+    // same-origin relative path — assert on the stable suffix.
+    expect(userPhotoUrl("abc-123")).toBe("/api/profiles/abc-123/photo");
+  });
+
+  it("appends a cache-busting version query", () => {
+    expect(userPhotoUrlWithVersion("abc-123", 42)).toBe(
+      "/api/profiles/abc-123/photo?v=42",
+    );
+    expect(userPhotoUrlWithVersion("abc-123", "hash")).toBe(
+      "/api/profiles/abc-123/photo?v=hash",
+    );
+  });
+});


### PR DESCRIPTION
Expands the client unit test suite from 18 to 65 tests, targeting the highest-value previously-untested pure logic. All deterministic (no network/timers).

## Coverage added
- **auth** — `switchableRoles` (the #45 consultant-eligibility gate: Consultant only offered when `canActAsConsultant`; plus a Company→ScholarshipProvider rename guard) and `postAuthPath` role→route routing.
- **expertiseTagLabel** — EN/AR mapping, Arabic-stored-value normalisation back to canonical English (the "consultant typed their tag in Arabic" case), free-text aliases, and fallbacks.
- **bookingFormat** — `BookingStatus` → bucket/badge/label mapping (all 9 statuses), `formatUsd`, and `formatDate`/`formatTime` null-safety.
- **flagReasons** — bilingual reason labels + legacy free-text fallback.
- **userPhoto** — photo endpoint URL + cache-busting version query.

## Verify
- `vitest`: 65 passed (10 files). `tsc` + `eslint --max-warnings 0` green.