### PR TITLE
feat(support): make the application-support flow real via Direct Messages

### DIFF
--- a/client/src/locales/ar/payments.json
+++ b/client/src/locales/ar/payments.json
@@ -225,6 +225,7 @@
     "reference": "المرجع",
     "unknownScholarshipProvider": "شركة غير معروفة",
     "unknownStudent": "طالب غير معروف",
+    "message": "مراسلة",
     "cancel": "إلغاء الطلب",
     "cancelWithRefund": "إلغاء (استرداد 50٪)",
     "cancelConfirm50": "الإلغاء الآن يُطبِّق استرداد 50٪ ويُحتفظ بالـ 50٪ المتبقية. هل تريد المتابعة؟",

--- a/client/src/locales/en/payments.json
+++ b/client/src/locales/en/payments.json
@@ -225,6 +225,7 @@
     "reference": "Reference",
     "unknownScholarshipProvider": "Unknown company",
     "unknownStudent": "Unknown student",
+    "message": "Message",
     "cancel": "Cancel request",
     "cancelWithRefund": "Cancel (50% refund)",
     "cancelConfirm50": "Cancelling now triggers a 50% refund — the remaining 50% is retained. Continue?",

--- a/client/src/pages/chat/Chat.tsx
+++ b/client/src/pages/chat/Chat.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from "react";
+import { useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import {
   Send,
@@ -37,6 +38,8 @@ export function Chat() {
 
   const currentUser = useAuthStore((state) => state.user);
   const accessToken = useAuthStore((state) => state.tokens?.accessToken);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const deepLinkHandledRef = useRef(false);
 
   const [selectedConv, setSelectedConv] = useState<ChatConversation | null>(null);
   const [messageBody, setMessageBody] = useState("");
@@ -69,7 +72,7 @@ export function Chat() {
     ? onlineUserIds.has(selectedConv.otherParticipantId) || selectedConv.isOnline
     : false;
 
-  const { data: conversations = [] } = useQuery({
+  const { data: conversations = [], isSuccess: conversationsLoaded } = useQuery({
     queryKey: ["chat", "conversations"],
     queryFn: () => chatApi.getConversations(),
   });
@@ -135,6 +138,30 @@ export function Chat() {
     }
     setSelectedConv(next);
   };
+
+  // Deep-link: /messages?with={userId}&name={name}. Lets a "Message" button
+  // elsewhere (e.g. on an accepted application-support request) jump straight
+  // into a conversation with that person — reusing an existing thread if there
+  // is one, or staging a fresh compose that the first message turns real.
+  useEffect(() => {
+    const withId = searchParams.get("with");
+    if (!withId || deepLinkHandledRef.current || !conversationsLoaded) return;
+    deepLinkHandledRef.current = true;
+    const name = searchParams.get("name") ?? "";
+    const existing = conversations.find((c) => c.otherParticipantId === withId);
+    selectConversation(
+      existing ?? {
+        id: `pending:${withId}`,
+        otherParticipantId: withId,
+        otherParticipantName: name,
+        isOnline: false,
+        isBlocked: false,
+      },
+    );
+    // Drop the query params so a later refresh doesn't re-open this thread.
+    setSearchParams({}, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, conversationsLoaded, conversations]);
 
   useEffect(() => {
     if (!accessToken) return;

--- a/client/src/pages/company/ScholarshipProviderReviewRequests.tsx
+++ b/client/src/pages/company/ScholarshipProviderReviewRequests.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
+import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Check, Loader2, X, CheckCircle2 } from "lucide-react";
+import { Check, Loader2, X, CheckCircle2, MessageSquare } from "lucide-react";
 import {
   scholarshipProviderReviewRequestsApi,
   type ScholarshipProviderReviewRequestDto,
@@ -165,6 +166,15 @@ export function ScholarshipProviderReviewRequests() {
                   </span>
                 )}
                 <div className="flex flex-wrap gap-2">
+                  {(isPending || isUnderReview) && (
+                    <Link
+                      to={`/company/messages?with=${req.studentId}&name=${encodeURIComponent(req.studentName ?? "")}`}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-brand-200 bg-bg-canvas px-3 py-1.5 text-xs font-medium text-brand-600 hover:bg-brand-50"
+                    >
+                      <MessageSquare aria-hidden className="size-3" />
+                      {t("payments:reviewRequest.message")}
+                    </Link>
+                  )}
                   {isPending && (
                     <>
                       <button

--- a/client/src/pages/student/StudentReviewRequests.tsx
+++ b/client/src/pages/student/StudentReviewRequests.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2, MessageSquare } from "lucide-react";
 import {
   scholarshipProviderReviewRequestsApi,
   isRequestCancellableByStudent,
@@ -146,6 +146,15 @@ export function StudentReviewRequests() {
                   className="inline-flex items-center gap-1.5 rounded-md border border-brand-200 bg-bg-canvas px-3 py-1.5 text-xs font-medium text-brand-600 hover:bg-brand-50"
                 >
                   {t("payments:reviewRequest.applyAgain")}
+                </Link>
+              )}
+              {!TERMINAL_REQUEST_STATUSES.has(req.status) && (
+                <Link
+                  to={`/student/messages?with=${req.scholarshipProviderId}&name=${encodeURIComponent(req.scholarshipProviderName ?? "")}`}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-brand-200 bg-bg-canvas px-3 py-1.5 text-xs font-medium text-brand-600 hover:bg-brand-50"
+                >
+                  <MessageSquare aria-hidden className="size-3.5" />
+                  {t("payments:reviewRequest.message")}
                 </Link>
               )}
               {isRequestCancellableByStudent(req.status) && (


### PR DESCRIPTION
The team lead flagged that the application-support flow was hollow: after the company accepts, there was **no mechanism for the actual help** — just Accept → 'Mark completed' with nothing in between (the entity has no feedback/deliverable field, and there was no chat link).

Wire it to the existing **Direct Messages**:
- Chat page honours a `?with={userId}&name={name}` deep link — opens the existing conversation with that person, or stages a fresh compose that the first message turns real.
- Student support cards → **Message** button (chat with the company) for active requests.
- Company incoming cards → **Message** button (chat with the student) for Pending/in-progress requests.

Flow now: student sends request → company accepts → they **message each other** to do the review/support → company marks completed.

tsc + eslint + build clean.